### PR TITLE
chore: update Claude Code SDK to v1.0.127

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
 	},
 	"dependencies": {
 		"@ai-sdk/react": "^2.0.44",
-		"@anthropic-ai/claude-code": "^1.0.113",
+		"@anthropic-ai/claude-code": "^1.0.127",
 		"@orpc/client": "^1.8.6",
 		"@orpc/server": "^1.8.6",
 		"@orpc/standard-server-fetch": "^1.9.1",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -13,14 +13,14 @@
 	},
 	"dependencies": {},
 	"devDependencies": {
-		"@anthropic-ai/claude-code": "^1.0.113",
+		"@anthropic-ai/claude-code": "^1.0.127",
 		"@vibe-web/typescript": "workspace:*",
 		"ai-sdk-claude-code": "workspace:*",
 		"ai": "^5.0.44",
 		"zod": "^4.1.8"
 	},
 	"peerDependencies": {
-		"@anthropic-ai/claude-code": "^1.0.113",
+		"@anthropic-ai/claude-code": "^1.0.127",
 		"ai-sdk-claude-code": "workspace:*",
 		"ai": "^5.0.44",
 		"zod": "^4.1.8"

--- a/packages/ai-sdk-claude-code/package.json
+++ b/packages/ai-sdk-claude-code/package.json
@@ -24,14 +24,14 @@
 		}
 	},
 	"devDependencies": {
-		"@anthropic-ai/claude-code": "^1.0.113",
+		"@anthropic-ai/claude-code": "^1.0.127",
 		"@vibe-web/typescript": "workspace:*",
 		"ai": "^5.0.44",
 		"zod": "^4.1.8",
 		"tsdown": "^0.13.5"
 	},
 	"peerDependencies": {
-		"@anthropic-ai/claude-code": "^1.0.113",
+		"@anthropic-ai/claude-code": "^1.0.127",
 		"ai": "^5.0.44",
 		"zod": "^4.1.8"
 	}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
 		"clean": "git clean -xdf node_modules .turbo dist"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "^1.0.113",
+		"@anthropic-ai/claude-code": "^1.0.127",
 		"@orpc/server": "^1.8.6",
 		"ai": "^5.0.44",
 		"cors": "^2.8.5",

--- a/packages/server-rpc/package.json
+++ b/packages/server-rpc/package.json
@@ -41,7 +41,7 @@
 		"zod": "^3.25.67"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "^1.0.113",
+		"@anthropic-ai/claude-code": "^1.0.127",
 		"@orpc/contract": "^1.9.1",
 		"ai-sdk-claude-code": "workspace:*",
 		"uuid": "^13.0.0"

--- a/packages/ui/src/claude-code/bash-tool.tsx
+++ b/packages/ui/src/claude-code/bash-tool.tsx
@@ -1,10 +1,6 @@
-import {
-	CodeBlock,
-} from "@vibe-web/ui/ai-elements/code-block";
+import { CodeBlock } from "@vibe-web/ui/ai-elements/code-block";
 import { Tool, ToolContent, ToolHeader } from "@vibe-web/ui/ai-elements/tool";
-import type {
-	BashUIToolInvocation,
-} from "ai-sdk-claude-code";
+import type { BashUIToolInvocation } from "ai-sdk-claude-code";
 import { TerminalIcon } from "lucide-react";
 
 export function ClaudeCodeBashTool({

--- a/packages/ui/src/claude-code/edit-tool.tsx
+++ b/packages/ui/src/claude-code/edit-tool.tsx
@@ -1,8 +1,6 @@
 import { CodeBlock } from "@vibe-web/ui/ai-elements/code-block";
 import { Tool, ToolContent, ToolHeader } from "@vibe-web/ui/ai-elements/tool";
-import type {
-	EditUIToolInvocation,
-} from "ai-sdk-claude-code";
+import type { EditUIToolInvocation } from "ai-sdk-claude-code";
 import { EditIcon } from "lucide-react";
 
 export function ClaudeCodeEditTool({

--- a/packages/ui/src/claude-code/grep-tool.tsx
+++ b/packages/ui/src/claude-code/grep-tool.tsx
@@ -1,8 +1,6 @@
 import { CodeBlock } from "@vibe-web/ui/ai-elements/code-block";
 import { Tool, ToolContent, ToolHeader } from "@vibe-web/ui/ai-elements/tool";
-import type {
-	GrepUIToolInvocation,
-} from "ai-sdk-claude-code";
+import type { GrepUIToolInvocation } from "ai-sdk-claude-code";
 import { SearchIcon } from "lucide-react";
 
 export function ClaudeCodeGrepTool({

--- a/packages/ui/src/claude-code/read-tool.tsx
+++ b/packages/ui/src/claude-code/read-tool.tsx
@@ -3,9 +3,7 @@ import {
 	CodeBlockCopyButton,
 } from "@vibe-web/ui/ai-elements/code-block";
 import { Tool, ToolContent, ToolHeader } from "@vibe-web/ui/ai-elements/tool";
-import type {
-	ReadUIToolInvocation,
-} from "ai-sdk-claude-code";
+import type { ReadUIToolInvocation } from "ai-sdk-claude-code";
 import { FileTextIcon } from "lucide-react";
 
 export function ClaudeCodeReadTool({

--- a/packages/ui/src/claude-code/task-tool.tsx
+++ b/packages/ui/src/claude-code/task-tool.tsx
@@ -6,12 +6,9 @@ import {
 	type UIDataTypes,
 	type UIMessage,
 } from "ai";
-import type {
-	ClaudeCodeTools,
-	TaskUIToolInvocation,
-} from "ai-sdk-claude-code";
+import type { ClaudeCodeTools, TaskUIToolInvocation } from "ai-sdk-claude-code";
 import { ListChecksIcon } from "lucide-react";
-import { useMemo, type ReactNode } from "react";
+import { type ReactNode, useMemo } from "react";
 
 export function ClaudeCodeTaskTool({
 	message,

--- a/packages/ui/src/claude-code/web-fetch-tool.tsx
+++ b/packages/ui/src/claude-code/web-fetch-tool.tsx
@@ -1,9 +1,7 @@
 import { CodeBlock } from "@vibe-web/ui/ai-elements/code-block";
 import { Response } from "@vibe-web/ui/ai-elements/response";
 import { Tool, ToolContent, ToolHeader } from "@vibe-web/ui/ai-elements/tool";
-import type {
-	WebFetchUIToolInvocation,
-} from "ai-sdk-claude-code";
+import type { WebFetchUIToolInvocation } from "ai-sdk-claude-code";
 import { GlobeIcon } from "lucide-react";
 
 export function ClaudeCodeWebFetchTool({

--- a/packages/ui/src/claude-code/web-search-tool.tsx
+++ b/packages/ui/src/claude-code/web-search-tool.tsx
@@ -1,8 +1,6 @@
 import { Response } from "@vibe-web/ui/ai-elements/response";
 import { Tool, ToolContent, ToolHeader } from "@vibe-web/ui/ai-elements/tool";
-import type {
-	WebSearchUIToolInvocation,
-} from "ai-sdk-claude-code";
+import type { WebSearchUIToolInvocation } from "ai-sdk-claude-code";
 import { SearchIcon } from "lucide-react";
 
 export function ClaudeCodeWebSearchTool({

--- a/packages/vibe-web-devtools/package.json
+++ b/packages/vibe-web-devtools/package.json
@@ -43,7 +43,7 @@
 		}
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "^1.0.113",
+		"@anthropic-ai/claude-code": "^1.0.127",
 		"@babel/core": "^7.28.3",
 		"@babel/generator": "^7.28.3",
 		"@babel/parser": "^7.28.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^2.0.44
         version: 2.0.44(react@19.1.1)(zod@4.1.8)
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.113
-        version: 1.0.113
+        specifier: ^1.0.127
+        version: 1.0.127
       '@orpc/client':
         specifier: ^1.8.6
         version: 1.8.6(@opentelemetry/api@1.9.0)
@@ -559,8 +559,8 @@ importers:
   packages/agents:
     devDependencies:
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.113
-        version: 1.0.113
+        specifier: ^1.0.127
+        version: 1.0.127
       '@vibe-web/typescript':
         specifier: workspace:*
         version: link:../../tools/typescript
@@ -577,8 +577,8 @@ importers:
   packages/ai-sdk-claude-code:
     devDependencies:
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.113
-        version: 1.0.113
+        specifier: ^1.0.127
+        version: 1.0.127
       '@vibe-web/typescript':
         specifier: workspace:*
         version: link:../../tools/typescript
@@ -595,8 +595,8 @@ importers:
   packages/cli:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.113
-        version: 1.0.113
+        specifier: ^1.0.127
+        version: 1.0.127
       '@orpc/server':
         specifier: ^1.8.6
         version: 1.8.6(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.18.3)
@@ -750,8 +750,8 @@ importers:
   packages/server-rpc:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.113
-        version: 1.0.113
+        specifier: ^1.0.127
+        version: 1.0.127
       '@orpc/contract':
         specifier: ^1.9.1
         version: 1.9.1(@opentelemetry/api@1.9.0)
@@ -881,8 +881,8 @@ importers:
   packages/vibe-web-devtools:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.113
-        version: 1.0.113
+        specifier: ^1.0.127
+        version: 1.0.127
       '@babel/core':
         specifier: ^7.28.3
         version: 7.28.3
@@ -1181,8 +1181,8 @@ packages:
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
-  '@anthropic-ai/claude-code@1.0.113':
-    resolution: {integrity: sha512-K/+N/rECfWa1ZauWLD6C/CnX6bxxAck5CFDuK58JjRN8v6QDuJVX7HZcNCanB0ucxEkaczAwvWnEM+UjFQsdqw==}
+  '@anthropic-ai/claude-code@1.0.127':
+    resolution: {integrity: sha512-5L0nzdNjH4jAj/sw7pP/J48/XwJ8sYFUvbkeStm+1lOyJOkAtWVBErdfju0D4j4zKUQfFrZewt4m/Hagd6W1Pw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -8885,7 +8885,7 @@ snapshots:
 
   '@antfu/utils@0.7.10': {}
 
-  '@anthropic-ai/claude-code@1.0.113':
+  '@anthropic-ai/claude-code@1.0.127':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updates @anthropic-ai/claude-code from v1.0.113 to v1.0.127 across all packages
- Includes automatic code formatting fixes from biome lint

## Changes
- Updated Claude Code SDK dependency in 6 package.json files
- Applied automatic formatting fixes to Claude Code tool components
- Verified compatibility with tests, typecheck, and build

## Test plan
- [x] Dependencies installed successfully (`pnpm install`)
- [x] TypeScript compilation passed (`pnpm typecheck`)  
- [x] All tests passed (`pnpm test`)
- [x] Code formatting applied (`pnpm lint:fix`)

🤖 Generated with [Claude Code](https://claude.ai/code)