### PR TITLE
refactor: rename server-trpc to server-rpc

### DIFF
--- a/apps/chrome-side-panel/package.json
+++ b/apps/chrome-side-panel/package.json
@@ -15,7 +15,7 @@
 		"@orpc/client": "^1.8.6",
 		"@orpc/server": "^1.8.6",
 		"@vibe-web/code-inspector-web": "workspace:*",
-		"@vibe-web/server-trpc": "workspace:*",
+		"@vibe-web/server-rpc": "workspace:*",
 		"@vibe-web/shared": "workspace:*",
 		"@vibe-web/ui": "workspace:*",
 		"ai": "^5.0.63",

--- a/apps/chrome-side-panel/src/context.tsx
+++ b/apps/chrome-side-panel/src/context.tsx
@@ -1,7 +1,7 @@
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import type { RouterClient } from "@orpc/server";
-import type { ChatRouter } from "@vibe-web/server-trpc/routes/chat";
+import type { ChatRouter } from "@vibe-web/server-rpc/routes/chat";
 import { createContext, useContext, useMemo } from "react";
 
 interface ORPCContextType {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,7 +33,7 @@
 		"@tanstack/react-start": "^1.121.0-alpha.27",
 		"@tanstack/router-plugin": "^1.131.33",
 		"@vibe-web/agents": "workspace:*",
-		"@vibe-web/server-trpc": "workspace:*",
+		"@vibe-web/server-rpc": "workspace:*",
 		"@vibe-web/ui": "workspace:*",
 		"vibe-web-devtools": "workspace:*",
 		"ai": "^5.0.63",

--- a/apps/web/src/lib/orpc.ts
+++ b/apps/web/src/lib/orpc.ts
@@ -4,7 +4,7 @@ import type { RouterClient } from "@orpc/server";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { createIsomorphicFn } from "@tanstack/react-start";
-import type { Router } from "@vibe-web/server-trpc/routes";
+import type { Router } from "@vibe-web/server-rpc/routes";
 import { toast } from "sonner";
 
 export const queryClient = new QueryClient({

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
 		"@types/express": "^5.0.3",
 		"@types/ws": "^8.18.1",
 		"@vibe-web/agents": "workspace:*",
-		"@vibe-web/server-trpc": "workspace:*",
+		"@vibe-web/server-rpc": "workspace:*",
 		"@vibe-web/typescript": "workspace:*",
 		"tsx": "^4.20.5",
 		"tsdown": "^0.13.5"

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { RPCHandler as NodeRPCHandler } from "@orpc/server/node";
 import { ClaudeCodeAgent } from "@vibe-web/agents/claude-code";
-import { router } from "@vibe-web/server-trpc/routes";
+import { router } from "@vibe-web/server-rpc/routes";
 import cors from "cors";
 import express from "express";
 

--- a/packages/server-rpc/package.json
+++ b/packages/server-rpc/package.json
@@ -1,9 +1,9 @@
 {
-	"name": "@vibe-web/server-trpc",
+	"name": "@vibe-web/server-rpc",
 	"private": true,
 	"type": "module",
 	"version": "0.0.0",
-	"description": "TRPC for Vibe Coding Devtools",
+	"description": "RPC for Vibe Coding Devtools",
 	"exports": {
 		"./contract": "./src/contract/index.ts",
 		"./routes": "./src/routes/index.ts"

--- a/packages/vibe-web-devtools-client/package.json
+++ b/packages/vibe-web-devtools-client/package.json
@@ -51,7 +51,7 @@
 		"@types/react-dom": "^19.2.1",
 		"@vibe-web/agents": "workspace:*",
 		"@vibe-web/code-inspector-web": "workspace:*",
-		"@vibe-web/server-trpc": "workspace:*",
+		"@vibe-web/server-rpc": "workspace:*",
 		"@vibe-web/ui": "workspace:*",
 		"@vitejs/plugin-react": "^5.0.1",
 		"@vitejs/plugin-react-oxc": "^0.4.1",

--- a/packages/vibe-web-devtools-client/src/lib/orpc.ts
+++ b/packages/vibe-web-devtools-client/src/lib/orpc.ts
@@ -1,7 +1,7 @@
 import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import type { RouterClient } from "@orpc/server";
-import type { Router } from "@vibe-web/server-trpc/routes";
+import type { Router } from "@vibe-web/server-rpc/routes";
 
 const rpcUrl = new URL("/__vibe/rpc", window.location.origin).toString();
 

--- a/packages/vibe-web-devtools/package.json
+++ b/packages/vibe-web-devtools/package.json
@@ -71,7 +71,7 @@
 		"@types/node": "^22.16.5",
 		"@vibe-web/agents": "workspace:*",
 		"@vibe-web/code-inspector-node": "workspace:*",
-		"@vibe-web/server-trpc": "workspace:*",
+		"@vibe-web/server-rpc": "workspace:*",
 		"publint": "^0.3.12",
 		"tsdown": "^0.13.5",
 		"vitest": "^3.2.4"

--- a/packages/vibe-web-devtools/src/vite.ts
+++ b/packages/vibe-web-devtools/src/vite.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { RPCHandler as NodeRPCHandler } from "@orpc/server/node";
 import { ClaudeCodeAgent } from "@vibe-web/agents/claude-code";
-import { router } from "@vibe-web/server-trpc/routes";
+import { router } from "@vibe-web/server-rpc/routes";
 import sirv from "sirv";
 import invariant from "tiny-invariant";
 import type { Plugin, ViteDevServer } from "vite";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
       '@vibe-web/code-inspector-web':
         specifier: workspace:*
         version: link:../../packages/code-inspector-web
-      '@vibe-web/server-trpc':
+      '@vibe-web/server-rpc':
         specifier: workspace:*
         version: link:../../packages/server-rpc
       '@vibe-web/shared':
@@ -171,7 +171,7 @@ importers:
       '@vibe-web/agents':
         specifier: workspace:*
         version: link:../../packages/agents
-      '@vibe-web/server-trpc':
+      '@vibe-web/server-rpc':
         specifier: workspace:*
         version: link:../../packages/server-rpc
       '@vibe-web/ui':
@@ -628,7 +628,7 @@ importers:
       '@vibe-web/agents':
         specifier: workspace:*
         version: link:../agents
-      '@vibe-web/server-trpc':
+      '@vibe-web/server-rpc':
         specifier: workspace:*
         version: link:../server-rpc
       '@vibe-web/typescript':
@@ -971,7 +971,7 @@ importers:
       '@vibe-web/code-inspector-node':
         specifier: workspace:*
         version: link:../code-inspector-node
-      '@vibe-web/server-trpc':
+      '@vibe-web/server-rpc':
         specifier: workspace:*
         version: link:../server-rpc
       publint:
@@ -1071,7 +1071,7 @@ importers:
       '@vibe-web/code-inspector-web':
         specifier: workspace:*
         version: link:../code-inspector-web
-      '@vibe-web/server-trpc':
+      '@vibe-web/server-rpc':
         specifier: workspace:*
         version: link:../server-rpc
       '@vibe-web/ui':


### PR DESCRIPTION
## Summary
- Renamed package from `@vibe-web/server-trpc` to `@vibe-web/server-rpc`
- Updated package description from "TRPC for Vibe Coding Devtools" to "RPC for Vibe Coding Devtools"
- Updated all import references across the codebase
- Updated all package.json dependencies to use the new package name

## Changes
This PR renames the `server-trpc` package to `server-rpc` to better reflect that the package uses ORPC rather than tRPC for RPC communication.

### Files Changed
- Package name and description in `packages/server-rpc/package.json`
- Import statements in:
  - `apps/chrome-side-panel/src/context.tsx`
  - `apps/web/src/lib/orpc.ts`
  - `packages/vibe-web-devtools-client/src/lib/orpc.ts`
  - `packages/vibe-web-devtools/src/vite.ts`
  - `packages/cli/src/server.ts`
- Dependencies in:
  - `apps/chrome-side-panel/package.json`
  - `apps/web/package.json`
  - `packages/vibe-web-devtools-client/package.json`
  - `packages/vibe-web-devtools/package.json`
  - `packages/cli/package.json`
- Updated `pnpm-lock.yaml`

## Test plan
- [x] All package references have been updated
- [x] pnpm install runs successfully
- [ ] Build and test the application to ensure no broken imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified RPC integration across web, Chrome side panel, CLI, and devtools to use the new server-rpc module, aligning router/type imports for consistency.

* **Chores**
  * Updated dependencies and package metadata to reflect the new module name across the workspace.
  * Streamlined internal references for improved maintainability.

No UI changes or user actions required; existing workflows and builds should continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->