### PR TITLE
chore: publish web package to npm

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@vibest/web",
-	"private": true,
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev --port=3001",


### PR DESCRIPTION
## Summary
- Removed `private: true` from `@vibest/web` package.json to allow publishing to npm

## Changes
- Updated `packages/web/package.json` to make the package publishable

## Test plan
- [ ] Verify package.json changes are correct
- [ ] Ensure the package can be published to npm
- [ ] Test that the web package still builds correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to enable publishing of the web package to registries.
  * Affects release and distribution workflows only; no changes to features, UI, or performance.
  * End-users will experience the same behavior; no action required.
  * This update streamlines future releases and makes the package eligible for external distribution without impacting runtime functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->