### PR TITLE
feat: implement tool permission request system

### DIFF
--- a/packages/agents/src/claude-code/agent.ts
+++ b/packages/agents/src/claude-code/agent.ts
@@ -21,12 +21,7 @@ interface SessionState {
 	pendingPermissionRequests: Map<string, PendingToolPermission>;
 }
 
-type PendingToolPermission = {
-	timeoutId?: ReturnType<typeof setTimeout>;
-	resolve: (result: PermissionResult) => void;
-};
-
-export const DEFAULT_TOOL_PERMISSION_TIMEOUT_MS = 1000 * 60 * 10; /// 10 minutes
+type PendingToolPermission = (result: PermissionResult) => void;
 
 export class Session {
 	private store = new Map<string, SessionState>();
@@ -51,7 +46,7 @@ export class Session {
 		const options: Options = {
 			mcpServers: {},
 			strictMcpConfig: true,
-			permissionMode: "plan",
+			permissionMode: "default",
 			stderr: (err) => console.error(err),
 			// note: although not documented by the types, passing an absolute path
 			executable: process.execPath as "node",
@@ -69,23 +64,14 @@ export class Session {
 					resolve = _resolve;
 				});
 
-				const pendingPermission = {
-					resolve: (result: PermissionResult) => {
-						resolve(result);
-						cleanUp();
-					},
-					timeoutId: setTimeout(() => {
-						resolve({
-							behavior: "deny",
-							message: `Tool permission for ${toolName} timed out after ${DEFAULT_TOOL_PERMISSION_TIMEOUT_MS}ms`,
-							interrupt: true,
-						});
-						cleanUp();
-					}, DEFAULT_TOOL_PERMISSION_TIMEOUT_MS),
-				} satisfies PendingToolPermission;
+				const pendingPermission: PendingToolPermission = (
+					result: PermissionResult,
+				) => {
+					resolve(result);
+					cleanUp();
+				};
 
 				function cleanUp() {
-					clearTimeout(pendingPermission.timeoutId);
 					pendingPermissionRequests.delete(requestId);
 					signal.removeEventListener("abort", abortHandler);
 				}
@@ -133,8 +119,12 @@ export class Session {
 	abort(sessionId: string) {
 		const session = this.get(sessionId);
 
-		for (const pending of session.pendingPermissionRequests.values()) {
-			clearTimeout(pending.timeoutId);
+		for (const resolve of session.pendingPermissionRequests.values()) {
+			resolve({
+				behavior: "deny",
+				message: "Request aborted due to session termination",
+				interrupt: true,
+			});
 		}
 		session.requestPermission.end();
 		session.pendingPermissionRequests.clear();
@@ -198,7 +188,7 @@ export class Session {
 		if (!request) {
 			throw new Error(`Pending tool permission request ${requestId} not found`);
 		}
-		request.resolve(result);
+		request(result);
 		return true;
 	}
 }


### PR DESCRIPTION
## Summary
- Implement a comprehensive tool permission request system for AI agents
- Add pending permission request management with proper cleanup on session termination
- Introduce browser-based permission dialogs for user approval
- Support for model selection between Opus and Sonnet
- Refactor vibest package architecture for better build process

## Key Changes
- **Permission System**: Added `canUseTool` callback that creates pending permission requests and waits for user responses
- **Session Management**: Enhanced session handling with proper cleanup of pending requests and abort signal handling
- **UI Integration**: Implemented browser confirm dialogs for permission requests with automatic response handling
- **Build Improvements**: Simplified vibest package build process and removed redundant dependencies
- **Error Handling**: Added comprehensive error handling and cleanup for aborted sessions

## Test plan
- [ ] Test tool permission requests with browser confirm dialogs
- [ ] Verify session cleanup works properly when aborted
- [ ] Test model selection between Opus and Sonnet
- [ ] Verify build process works correctly after refactoring
- [ ] Test pending permission request cleanup on session termination

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal permission request handling mechanism, removing timeout-based denial logic.
  * Changed default permission mode for agent sessions.
  * Updated session abort behavior to immediately deny all pending permission requests with a standard message instead of relying on timeout mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->