### PR TITLE
feat: upgrade @anthropic-ai/claude-agent-sdk to v0.2.19 and zod to v4

### DIFF
--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -52,7 +52,7 @@
 		"tailwind-merge": "^3.3.1",
 		"tailwindcss": "^4.1.12",
 		"tw-animate-css": "^1.3.8",
-		"zod": "^3.24.1",
+		"zod": "^4.3.6",
 		"zustand": "^5.0.7"
 	},
 	"devDependencies": {

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -27,17 +27,17 @@
 		"uuid": "^13.0.0"
 	},
 	"devDependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.22",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.19",
 		"@vibest/typescript": "workspace:*",
 		"ai": "^5.0.63",
 		"ai-sdk-agents": "workspace:*",
 		"tsdown": "^0.13.5",
-		"zod": "^3.24.1"
+		"zod": "^4.3.6"
 	},
 	"peerDependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.22",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.19",
 		"ai": "^5.0.63",
 		"ai-sdk-agents": "workspace:*",
-		"zod": "^3.24.1"
+		"zod": "^4.3.6"
 	}
 }

--- a/packages/ai-sdk-agents/package.json
+++ b/packages/ai-sdk-agents/package.json
@@ -30,15 +30,15 @@
 		}
 	},
 	"devDependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.22",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.19",
 		"@vibest/typescript": "workspace:*",
 		"ai": "^5.0.63",
-		"zod": "^3.24.1",
+		"zod": "^4.3.6",
 		"tsdown": "^0.13.5"
 	},
 	"peerDependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.22",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.19",
 		"ai": "^5.0.63",
-		"zod": "^3.24.1"
+		"zod": "^4.3.6"
 	}
 }

--- a/packages/ai-sdk-agents/src/claude-code/schema/index.ts
+++ b/packages/ai-sdk-agents/src/claude-code/schema/index.ts
@@ -30,6 +30,7 @@ export const McpServerStatusSchema = z.object({
 			version: z.string(),
 		})
 		.optional(),
+	error: z.string().optional(),
 });
 
 /**
@@ -114,7 +115,7 @@ const PermissionUpdateSchema = z.discriminatedUnion("type", [
 export const PermissionResultSchema = z.discriminatedUnion("behavior", [
 	z.object({
 		behavior: z.literal("allow"),
-		updatedInput: z.record(z.string(), z.unknown()),
+		updatedInput: z.record(z.string(), z.unknown()).optional(),
 		updatedPermissions: z.array(PermissionUpdateSchema).optional(),
 		toolUseID: z.string().optional(),
 	}),

--- a/packages/ai-sdk-agents/src/claude-code/schema/index.ts
+++ b/packages/ai-sdk-agents/src/claude-code/schema/index.ts
@@ -40,6 +40,8 @@ export const PermissionModeSchema = z.enum([
 	"acceptEdits",
 	"bypassPermissions",
 	"plan",
+	"delegate",
+	"dontAsk",
 ]);
 
 /**
@@ -55,6 +57,7 @@ const PermissionUpdateDestinationSchema = z.enum([
 	"projectSettings",
 	"localSettings",
 	"session",
+	"cliArg",
 ]);
 
 /**
@@ -113,10 +116,12 @@ export const PermissionResultSchema = z.discriminatedUnion("behavior", [
 		behavior: z.literal("allow"),
 		updatedInput: z.record(z.string(), z.unknown()),
 		updatedPermissions: z.array(PermissionUpdateSchema).optional(),
+		toolUseID: z.string().optional(),
 	}),
 	z.object({
 		behavior: z.literal("deny"),
 		message: z.string(),
 		interrupt: z.boolean().optional(),
+		toolUseID: z.string().optional(),
 	}),
 ]);

--- a/packages/ai-sdk-agents/test/schema-type-compatibility.test-d.ts
+++ b/packages/ai-sdk-agents/test/schema-type-compatibility.test-d.ts
@@ -118,7 +118,7 @@ describe("Schema Type Compatibility", () => {
 	describe("Enum Values", () => {
 		test("PermissionMode has correct values", () => {
 			expectTypeOf<PermissionMode>().toEqualTypeOf<
-				"default" | "acceptEdits" | "bypassPermissions" | "plan"
+				"default" | "acceptEdits" | "bypassPermissions" | "plan" | "delegate" | "dontAsk"
 			>();
 		});
 

--- a/packages/ai-sdk-agents/test/schema-type-compatibility.test-d.ts
+++ b/packages/ai-sdk-agents/test/schema-type-compatibility.test-d.ts
@@ -73,9 +73,9 @@ describe("Schema Type Compatibility", () => {
 				expectTypeOf<AllowResult["behavior"]>().toEqualTypeOf<"allow">();
 			});
 
-			test("updatedInput is Record<string, unknown>", () => {
+			test("updatedInput is optional Record<string, unknown>", () => {
 				expectTypeOf<AllowResult["updatedInput"]>().toEqualTypeOf<
-					Record<string, unknown>
+					Record<string, unknown> | undefined
 				>();
 			});
 

--- a/packages/ai-sdk-agents/tsdown.config.ts
+++ b/packages/ai-sdk-agents/tsdown.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
 	dts: true,
 	sourcemap: true,
 	publint: true,
+	unbundle: true,
 });

--- a/packages/code-inspector-web/package.json
+++ b/packages/code-inspector-web/package.json
@@ -31,7 +31,7 @@
 		"uuid": "^13.0.0",
 		"vitest": "^3.2.4",
 		"xstate": "^5.20.2",
-		"zod": "^3.24.1"
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@types/react": "^19.2.2",

--- a/packages/server-rpc/package.json
+++ b/packages/server-rpc/package.json
@@ -42,7 +42,7 @@
 		"superjson": "^2.2.2",
 		"tsdown": "^0.13.5",
 		"ws": "^8.18.3",
-		"zod": "^3.24.1"
+		"zod": "^4.3.6"
 	},
 	"peerDependencies": {
 		"@orpc/server": "^1.8.6",
@@ -50,10 +50,10 @@
 		"ai": "^5.0.30",
 		"superjson": "^2.2.2",
 		"ws": "^8.18.3",
-		"zod": "^3.25.67"
+		"zod": "^4.3.6"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.22",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.19",
 		"@orpc/contract": "^1.9.1",
 		"@orpc/shared": "^1.9.4",
 		"@vibest/agents": "workspace:*",

--- a/packages/server-rpc/tsdown.config.ts
+++ b/packages/server-rpc/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
 	entry: ["./src/**/*.ts"],
 	format: "esm",
 	dts: true,
+	unbundle: true,
 });

--- a/packages/vibest-devtools-client/package.json
+++ b/packages/vibest-devtools-client/package.json
@@ -41,7 +41,7 @@
 		"tailwind-merge": "^3.3.1",
 		"use-stick-to-bottom": "^1.1.1",
 		"xstate": "^5.20.2",
-		"zod": "^3.24.1"
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@orpc/server": "^1.8.6",

--- a/packages/vibest-devtools/package.json
+++ b/packages/vibest-devtools/package.json
@@ -43,7 +43,7 @@
 		}
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.12",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.19",
 		"@babel/core": "^7.28.3",
 		"@babel/generator": "^7.28.3",
 		"@babel/parser": "^7.28.3",
@@ -60,7 +60,7 @@
 		"sirv": "^3.0.2",
 		"tiny-invariant": "^1.3.3",
 		"ws": "^8.18.3",
-		"zod": "^3.24.1"
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@types/babel__core": "^7.20.5",

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -17,7 +17,7 @@
 	},
 	"dependencies": {
 		"@ai-sdk/react": "^2.0.44",
-		"@anthropic-ai/claude-agent-sdk": "^0.1.22",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.19",
 		"@hono/node-server": "^1.19.5",
 		"@orpc/client": "^1.8.6",
 		"@orpc/openapi": "^1.9.3",
@@ -63,7 +63,7 @@
 		"uuid": "^13.0.0",
 		"vibest-devtools": "workspace:*",
 		"ws": "^8.18.3",
-		"zod": "^3.25.61"
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@orpc/contract": "^1.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,8 +256,8 @@ importers:
         specifier: ^1.3.8
         version: 1.4.0
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
       zustand:
         specifier: ^5.0.7
         version: 5.0.10(@types/react@19.2.9)(immer@11.1.3)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -379,14 +379,14 @@ importers:
         version: 13.0.0
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.22
-        version: 0.1.77(zod@3.25.76)
+        specifier: ^0.2.19
+        version: 0.2.19(zod@4.3.6)
       '@vibest/typescript':
         specifier: workspace:*
         version: link:../../tools/typescript
       ai:
         specifier: ^5.0.63
-        version: 5.0.123(zod@3.25.76)
+        version: 5.0.123(zod@4.3.6)
       ai-sdk-agents:
         specifier: workspace:*
         version: link:../ai-sdk-agents
@@ -394,26 +394,26 @@ importers:
         specifier: ^0.13.5
         version: 0.13.5(oxc-resolver@11.16.4)(publint@0.3.17)(typescript@5.9.3)
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
 
   packages/ai-sdk-agents:
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.22
-        version: 0.1.77(zod@3.25.76)
+        specifier: ^0.2.19
+        version: 0.2.19(zod@4.3.6)
       '@vibest/typescript':
         specifier: workspace:*
         version: link:../../tools/typescript
       ai:
         specifier: ^5.0.63
-        version: 5.0.123(zod@3.25.76)
+        version: 5.0.123(zod@4.3.6)
       tsdown:
         specifier: ^0.13.5
         version: 0.13.5(oxc-resolver@11.16.4)(publint@0.3.17)(typescript@5.9.3)
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
 
   packages/code-inspector-node:
     devDependencies:
@@ -502,8 +502,8 @@ importers:
         specifier: ^5.20.2
         version: 5.25.1
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@types/react':
         specifier: ^19.2.2
@@ -521,8 +521,8 @@ importers:
   packages/server-rpc:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.22
-        version: 0.1.77(zod@3.25.76)
+        specifier: ^0.2.19
+        version: 0.2.19(zod@4.3.6)
       '@orpc/contract':
         specifier: ^1.9.1
         version: 1.13.4(@opentelemetry/api@1.9.0)
@@ -562,7 +562,7 @@ importers:
         version: link:../../tools/typescript
       ai:
         specifier: ^5.0.63
-        version: 5.0.123(zod@3.25.76)
+        version: 5.0.123(zod@4.3.6)
       superjson:
         specifier: ^2.2.2
         version: 2.2.6
@@ -573,8 +573,8 @@ importers:
         specifier: ^8.18.3
         version: 8.19.0
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
 
   packages/shared:
     devDependencies:
@@ -668,10 +668,10 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: ^2.0.44
-        version: 2.0.125(react@19.2.3)(zod@3.25.76)
+        version: 2.0.125(react@19.2.3)(zod@4.3.6)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.22
-        version: 0.1.77(zod@3.25.76)
+        specifier: ^0.2.19
+        version: 0.2.19(zod@4.3.6)
       '@hono/node-server':
         specifier: ^1.19.5
         version: 1.19.9(hono@4.11.5)
@@ -743,7 +743,7 @@ importers:
         version: link:../ui
       ai:
         specifier: ^5.0.63
-        version: 5.0.123(zod@3.25.76)
+        version: 5.0.123(zod@4.3.6)
       ai-sdk-agents:
         specifier: workspace:*
         version: link:../ai-sdk-agents
@@ -808,8 +808,8 @@ importers:
         specifier: ^8.18.3
         version: 8.19.0
       zod:
-        specifier: ^3.25.61
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@orpc/contract':
         specifier: ^1.9.1
@@ -884,8 +884,8 @@ importers:
   packages/vibest-devtools:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.12
-        version: 0.1.77(zod@3.25.76)
+        specifier: ^0.2.19
+        version: 0.2.19(zod@4.3.6)
       '@babel/core':
         specifier: ^7.28.3
         version: 7.28.6
@@ -918,7 +918,7 @@ importers:
         version: 3.5.27
       ai:
         specifier: ^5.0.63
-        version: 5.0.123(zod@3.25.76)
+        version: 5.0.123(zod@4.3.6)
       magic-string:
         specifier: ^0.30.18
         version: 0.30.21
@@ -938,8 +938,8 @@ importers:
         specifier: ^8.18.3
         version: 8.19.0
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@types/babel__core':
         specifier: ^7.20.5
@@ -982,7 +982,7 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: ^2.0.44
-        version: 2.0.125(react@19.2.3)(zod@3.25.76)
+        version: 2.0.125(react@19.2.3)(zod@4.3.6)
       '@ark-ui/react':
         specifier: ^5.23.0
         version: 5.30.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1000,7 +1000,7 @@ importers:
         version: 3.15.0(react@19.2.3)
       ai:
         specifier: ^5.0.63
-        version: 5.0.123(zod@3.25.76)
+        version: 5.0.123(zod@4.3.6)
       birpc:
         specifier: ^2.6.1
         version: 2.9.0
@@ -1041,8 +1041,8 @@ importers:
         specifier: ^5.20.2
         version: 5.25.1
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@orpc/server':
         specifier: ^1.8.6
@@ -1187,11 +1187,11 @@ packages:
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.77':
-    resolution: {integrity: sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==}
+  '@anthropic-ai/claude-agent-sdk@0.2.19':
+    resolution: {integrity: sha512-DjaX4t3Swjt5PcsZt6krcp5TfBTRxVuUZhkY6L8WWF8kZBJFuuEd5akNg486XRskTXGuwLmitxp0wHB1hJ9muw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.61.0':
     resolution: {integrity: sha512-GnlOXrPxow0uoaVB3DGNh9EJBU1MyagCBCLpU+bwDVlj/oOPYIwoiasMWlykkfYcQOrDP2x/zHnRD0xN7PeZPw==}
@@ -7430,26 +7430,12 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@2.0.29(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      '@vercel/oidc': 3.1.0
-      zod: 3.25.76
-
   '@ai-sdk/gateway@2.0.29(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
-
-  '@ai-sdk/provider-utils@3.0.20(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.1
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 3.25.76
 
   '@ai-sdk/provider-utils@3.0.20(zod@4.3.6)':
     dependencies:
@@ -7461,16 +7447,6 @@ snapshots:
   '@ai-sdk/provider@2.0.1':
     dependencies:
       json-schema: 0.4.0
-
-  '@ai-sdk/react@2.0.125(react@19.2.3)(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      ai: 5.0.123(zod@3.25.76)
-      react: 19.2.3
-      swr: 2.3.8(react@19.2.3)
-      throttleit: 2.1.0
-    optionalDependencies:
-      zod: 3.25.76
 
   '@ai-sdk/react@2.0.125(react@19.2.3)(zod@4.3.6)':
     dependencies:
@@ -7494,9 +7470,9 @@ snapshots:
 
   '@antfu/utils@0.7.10': {}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.77(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.2.19(zod@4.3.6)':
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -11112,14 +11088,6 @@ snapshots:
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
-
-  ai@5.0.123(zod@3.25.76):
-    dependencies:
-      '@ai-sdk/gateway': 2.0.29(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
 
   ai@5.0.123(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrade `@anthropic-ai/claude-agent-sdk` from `^0.1.22` to `^0.2.19`
- Upgrade `zod` from `^3.x` to `^4.0.0` across all packages
- Sync Zod schemas with new SDK types

## Changes

### Package updates
Updated versions in 9 packages:
- `packages/agents`
- `packages/ai-sdk-agents`
- `packages/server-rpc`
- `packages/vibest-devtools`
- `packages/vibest`
- `packages/vibest-devtools-client`
- `packages/code-inspector-web`
- `examples/vite-react`

### Schema updates
- Added `error?: string` field to `McpServerStatusSchema`
- Made `updatedInput` optional in `PermissionResultSchema` (was required)

### Test updates
- Updated type expectation for `updatedInput` to be `Record<string, unknown> | undefined`

## Test plan

- [x] All tests pass (118 tests across 5 test files)
- [x] All typechecks pass (20 tasks)
- [x] Core packages build successfully (`ai-sdk-agents`, `@vibest/agents`, `@vibest/server-rpc`)