### PR TITLE
fix: sync schemas with Claude Agent SDK v0.1.77 and fix UI type errors

### DIFF
--- a/packages/ai-sdk-agents/src/claude-code/schema/index.ts
+++ b/packages/ai-sdk-agents/src/claude-code/schema/index.ts
@@ -35,7 +35,14 @@ export const McpServerStatusSchema = z.object({
 /**
  * Represents the permission mode for tool usage in Claude Code
  */
-export const PermissionModeSchema = z.enum(["default", "acceptEdits", "bypassPermissions", "plan"]);
+export const PermissionModeSchema = z.enum([
+  "default",
+  "acceptEdits",
+  "bypassPermissions",
+  "plan",
+  "delegate",
+  "dontAsk",
+]);
 
 /**
  * Represents the behavior for a permission decision
@@ -50,6 +57,7 @@ const PermissionUpdateDestinationSchema = z.enum([
   "projectSettings",
   "localSettings",
   "session",
+  "cliArg",
 ]);
 
 /**
@@ -108,10 +116,12 @@ export const PermissionResultSchema = z.discriminatedUnion("behavior", [
     behavior: z.literal("allow"),
     updatedInput: z.record(z.string(), z.unknown()),
     updatedPermissions: z.array(PermissionUpdateSchema).optional(),
+    toolUseID: z.string().optional(),
   }),
   z.object({
     behavior: z.literal("deny"),
     message: z.string(),
     interrupt: z.boolean().optional(),
+    toolUseID: z.string().optional(),
   }),
 ]);

--- a/packages/ai-sdk-agents/test/schema-type-compatibility.test-d.ts
+++ b/packages/ai-sdk-agents/test/schema-type-compatibility.test-d.ts
@@ -116,7 +116,7 @@ describe("Schema Type Compatibility", () => {
   describe("Enum Values", () => {
     test("PermissionMode has correct values", () => {
       expectTypeOf<PermissionMode>().toEqualTypeOf<
-        "default" | "acceptEdits" | "bypassPermissions" | "plan"
+        "default" | "acceptEdits" | "bypassPermissions" | "plan" | "delegate" | "dontAsk"
       >();
     });
 

--- a/packages/ui/src/ai-elements/web-preview.tsx
+++ b/packages/ui/src/ai-elements/web-preview.tsx
@@ -127,7 +127,7 @@ export const WebPreviewUrl = ({ value, onChange, onKeyDown, ...props }: WebPrevi
       const target = event.target as HTMLInputElement;
       setUrl(target.value);
     }
-    onKeyDown?.(event);
+    onKeyDown?.(event as Parameters<NonNullable<typeof onKeyDown>>[0]);
   };
 
   return (

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -167,6 +167,10 @@ function SelectGroupLabel(props: SelectPrimitive.GroupLabel.Props) {
   );
 }
 
+const SelectIcon = SelectPrimitive.Icon;
+const SelectList = SelectPrimitive.List;
+const SelectItemText = SelectPrimitive.ItemText;
+
 export {
   Select,
   SelectTrigger,
@@ -174,7 +178,10 @@ export {
   SelectPopup,
   SelectPopup as SelectContent,
   SelectItem,
+  SelectItemText,
   SelectSeparator,
   SelectGroup,
   SelectGroupLabel,
+  SelectIcon,
+  SelectList,
 };

--- a/packages/ui/src/components/splitter.tsx
+++ b/packages/ui/src/components/splitter.tsx
@@ -2,12 +2,12 @@
 
 import { cn } from "@vibest/ui/lib/utils";
 import {
+  Group,
   Panel,
-  PanelGroup,
-  PanelResizeHandle,
-  type PanelGroupProps,
+  Separator,
+  type GroupProps,
   type PanelProps,
-  type PanelResizeHandleProps,
+  type SeparatorProps,
 } from "react-resizable-panels";
 
 interface SplitterPanelConfig {
@@ -17,7 +17,7 @@ interface SplitterPanelConfig {
   collapsible?: boolean;
 }
 
-interface SplitterProps extends Omit<PanelGroupProps, "direction"> {
+interface SplitterProps extends Omit<GroupProps, "orientation"> {
   panels?: SplitterPanelConfig[];
   defaultSize?: number[];
   direction?: "horizontal" | "vertical";
@@ -31,8 +31,8 @@ function Splitter({
   ...props
 }: SplitterProps) {
   return (
-    <PanelGroup
-      direction={direction}
+    <Group
+      orientation={direction}
       className={cn("flex", direction === "vertical" ? "flex-col" : "flex-row", className)}
       {...props}
     />
@@ -47,13 +47,13 @@ function SplitterPanel({ className, id, ...props }: SplitterPanelProps) {
   return <Panel id={id} className={cn("", className)} {...props} />;
 }
 
-interface SplitterResizeTriggerProps extends PanelResizeHandleProps {
+interface SplitterResizeTriggerProps extends SeparatorProps {
   id?: string;
 }
 
 function SplitterResizeTrigger({ className, id: _id, ...props }: SplitterResizeTriggerProps) {
   return (
-    <PanelResizeHandle
+    <Separator
       className={cn(
         "bg-border relative w-0.5 transition-all duration-200 ease-in-out",
         "hover:bg-accent hover:shadow-accent/50 hover:z-10 hover:scale-x-[3] hover:shadow-lg",


### PR DESCRIPTION
## Summary
- Sync Zod schemas with Claude Agent SDK v0.1.77 type changes
- Fix UI component type errors introduced in PR #36

## Changes

### ai-sdk-agents
- Add `delegate` and `dontAsk` to `PermissionModeSchema`
- Add `cliArg` to `PermissionUpdateDestinationSchema`
- Add `toolUseID?: string` to both allow/deny branches of `PermissionResultSchema`
- Update test expectations

### @vibest/ui
- **splitter.tsx**: Update `react-resizable-panels` API (`PanelGroup`→`Group`, `PanelResizeHandle`→`Separator`, `direction`→`orientation`)
- **select.tsx**: Export missing components (`SelectIcon`, `SelectList`, `SelectItemText`)
- **web-preview.tsx**: Fix `onKeyDown` type compatibility with base-ui

## Test plan
- [x] `pnpm turbo run test lint typecheck` passes (25/25 tasks)