### PR TITLE
feat(desktop): add git diff stats display to sidebar worktrees

### DIFF
--- a/apps/desktop/src/renderer/src/components/layout/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/sidebar.tsx
@@ -44,6 +44,7 @@ import { useEffect, useState } from "react";
 import type { Repository, Worktree } from "../../types";
 
 import { orpc } from "../../lib/queries/workspace";
+import { WorktreeDiffStats } from "../worktrees/worktree-diff-stats";
 
 function getBasename(path: string): string {
   return path.split("/").pop() ?? path;
@@ -225,7 +226,7 @@ export function Sidebar({
                             {worktrees.map((worktree) => (
                               <SidebarMenuSubItem key={worktree.id} className="group/worktree">
                                 <div
-                                  className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground flex h-7 w-full min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-lg text-sm"
+                                  className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground relative flex h-10 w-full min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-lg text-sm"
                                   data-active={selectedWorktreeId === worktree.id}
                                 >
                                   <button
@@ -234,11 +235,17 @@ export function Sidebar({
                                     className="ring-sidebar-ring flex h-full min-w-0 flex-1 items-center gap-2 px-2 outline-hidden focus-visible:ring-2"
                                   >
                                     <GitBranch className="size-4 shrink-0" />
-                                    <span className="truncate">{worktree.branch}</span>
+                                    <div className="flex min-w-0 flex-col items-start">
+                                      <span className="truncate">{worktree.branch}</span>
+                                      <span className="text-muted-foreground truncate text-xs font-normal">
+                                        {getBasename(worktree.path)}
+                                      </span>
+                                    </div>
                                   </button>
+                                  <WorktreeDiffStats path={worktree.path} />
                                   <button
                                     type="button"
-                                    className="hover:bg-foreground/10 mr-1 flex size-5 shrink-0 items-center justify-center rounded opacity-0 transition-opacity duration-150 group-hover/worktree:opacity-100"
+                                    className="hover:bg-foreground/10 absolute right-1 flex size-5 shrink-0 items-center justify-center rounded opacity-0 transition-opacity duration-150 group-hover/worktree:opacity-100"
                                     onClick={(e) => handleArchiveClick(worktree, e)}
                                     title="Archive worktree"
                                   >

--- a/apps/desktop/src/renderer/src/components/worktrees/worktree-diff-stats.tsx
+++ b/apps/desktop/src/renderer/src/components/worktrees/worktree-diff-stats.tsx
@@ -1,0 +1,26 @@
+import { useWorktreeDiffStats } from "../../hooks/use-worktree-diff-stats";
+
+interface WorktreeDiffStatsProps {
+  path: string;
+}
+
+/**
+ * Displays git diff stats (insertions/deletions) for a worktree.
+ * Shows nothing when the worktree is clean.
+ * Hidden on hover (to make room for archive button).
+ */
+export function WorktreeDiffStats({ path }: WorktreeDiffStatsProps) {
+  const stats = useWorktreeDiffStats(path);
+
+  // Don't render anything if no changes
+  if (!stats) {
+    return null;
+  }
+
+  return (
+    <div className="absolute right-1 flex shrink-0 items-center gap-0.5 text-[10px] font-medium tabular-nums transition-opacity duration-150 group-hover/worktree:opacity-0">
+      <span className="text-success">+{stats.insertions}</span>
+      <span className="text-destructive">-{stats.deletions}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/hooks/use-worktree-diff-stats.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-worktree-diff-stats.ts
@@ -1,0 +1,25 @@
+import { skipToken, useQuery } from "@tanstack/react-query";
+
+import { orpc } from "../lib/queries/workspace";
+
+/**
+ * Hook to fetch git diff stats (insertions/deletions) for a worktree.
+ * Returns null when the worktree is clean (no changes).
+ */
+export function useWorktreeDiffStats(path: string | undefined) {
+  const { data: diffResult, isLoading } = useQuery(
+    orpc.git.diff.queryOptions({
+      input: path ? { path, staged: false } : skipToken,
+    }),
+  );
+
+  // Return null if loading, no data, or clean (no changes)
+  if (isLoading || !diffResult || diffResult.stats.filesChanged === 0) {
+    return null;
+  }
+
+  return {
+    insertions: diffResult.stats.insertions,
+    deletions: diffResult.stats.deletions,
+  };
+}


### PR DESCRIPTION
## Summary
- Add git diff stats (+X -Y) display next to each worktree in the sidebar
- Stats show insertions and deletions for uncommitted changes
- Stats and archive button toggle on hover (mutually exclusive display)

## Test plan
- [ ] Add a repository with worktrees to the sidebar
- [ ] Make file changes in a worktree
- [ ] Verify +X -Y stats appear on the right side of the worktree row
- [ ] Hover over the row to confirm stats fade out and archive icon fades in
- [ ] Verify clean worktrees show no stats