### PR TITLE
feat(desktop): add clickable links in terminal

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "electron-store": "^10.0.1",
     "node-pty": "^1.1.0",
     "simple-git": "^3.27.0"

--- a/apps/desktop/src/main/ipc/router/index.ts
+++ b/apps/desktop/src/main/ipc/router/index.ts
@@ -6,6 +6,7 @@ import { contract } from "../../../shared/contract";
 import { fsRouter } from "./fs";
 import { gitRouter } from "./git";
 import { labelRouter } from "./label";
+import { shellRouter } from "./shell";
 import { taskRouter } from "./task";
 import { terminalRouter } from "./terminal";
 import { workspaceRouter } from "./workspace";
@@ -19,6 +20,7 @@ export const router = os.router({
 	terminal: terminalRouter,
 	task: taskRouter,
 	label: labelRouter,
+	shell: shellRouter,
 });
 
 export type Router = typeof router;

--- a/apps/desktop/src/main/ipc/router/shell.ts
+++ b/apps/desktop/src/main/ipc/router/shell.ts
@@ -1,0 +1,23 @@
+import { implement } from "@orpc/server";
+import { shell } from "electron";
+
+import type { AppContext } from "../../app";
+
+import { shellContract } from "../../../shared/contract";
+
+const os = implement(shellContract).$context<AppContext>();
+
+export const openExternal = os.openExternal.handler(async ({ input }) => {
+	const { url } = input;
+
+	const parsed = new URL(url);
+	const allowed = ["http:", "https:", "file:"];
+
+	if (allowed.includes(parsed.protocol)) {
+		await shell.openExternal(url);
+	}
+});
+
+export const shellRouter = os.router({
+	openExternal,
+});

--- a/apps/desktop/src/renderer/src/components/terminal/terminal-view.tsx
+++ b/apps/desktop/src/renderer/src/components/terminal/terminal-view.tsx
@@ -2,6 +2,7 @@ import "@xterm/xterm/css/xterm.css";
 
 import { consumeEventIterator } from "@orpc/client";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
@@ -40,6 +41,12 @@ export function TerminalView({ terminalId, isVisible }: TerminalViewProps) {
 
 		const fitAddon = new FitAddon();
 		terminal.loadAddon(fitAddon);
+
+		// WebLinksAddon: detect URLs and make them clickable
+		const webLinksAddon = new WebLinksAddon((_event, uri) => {
+			client.shell.openExternal({ url: uri });
+		});
+		terminal.loadAddon(webLinksAddon);
 
 		// Try WebGL renderer for better performance, fallback to canvas
 		try {

--- a/apps/desktop/src/shared/contract/index.ts
+++ b/apps/desktop/src/shared/contract/index.ts
@@ -1,6 +1,7 @@
 import { fsContract } from "./fs";
 import { gitContract } from "./git";
 import { labelContract } from "./label";
+import { shellContract } from "./shell";
 import { taskContract } from "./task";
 import { terminalContract } from "./terminal";
 import { workspaceContract } from "./workspace";
@@ -12,8 +13,9 @@ export const contract = {
 	terminal: terminalContract,
 	task: taskContract,
 	label: labelContract,
+	shell: shellContract,
 };
 
 export type Contract = typeof contract;
 
-export { fsContract, gitContract, labelContract, taskContract, terminalContract, workspaceContract };
+export { fsContract, gitContract, labelContract, shellContract, taskContract, terminalContract, workspaceContract };

--- a/apps/desktop/src/shared/contract/shell.ts
+++ b/apps/desktop/src/shared/contract/shell.ts
@@ -1,0 +1,10 @@
+import { oc } from "@orpc/contract";
+import { z } from "zod";
+
+export const shellContract = {
+	openExternal: oc.input(
+		z.object({
+			url: z.string(),
+		}),
+	),
+};

--- a/docs/plans/2026-02-01-terminal-link-support-design.md
+++ b/docs/plans/2026-02-01-terminal-link-support-design.md
@@ -1,0 +1,125 @@
+# Terminal Link Support Design
+
+## Overview
+
+Enable clickable links in the desktop terminal, supporting both ANSI hyperlinks (OSC 8) and auto-detected URLs.
+
+## Requirements
+
+- Support ANSI hyperlinks (OSC 8 escape sequences)
+- Auto-detect URLs in terminal output (`http://`, `https://`, `file://`)
+- Click to open with system default application
+- Keep implementation simple with default styling
+
+## Architecture
+
+### Data Flow
+
+```
+Terminal Output → XTerm Render → addon-web-links detects URL
+                                        ↓
+                               User clicks link
+                                        ↓
+                               Callback triggers IPC
+                                        ↓
+                               Main process shell.openExternal(url)
+                                        ↓
+                               System default app opens
+```
+
+### Link Types
+
+| Type | Handling |
+|------|----------|
+| ANSI hyperlinks (OSC 8) | XTerm v6 native support |
+| Auto-detected URLs | `@xterm/addon-web-links` |
+
+## Implementation
+
+### Dependencies
+
+```bash
+pnpm add @xterm/addon-web-links --filter @vibest/desktop
+```
+
+### File Changes
+
+#### 1. `apps/desktop/src/shared/contract/shell.ts` (new file)
+
+```typescript
+import { z } from "zod";
+
+export const openExternalInput = z.object({
+  url: z.string(),
+});
+
+export type OpenExternalInput = z.infer<typeof openExternalInput>;
+```
+
+#### 2. `apps/desktop/src/shared/contract/index.ts`
+
+Export shell contract.
+
+#### 3. `apps/desktop/src/main/router.ts`
+
+```typescript
+import { shell } from "electron";
+
+// Add to router
+shell: {
+  openExternal: async ({ url }) => {
+    const parsed = new URL(url);
+    const allowed = ["http:", "https:", "file:"];
+
+    if (allowed.includes(parsed.protocol)) {
+      await shell.openExternal(url);
+    }
+  },
+},
+```
+
+#### 4. `apps/desktop/src/renderer/src/components/terminal/terminal-view.tsx`
+
+```typescript
+import { WebLinksAddon } from "@xterm/addon-web-links";
+
+// After terminal initialization, before WebglAddon
+const webLinksAddon = new WebLinksAddon((event, uri) => {
+  event.preventDefault();
+  client.shell.openExternal({ url: uri });
+});
+
+terminal.loadAddon(webLinksAddon);
+```
+
+### Addon Load Order
+
+1. FitAddon
+2. WebLinksAddon (new)
+3. WebglAddon
+
+WebLinksAddon must load before WebglAddon.
+
+### Security
+
+Only allow safe protocols:
+- `http:`
+- `https:`
+- `file:`
+
+Reject dangerous protocols like `javascript:`, `data:`.
+
+## Testing
+
+1. Run `echo "https://github.com"` in terminal
+2. Hover to confirm underline appears
+3. Ctrl/Cmd + click to confirm browser opens
+4. Test `file:///` path opens Finder/file manager
+
+## Decision Log
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| URL detection | `@xterm/addon-web-links` | Official addon, minimal code |
+| Click behavior | System default app | Simplest UX |
+| Link styling | Default | YAGNI - add customization later if needed |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@39.4.0)
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
       electron-store:
         specifier: ^10.0.1
         version: 10.1.0
@@ -4537,6 +4540,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/addon-webgl@0.19.0':
     resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
@@ -12329,6 +12335,8 @@ snapshots:
       react: 19.2.4
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/addon-webgl@0.19.0': {}
 


### PR DESCRIPTION
## Summary
- Add terminal link support using `@xterm/addon-web-links`
- URLs in terminal output are automatically detected and made clickable
- Clicking opens the link in the system default application
- Only safe protocols allowed (http, https, file)

## Changes
- Added `@xterm/addon-web-links` dependency
- Created `shell.openExternal` IPC route with protocol validation
- Loaded WebLinksAddon in terminal-view component

## Testing
- Run `echo "https://github.com"` in terminal
- Hover to confirm underline appears
- Click link to confirm browser opens
- Test `file:///` paths open Finder