### PR TITLE
feat(desktop): add dark/light theme toggle to sidebar

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -59,6 +59,7 @@
     "electron-vite": "^5.0.0",
     "lucide-react": "^0.511.0",
     "nanoid": "^5.1.6",
+    "next-themes": "^0.4.6",
     "p-queue": "^9.1.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/apps/desktop/src/renderer/src/components/layout/header.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/header.tsx
@@ -1,259 +1,233 @@
 import { Button } from "@vibest/ui/components/button";
-import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from "@vibest/ui/components/menu";
 import {
-  Archive,
-  CheckCircle2,
-  Code,
-  ExternalLink,
-  FolderGit2,
-  MoreHorizontal,
-  Pencil,
-  RefreshCw,
-  Terminal,
-  Trash2,
+	Menu,
+	MenuItem,
+	MenuPopup,
+	MenuSeparator,
+	MenuTrigger,
+} from "@vibest/ui/components/menu";
+import {
+	Archive,
+	CheckCircle2,
+	ExternalLink,
+	FolderGit2,
+	MoreHorizontal,
+	Pencil,
+	RefreshCw,
+	Terminal,
+	Trash2,
 } from "lucide-react";
-
+import { client } from "../../lib/client";
 import type { Repository, Task, Worktree } from "../../types";
 
-import { client } from "../../lib/client";
-
 interface HeaderProps {
-  repository: Repository | null;
-  task: Task | null;
-  worktree: Worktree | null;
-  onRemoveRepository: (repositoryId: string) => void;
-  onEditTask: (task: Task) => void;
-  onArchiveTask: (taskId: string) => void;
-  onRefresh: () => void;
+	repository: Repository | null;
+	task: Task | null;
+	worktree: Worktree | null;
+	onRemoveRepository: (repositoryId: string) => void;
+	onEditTask: (task: Task) => void;
+	onArchiveTask: (taskId: string) => void;
+	onRefresh: () => void;
 }
 
 export function Header({
-  repository,
-  task,
-  worktree,
-  onRemoveRepository,
-  onEditTask,
-  onArchiveTask,
-  onRefresh,
+	repository,
+	task,
+	worktree,
+	onRemoveRepository,
+	onEditTask,
+	onArchiveTask,
+	onRefresh,
 }: HeaderProps) {
-  // Show task info if a task is selected
-  if (task) {
-    const handleOpenFinder = () => {
-      if (worktree) {
-        client.fs.openFinder({ path: worktree.path });
-      }
-    };
+	// Show task info if a task is selected
+	if (task) {
+		const handleOpenFinder = () => {
+			if (worktree) {
+				client.fs.openFinder({ path: worktree.path });
+			}
+		};
 
-    const handleOpenTerminal = () => {
-      if (worktree) {
-        client.fs.openTerminal({ path: worktree.path });
-      }
-    };
+		const handleOpenTerminal = () => {
+			if (worktree) {
+				client.fs.openTerminal({ path: worktree.path });
+			}
+		};
 
-    const handleOpenInVSCode = () => {
-      if (worktree) {
-        client.fs.openInVSCode({ path: worktree.path });
-      }
-    };
+		return (
+			<header className="border-border bg-background/50 app-drag-region flex h-12 items-center justify-between border-b px-5 backdrop-blur-sm">
+				<div className="app-no-drag flex min-w-0 items-center gap-3">
+					<div className="bg-accent flex h-7 w-7 items-center justify-center rounded-md">
+						<CheckCircle2 className="text-accent-foreground h-4 w-4" />
+					</div>
+					<div className="min-w-0">
+						<h1 className="text-foreground truncate text-[13px] leading-tight font-semibold">
+							{task.name}
+						</h1>
+						<p className="text-muted-foreground max-w-sm truncate text-[11px] leading-tight">
+							{task.description ||
+								(worktree ? worktree.branch : "No description")}
+						</p>
+					</div>
+				</div>
 
-    const handleOpenInCursor = () => {
-      if (worktree) {
-        client.fs.openInCursor({ path: worktree.path });
-      }
-    };
+				<div className="app-no-drag flex items-center gap-0.5">
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						className="text-muted-foreground hover:text-foreground h-7 w-7"
+						onClick={onRefresh}
+						aria-label="Refresh"
+					>
+						<RefreshCw className="h-3.5 w-3.5" />
+					</Button>
 
-    return (
-      <header className="border-border bg-background/50 app-drag-region flex h-12 items-center justify-between border-b px-5 backdrop-blur-sm">
-        <div className="app-no-drag flex min-w-0 items-center gap-3">
-          <div className="bg-accent flex h-7 w-7 items-center justify-center rounded-md">
-            <CheckCircle2 className="text-accent-foreground h-4 w-4" />
-          </div>
-          <div className="min-w-0">
-            <h1 className="text-foreground truncate text-[13px] leading-tight font-semibold">
-              {task.name}
-            </h1>
-            <p className="text-muted-foreground max-w-sm truncate text-[11px] leading-tight">
-              {task.description || (worktree ? worktree.branch : "No description")}
-            </p>
-          </div>
-        </div>
+					{worktree && (
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							className="text-muted-foreground hover:text-foreground h-7 w-7"
+							onClick={handleOpenFinder}
+							aria-label="Open in Finder"
+						>
+							<ExternalLink className="h-3.5 w-3.5" />
+						</Button>
+					)}
 
-        <div className="app-no-drag flex items-center gap-0.5">
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="text-muted-foreground hover:text-foreground h-7 w-7"
-            onClick={onRefresh}
-            aria-label="Refresh"
-          >
-            <RefreshCw className="h-3.5 w-3.5" />
-          </Button>
+					<Menu>
+						<MenuTrigger
+							render={
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									className="text-muted-foreground hover:text-foreground h-7 w-7"
+									aria-label="More options"
+								>
+									<MoreHorizontal className="h-3.5 w-3.5" />
+								</Button>
+							}
+						/>
+						<MenuPopup side="bottom" align="end">
+							<MenuItem onClick={() => onEditTask(task)}>
+								<Pencil className="h-4 w-4" />
+								Edit Task
+							</MenuItem>
+							{worktree && (
+								<>
+									<MenuSeparator />
+									<MenuItem onClick={handleOpenFinder}>
+										<ExternalLink className="h-4 w-4" />
+										Open in Finder
+									</MenuItem>
+									<MenuItem onClick={handleOpenTerminal}>
+										<Terminal className="h-4 w-4" />
+										Open Terminal
+									</MenuItem>
+								</>
+							)}
+							<MenuSeparator />
+							<MenuItem
+								variant="destructive"
+								onClick={() => onArchiveTask(task.id)}
+							>
+								<Archive className="h-4 w-4" />
+								Archive Task
+							</MenuItem>
+						</MenuPopup>
+					</Menu>
+				</div>
+			</header>
+		);
+	}
 
-          {worktree && (
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground hover:text-foreground h-7 w-7"
-              onClick={handleOpenFinder}
-              aria-label="Open in Finder"
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-            </Button>
-          )}
+	// Fallback: show repository info or empty state
+	if (!repository) {
+		return (
+			<header className="border-border bg-background/50 app-drag-region flex h-12 items-center justify-between border-b px-5 backdrop-blur-sm">
+				<span className="text-muted-foreground text-[13px]">
+					Select a task to get started
+				</span>
+			</header>
+		);
+	}
 
-          <Menu>
-            <MenuTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  className="text-muted-foreground hover:text-foreground h-7 w-7"
-                  aria-label="More options"
-                >
-                  <MoreHorizontal className="h-3.5 w-3.5" />
-                </Button>
-              }
-            />
-            <MenuPopup side="bottom" align="end">
-              <MenuItem onClick={() => onEditTask(task)}>
-                <Pencil className="h-4 w-4" />
-                Edit Task
-              </MenuItem>
-              {worktree && (
-                <>
-                  <MenuSeparator />
-                  <MenuItem onClick={handleOpenFinder}>
-                    <ExternalLink className="h-4 w-4" />
-                    Open in Finder
-                  </MenuItem>
-                  <MenuItem onClick={handleOpenTerminal}>
-                    <Terminal className="h-4 w-4" />
-                    Open Terminal
-                  </MenuItem>
-                  <MenuItem onClick={handleOpenInVSCode}>
-                    <Code className="h-4 w-4" />
-                    Open in VSCode
-                  </MenuItem>
-                  <MenuItem onClick={handleOpenInCursor}>
-                    <Code className="h-4 w-4" />
-                    Open in Cursor
-                  </MenuItem>
-                </>
-              )}
-              <MenuSeparator />
-              <MenuItem variant="destructive" onClick={() => onArchiveTask(task.id)}>
-                <Archive className="h-4 w-4" />
-                Archive Task
-              </MenuItem>
-            </MenuPopup>
-          </Menu>
-        </div>
-      </header>
-    );
-  }
+	const handleOpenFinder = () => {
+		client.fs.openFinder({ path: repository.path });
+	};
 
-  // Fallback: show repository info or empty state
-  if (!repository) {
-    return (
-      <header className="border-border bg-background/50 app-drag-region flex h-12 items-center border-b px-5 backdrop-blur-sm">
-        <span className="text-muted-foreground text-[13px]">
-          Select a task to get started
-        </span>
-      </header>
-    );
-  }
+	const handleOpenTerminal = () => {
+		client.fs.openTerminal({ path: repository.path });
+	};
 
-  const handleOpenFinder = () => {
-    client.fs.openFinder({ path: repository.path });
-  };
+	return (
+		<header className="border-border bg-background/50 app-drag-region flex h-12 items-center justify-between border-b px-5 backdrop-blur-sm">
+			<div className="app-no-drag flex min-w-0 items-center gap-3">
+				<div className="bg-accent flex h-7 w-7 items-center justify-center rounded-md">
+					<FolderGit2 className="text-accent-foreground h-4 w-4" />
+				</div>
+				<div className="min-w-0">
+					<h1 className="text-foreground truncate text-[13px] leading-tight font-semibold">
+						{repository.name}
+					</h1>
+					<p className="text-muted-foreground max-w-sm truncate font-mono text-[11px] leading-tight">
+						{repository.path.replace(/^\/Users\/[^/]+/, "~")}
+					</p>
+				</div>
+			</div>
 
-  const handleOpenTerminal = () => {
-    client.fs.openTerminal({ path: repository.path });
-  };
+			<div className="app-no-drag flex items-center gap-0.5">
+				<Button
+					variant="ghost"
+					size="icon-sm"
+					className="text-muted-foreground hover:text-foreground h-7 w-7"
+					onClick={onRefresh}
+					aria-label="Refresh"
+				>
+					<RefreshCw className="h-3.5 w-3.5" />
+				</Button>
 
-  const handleOpenInVSCode = () => {
-    client.fs.openInVSCode({ path: repository.path });
-  };
+				<Button
+					variant="ghost"
+					size="icon-sm"
+					className="text-muted-foreground hover:text-foreground h-7 w-7"
+					onClick={handleOpenFinder}
+					aria-label="Open in Finder"
+				>
+					<ExternalLink className="h-3.5 w-3.5" />
+				</Button>
 
-  const handleOpenInCursor = () => {
-    client.fs.openInCursor({ path: repository.path });
-  };
-
-  return (
-    <header className="border-border bg-background/50 app-drag-region flex h-12 items-center justify-between border-b px-5 backdrop-blur-sm">
-      <div className="app-no-drag flex min-w-0 items-center gap-3">
-        <div className="bg-accent flex h-7 w-7 items-center justify-center rounded-md">
-          <FolderGit2 className="text-accent-foreground h-4 w-4" />
-        </div>
-        <div className="min-w-0">
-          <h1 className="text-foreground truncate text-[13px] leading-tight font-semibold">
-            {repository.name}
-          </h1>
-          <p className="text-muted-foreground max-w-sm truncate font-mono text-[11px] leading-tight">
-            {repository.path.replace(/^\/Users\/[^/]+/, "~")}
-          </p>
-        </div>
-      </div>
-
-      <div className="app-no-drag flex items-center gap-0.5">
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="text-muted-foreground hover:text-foreground h-7 w-7"
-          onClick={onRefresh}
-          aria-label="Refresh"
-        >
-          <RefreshCw className="h-3.5 w-3.5" />
-        </Button>
-
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="text-muted-foreground hover:text-foreground h-7 w-7"
-          onClick={handleOpenFinder}
-          aria-label="Open in Finder"
-        >
-          <ExternalLink className="h-3.5 w-3.5" />
-        </Button>
-
-        <Menu>
-          <MenuTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className="text-muted-foreground hover:text-foreground h-7 w-7"
-                aria-label="More options"
-              >
-                <MoreHorizontal className="h-3.5 w-3.5" />
-              </Button>
-            }
-          />
-          <MenuPopup side="bottom" align="end">
-            <MenuItem onClick={handleOpenFinder}>
-              <ExternalLink className="h-4 w-4" />
-              Open in Finder
-            </MenuItem>
-            <MenuItem onClick={handleOpenTerminal}>
-              <Terminal className="h-4 w-4" />
-              Open Terminal
-            </MenuItem>
-            <MenuItem onClick={handleOpenInVSCode}>
-              <Code className="h-4 w-4" />
-              Open in VSCode
-            </MenuItem>
-            <MenuItem onClick={handleOpenInCursor}>
-              <Code className="h-4 w-4" />
-              Open in Cursor
-            </MenuItem>
-            <MenuSeparator />
-            <MenuItem variant="destructive" onClick={() => onRemoveRepository(repository.id)}>
-              <Trash2 className="h-4 w-4" />
-              Remove Repository
-            </MenuItem>
-          </MenuPopup>
-        </Menu>
-      </div>
-    </header>
-  );
+				<Menu>
+					<MenuTrigger
+						render={
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								className="text-muted-foreground hover:text-foreground h-7 w-7"
+								aria-label="More options"
+							>
+								<MoreHorizontal className="h-3.5 w-3.5" />
+							</Button>
+						}
+					/>
+					<MenuPopup side="bottom" align="end">
+						<MenuItem onClick={handleOpenFinder}>
+							<ExternalLink className="h-4 w-4" />
+							Open in Finder
+						</MenuItem>
+						<MenuItem onClick={handleOpenTerminal}>
+							<Terminal className="h-4 w-4" />
+							Open Terminal
+						</MenuItem>
+						<MenuSeparator />
+						<MenuItem
+							variant="destructive"
+							onClick={() => onRemoveRepository(repository.id)}
+						>
+							<Trash2 className="h-4 w-4" />
+							Remove Repository
+						</MenuItem>
+					</MenuPopup>
+				</Menu>
+			</div>
+		</header>
+	);
 }

--- a/apps/desktop/src/renderer/src/components/layout/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/sidebar.tsx
@@ -31,6 +31,8 @@ import {
   Settings,
   Tags,
 } from "lucide-react";
+
+import { ThemeToggle } from "../theme-toggle";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { Label, Repository, Task, Worktree } from "../../types";
@@ -481,7 +483,7 @@ export function Sidebar({
           )}
         </SidebarContent>
 
-        <SidebarFooter className="p-2">
+        <SidebarFooter className="!flex-row items-center justify-between">
           <button
             type="button"
             className="text-muted-foreground hover:bg-muted hover:text-foreground flex size-7 items-center justify-center rounded-md transition-colors"
@@ -489,6 +491,7 @@ export function Sidebar({
           >
             <Settings className="size-4" />
           </button>
+          <ThemeToggle />
         </SidebarFooter>
       </SidebarRoot>
 

--- a/apps/desktop/src/renderer/src/components/theme-provider.tsx
+++ b/apps/desktop/src/renderer/src/components/theme-provider.tsx
@@ -4,8 +4,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 	return (
 		<NextThemesProvider
 			attribute="class"
-			defaultTheme="system"
-			enableSystem
+			defaultTheme="dark"
 			disableTransitionOnChange
 		>
 			{children}

--- a/apps/desktop/src/renderer/src/components/theme-provider.tsx
+++ b/apps/desktop/src/renderer/src/components/theme-provider.tsx
@@ -1,0 +1,16 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+	return (
+		<NextThemesProvider
+			attribute="class"
+			defaultTheme="system"
+			enableSystem
+			disableTransitionOnChange
+		>
+			{children}
+		</NextThemesProvider>
+	);
+}
+
+export { useTheme } from "next-themes";

--- a/apps/desktop/src/renderer/src/components/theme-toggle.tsx
+++ b/apps/desktop/src/renderer/src/components/theme-toggle.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@vibest/ui/components/button";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+export function ThemeToggle() {
+	const { resolvedTheme, setTheme } = useTheme();
+
+	const toggleTheme = () => {
+		setTheme(resolvedTheme === "dark" ? "light" : "dark");
+	};
+
+	return (
+		<Button
+			variant="ghost"
+			size="icon-sm"
+			className="text-muted-foreground hover:text-foreground h-7 w-7"
+			onClick={toggleTheme}
+			aria-label="Toggle theme"
+		>
+			<Sun className="h-3.5 w-3.5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+			<Moon className="absolute h-3.5 w-3.5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+		</Button>
+	);
+}

--- a/apps/desktop/src/renderer/src/components/theme-toggle.tsx
+++ b/apps/desktop/src/renderer/src/components/theme-toggle.tsx
@@ -3,10 +3,10 @@ import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 export function ThemeToggle() {
-	const { resolvedTheme, setTheme } = useTheme();
+	const { theme, setTheme } = useTheme();
 
 	const toggleTheme = () => {
-		setTheme(resolvedTheme === "dark" ? "light" : "dark");
+		setTheme(theme === "dark" ? "light" : "dark");
 	};
 
 	return (

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -4,12 +4,15 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import App from "./App";
+import { ThemeProvider } from "./components/theme-provider";
 import { queryClient } from "./lib/query-client";
 
 createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
-  </StrictMode>,
+	<StrictMode>
+		<QueryClientProvider client={queryClient}>
+			<ThemeProvider>
+				<App />
+			</ThemeProvider>
+		</QueryClientProvider>
+	</StrictMode>,
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       p-queue:
         specifier: ^9.1.0
         version: 9.1.0


### PR DESCRIPTION
## Summary
- Add theme switching support using next-themes library
- Add ThemeToggle component in sidebar footer (bottom right, next to Settings)
- Uses resolvedTheme for instant visual feedback on single click

## Test plan
- [ ] Verify theme toggle appears in sidebar footer
- [ ] Click toggle and confirm theme switches immediately
- [ ] Refresh app and verify theme preference persists