### PR TITLE
feat(desktop): increase terminal font weight to medium

### DIFF
--- a/apps/desktop/src/renderer/src/components/terminal/terminal-view.tsx
+++ b/apps/desktop/src/renderer/src/components/terminal/terminal-view.tsx
@@ -35,7 +35,7 @@ export function TerminalView({ terminalId, isVisible }: TerminalViewProps) {
 			cursorStyle: "block",
 			fontSize: 14,
 			fontFamily: '"Geist Mono Variable", Menlo, Monaco, monospace',
-			fontWeight: "normal",
+			fontWeight: "500",
 			lineHeight: 1.2,
 			scrollback: 1000,
 			theme: TERMINAL_THEME_DARK,


### PR DESCRIPTION
## Summary
- Increase terminal font weight from `"normal"` (400) to `"500"` (medium) for better readability

## Test plan
- [ ] Open the desktop app
- [ ] Check that terminal text appears slightly bolder and more readable
- [ ] Verify terminal still renders correctly with WebGL addon