### PR TITLE
fix(desktop): disable automatic terminal creation

### DIFF
--- a/apps/desktop/src/renderer/src/components/terminal/terminal-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/terminal/terminal-panel.tsx
@@ -3,8 +3,6 @@ import { Button } from "@vibest/ui/components/button";
 import { Tabs, TabsList, TabsTrigger } from "@vibest/ui/components/tabs";
 import { Plus, X } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useRef } from "react";
-
 import type { TerminalInfo } from "../../../../shared/contract/terminal";
 
 import { orpc } from "../../lib/orpc";
@@ -13,167 +11,162 @@ import { useAppStore } from "../../stores/app-store";
 import { TerminalView } from "./terminal-view";
 
 interface TerminalPanelProps {
-  worktreeId: string;
-  worktreePath: string;
-  worktreeExists: boolean;
-  isVisible: boolean;
+	worktreeId: string;
+	worktreePath: string;
+	worktreeExists: boolean;
+	isVisible: boolean;
 }
 
 export function TerminalPanel({
-  worktreeId,
-  worktreePath,
-  worktreeExists,
-  isVisible,
+	worktreeId,
+	worktreePath,
+	worktreeExists,
+	isVisible,
 }: TerminalPanelProps) {
-  const { resolvedTheme } = useTheme();
-  const storedActiveTerminalId = useAppStore((state) => state.activeTerminalId[worktreeId] ?? null);
-  const setActiveTerminalId = useAppStore((state) => state.setActiveTerminalId);
+	const { resolvedTheme } = useTheme();
+	const storedActiveTerminalId = useAppStore(
+		(state) => state.activeTerminalId[worktreeId] ?? null,
+	);
+	const setActiveTerminalId = useAppStore((state) => state.setActiveTerminalId);
 
-  // Single query for terminals - used by both tabs and view rendering
-  const { data: terminals = [], isSuccess } = useQuery(
-    orpc.terminal.list.queryOptions({ input: { worktreeId } }),
-  );
+	// Single query for terminals - used by both tabs and view rendering
+	const { data: terminals = [] } = useQuery(
+		orpc.terminal.list.queryOptions({ input: { worktreeId } }),
+	);
 
-  // Compute effective activeTerminalId - fallback to first terminal if none selected
-  const activeTerminalId =
-    storedActiveTerminalId && terminals.some((t) => t.id === storedActiveTerminalId)
-      ? storedActiveTerminalId
-      : (terminals[0]?.id ?? null);
+	// Compute effective activeTerminalId - fallback to first terminal if none selected
+	const activeTerminalId =
+		storedActiveTerminalId &&
+		terminals.some((t) => t.id === storedActiveTerminalId)
+			? storedActiveTerminalId
+			: (terminals[0]?.id ?? null);
 
-  // Track if auto-creation has been initiated
-  // This prevents double-creation in React Strict Mode
-  const autoCreateInitiated = useRef(false);
+	// Create terminal mutation
+	const createTerminal = useMutation({
+		...orpc.terminal.create.mutationOptions(),
+		onSuccess: (data: TerminalInfo) => {
+			queryClient.invalidateQueries({
+				queryKey: orpc.terminal.list.key({
+					input: { worktreeId: data.worktreeId },
+				}),
+			});
+			setActiveTerminalId(data.worktreeId, data.id);
+		},
+	});
 
-  // Create terminal mutation
-  const createTerminal = useMutation({
-    ...orpc.terminal.create.mutationOptions(),
-    onSuccess: (data: TerminalInfo) => {
-      queryClient.invalidateQueries({
-        queryKey: orpc.terminal.list.key({ input: { worktreeId: data.worktreeId } }),
-      });
-      setActiveTerminalId(data.worktreeId, data.id);
-    },
-  });
+	// Close terminal mutation
+	const closeTerminal = useMutation({
+		...orpc.terminal.close.mutationOptions(),
+	});
 
-  // Close terminal mutation
-  const closeTerminal = useMutation({
-    ...orpc.terminal.close.mutationOptions(),
-  });
+	const handleCreateTerminal = () => {
+		createTerminal.mutate({ worktreeId, cwd: worktreePath });
+	};
 
-  // Auto-create terminal when worktree has no terminals (only if path exists)
-  // Uses ref to prevent double-creation in React Strict Mode
-  useEffect(() => {
-    if (worktreeExists && isSuccess && terminals.length === 0 && !autoCreateInitiated.current) {
-      autoCreateInitiated.current = true;
-      createTerminal.mutate({ worktreeId, cwd: worktreePath });
-    }
-    // Note: createTerminal is excluded from deps as useMutation returns unstable reference
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [worktreeExists, isSuccess, terminals.length, worktreeId, worktreePath]);
+	const handleCloseTerminal = (e: React.MouseEvent, terminalId: string) => {
+		e.stopPropagation();
+		closeTerminal.mutate(
+			{ terminalId },
+			{
+				onSuccess: () => {
+					const closedIndex = terminals.findIndex((t) => t.id === terminalId);
+					const remaining = terminals.filter((t) => t.id !== terminalId);
 
-  const handleCreateTerminal = () => {
-    createTerminal.mutate({ worktreeId, cwd: worktreePath });
-  };
+					queryClient.invalidateQueries({
+						queryKey: orpc.terminal.list.key({ input: { worktreeId } }),
+					});
 
-  const handleCloseTerminal = (e: React.MouseEvent, terminalId: string) => {
-    e.stopPropagation();
-    closeTerminal.mutate(
-      { terminalId },
-      {
-        onSuccess: () => {
-          const closedIndex = terminals.findIndex((t) => t.id === terminalId);
-          const remaining = terminals.filter((t) => t.id !== terminalId);
+					// Select adjacent terminal if the closed one was active
+					if (activeTerminalId === terminalId) {
+						// If closing the last tab, select the previous one
+						// Otherwise, select the next one (which now has the same index)
+						const nextIndex =
+							closedIndex >= remaining.length
+								? remaining.length - 1
+								: closedIndex;
+						setActiveTerminalId(worktreeId, remaining[nextIndex]?.id ?? null);
+					}
+				},
+			},
+		);
+	};
 
-          // Create a new terminal if closing the last one
-          if (remaining.length === 0 && worktreeExists) {
-            createTerminal.mutate({ worktreeId, cwd: worktreePath });
-            return;
-          }
+	const handleTabChange = (terminalId: string) => {
+		setActiveTerminalId(worktreeId, terminalId);
+	};
 
-          queryClient.invalidateQueries({
-            queryKey: orpc.terminal.list.key({ input: { worktreeId } }),
-          });
+	const isDark = resolvedTheme === "dark";
 
-          // Select adjacent terminal if the closed one was active
-          if (activeTerminalId === terminalId) {
-            // If closing the last tab, select the previous one
-            // Otherwise, select the next one (which now has the same index)
-            const nextIndex = closedIndex >= remaining.length ? remaining.length - 1 : closedIndex;
-            setActiveTerminalId(worktreeId, remaining[nextIndex]?.id ?? null);
-          }
-        },
-      },
-    );
-  };
+	return (
+		<div
+			className={`absolute inset-0 flex h-full flex-col ${isDark ? "bg-[#141414]" : "bg-[#f9f9f9]"}`}
+			style={{ visibility: isVisible ? "visible" : "hidden" }}
+		>
+			{/* Tabs header */}
+			<div
+				className={`flex items-center border-b ${isDark ? "border-zinc-800 bg-[#141414]" : "border-zinc-300 bg-[#f9f9f9]"}`}
+			>
+				<Tabs
+					value={activeTerminalId ?? ""}
+					onValueChange={handleTabChange}
+					className="flex-1"
+				>
+					<TabsList className="h-9 rounded-none bg-transparent p-0">
+						{terminals.map((terminal, index) => (
+							<TabsTrigger
+								key={terminal.id}
+								value={terminal.id}
+								className={`relative h-9 rounded-none border-r px-3 data-[state=active]:shadow-none ${isDark ? "border-zinc-800 data-[state=active]:bg-zinc-900" : "border-zinc-300 data-[state=active]:bg-zinc-200"}`}
+							>
+								<span className="mr-2">
+									{terminals.length === 1
+										? "Terminal"
+										: `Terminal ${index + 1}`}
+								</span>
+								<button
+									type="button"
+									onClick={(e) => handleCloseTerminal(e, terminal.id)}
+									className="opacity-60 hover:opacity-100"
+								>
+									<X className="h-3 w-3" />
+								</button>
+							</TabsTrigger>
+						))}
+					</TabsList>
+				</Tabs>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-9 w-9 rounded-none"
+					onClick={handleCreateTerminal}
+					disabled={!worktreeExists || createTerminal.isPending}
+					title={
+						worktreeExists ? "New terminal" : "Worktree path does not exist"
+					}
+				>
+					<Plus className="h-4 w-4" />
+				</Button>
+			</div>
 
-  const handleTabChange = (terminalId: string) => {
-    setActiveTerminalId(worktreeId, terminalId);
-  };
-
-  const isDark = resolvedTheme === "dark";
-
-  return (
-    <div
-      className={`absolute inset-0 flex h-full flex-col ${isDark ? "bg-[#141414]" : "bg-[#f9f9f9]"}`}
-      style={{ visibility: isVisible ? "visible" : "hidden" }}
-    >
-      {/* Tabs header */}
-      <div
-        className={`flex items-center border-b ${isDark ? "border-zinc-800 bg-[#141414]" : "border-zinc-300 bg-[#f9f9f9]"}`}
-      >
-        <Tabs value={activeTerminalId ?? ""} onValueChange={handleTabChange} className="flex-1">
-          <TabsList className="h-9 rounded-none bg-transparent p-0">
-            {terminals.map((terminal, index) => (
-              <TabsTrigger
-                key={terminal.id}
-                value={terminal.id}
-                className={`relative h-9 rounded-none border-r px-3 data-[state=active]:shadow-none ${isDark ? "border-zinc-800 data-[state=active]:bg-zinc-900" : "border-zinc-300 data-[state=active]:bg-zinc-200"}`}
-              >
-                <span className="mr-2">
-                  {terminals.length === 1 ? "Terminal" : `Terminal ${index + 1}`}
-                </span>
-                <button
-                  type="button"
-                  onClick={(e) => handleCloseTerminal(e, terminal.id)}
-                  className="opacity-60 hover:opacity-100"
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-9 w-9 rounded-none"
-          onClick={handleCreateTerminal}
-          disabled={!worktreeExists || createTerminal.isPending}
-          title={worktreeExists ? "New terminal" : "Worktree path does not exist"}
-        >
-          <Plus className="h-4 w-4" />
-        </Button>
-      </div>
-
-      {/* Terminal views */}
-      <div className="relative flex-1">
-        {terminals.map((terminal) => (
-          <TerminalView
-            key={terminal.id}
-            terminalId={terminal.id}
-            isVisible={isVisible && terminal.id === activeTerminalId}
-          />
-        ))}
-        {terminals.length === 0 && (
-          <div
-            className={`flex h-full items-center justify-center ${isDark ? "text-zinc-500" : "text-zinc-600"}`}
-          >
-            {worktreeExists
-              ? "No terminals. Click + to create one."
-              : "Worktree path does not exist on disk."}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+			{/* Terminal views */}
+			<div className="relative flex-1">
+				{terminals.map((terminal) => (
+					<TerminalView
+						key={terminal.id}
+						terminalId={terminal.id}
+						isVisible={isVisible && terminal.id === activeTerminalId}
+					/>
+				))}
+				{terminals.length === 0 && (
+					<div
+						className={`flex h-full items-center justify-center ${isDark ? "text-zinc-500" : "text-zinc-600"}`}
+					>
+						{worktreeExists
+							? "No terminals. Click + to create one."
+							: "Worktree path does not exist on disk."}
+					</div>
+				)}
+			</div>
+		</div>
+	);
 }


### PR DESCRIPTION
## Summary
- Remove auto-creation of terminal when selecting a task/worktree
- Remove auto-creation of terminal when closing the last one
- Terminal panel now stays empty until user manually clicks the + button
- Clean up unused imports (`useEffect`, `useRef`) and variables (`isSuccess`, `autoCreateInitiated`)

## Test plan
- [ ] Select a task - verify terminal panel shows empty state message
- [ ] Click + button to create a terminal manually
- [ ] Close the last terminal - verify it stays empty (no auto-recreation)
- [ ] Verify "No terminals. Click + to create one." message displays correctly