### PR TITLE
feat(desktop): add hover-to-open for repo overflow menu

### DIFF
--- a/apps/desktop/src/renderer/src/components/layout/sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/layout/sidebar.tsx
@@ -242,6 +242,9 @@ function RepoTabs({
         {overflowRepos.length > 0 && (
           <Menu>
             <MenuTrigger
+              openOnHover
+              delay={0}
+              closeDelay={0}
               render={
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- Enable hover-to-open functionality for the +N repository overflow menu in sidebar
- Menu opens immediately on hover (0ms delay)
- Menu closes immediately when mouse leaves (0ms closeDelay)
- Maintains click interaction and keyboard accessibility

## Implementation
Uses Base UI React's native `openOnHover` prop on `MenuTrigger` component with zero delay configuration for instant response.

## Test plan
- [ ] Hover over +N button → menu opens instantly
- [ ] Move mouse away → menu closes instantly
- [ ] Click +N button → menu still toggles correctly
- [ ] Tab to button and press Enter → menu opens
- [ ] Press Escape → menu closes
- [ ] Test rapid mouse movements for stability