### PR TITLE
fix(desktop): prevent terminal rerender when archiving task

### DIFF
--- a/apps/desktop/src/renderer/src/stores/slices/terminal-slice.ts
+++ b/apps/desktop/src/renderer/src/stores/slices/terminal-slice.ts
@@ -4,6 +4,7 @@ export interface TerminalSlice {
   // Active terminal per worktree
   activeTerminalId: Record<string, string | null>;
   setActiveTerminalId: (worktreeId: string, terminalId: string | null) => void;
+  clearActiveTerminalId: (worktreeId: string) => void;
 }
 
 export const createTerminalSlice: StateCreator<TerminalSlice, [], [], TerminalSlice> = (set) => ({
@@ -18,4 +19,10 @@ export const createTerminalSlice: StateCreator<TerminalSlice, [], [], TerminalSl
         [worktreeId]: terminalId,
       },
     })),
+
+  clearActiveTerminalId: (worktreeId) =>
+    set((state) => {
+      const { [worktreeId]: _, ...rest } = state.activeTerminalId;
+      return { activeTerminalId: rest };
+    }),
 });


### PR DESCRIPTION
## Problem

When archiving a task, other terminals were experiencing rendering issues due to unnecessary component rerenders and disposal.

## Root Cause

1. Only the currently selected worktree was being removed from `openedWorktreeIds`, leaving stale IDs for other worktrees of the archived task
2. `invalidateQueries(workspace.key())` triggered a refetch, causing `worktreesByRepository` to update and `openedWorktrees` array to be recalculated, leading to TerminalPanel unmounting and remounting

## Solution

1. **Clean up all worktrees** of the archived task from both `openedWorktreeIds` and `activeTerminalId` state
2. **Use optimistic cache update** instead of invalidating workspace query to avoid triggering refetch and preventing unnecessary rerenders
3. **Add `clearActiveTerminalId`** method to terminal slice for proper state cleanup

## Changes

- `apps/desktop/src/renderer/src/App.tsx`: Updated `archiveTaskMutation` to clean up all archived task worktrees and use optimistic update
- `apps/desktop/src/renderer/src/stores/slices/terminal-slice.ts`: Added `clearActiveTerminalId` method

This ensures terminal instances remain stable when archiving tasks, preventing the disposal and recreation that was causing rendering issues.