### PR TITLE
chore: upgrade pnpm to 11.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@10.15.1"
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882"
 }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882"
+  "packageManager": "pnpm@11.11.0"
 }


### PR DESCRIPTION
Bump the packageManager field from pnpm@10.15.1 to pnpm@11.11.0 (latest).
The lockfile keeps lockfileVersion 9.0, so no lockfile changes are needed,
and CI picks up the new version automatically via corepack.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lf4fJiZgGQSjGuvywiq8Gm