### PR TITLE
Use Vite native tsconfig path resolution

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,7 +48,6 @@
     "code-inspector-plugin": "latest",
     "typescript": "^7.0.2",
     "vite": "catalog:",
-    "vite-plus": "catalog:",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-plus": "catalog:"
   }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,10 +4,10 @@ import react from "@vitejs/plugin-react";
 import { codeInspectorPlugin } from "code-inspector-plugin";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite-plus";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   resolve: {
+    tsconfigPaths: true,
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
@@ -26,6 +26,5 @@ export default defineConfig({
     }),
     react(),
     tailwindcss(),
-    tsconfigPaths(),
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,10 +303,6 @@ importers:
       vite-plus:
         specifier: 'catalog:'
         version: 0.2.4(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.6.1)(publint@0.3.17)(tsx@4.23.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.6.1)(jsdom@26.1.0)(publint@0.3.17)(tsx@4.23.0)(typescript@7.0.2)(yaml@2.9.0)
-      vite-tsconfig-paths:
-        specifier: ^5.1.4
-        version: 5.1.4(@voidzero-dev/vite-plus-core@0.2.4(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.6.1)(publint@0.3.17)(tsx@4.23.0)(typescript@7.0.2)(yaml@2.9.0))(typescript@7.0.2)
-
   packages/ai-sdk-agents:
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
@@ -6153,14 +6149,6 @@ packages:
       '@vitest/browser-playwright':
         optional: true
       '@vitest/browser-webdriverio':
-        optional: true
-
-  vite-tsconfig-paths@5.1.4:
-    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
         optional: true
 
   vitest@4.1.10:
@@ -12624,17 +12612,6 @@ snapshots:
       - utf-8-validate
       - vite
       - yaml
-
-  vite-tsconfig-paths@5.1.4(@voidzero-dev/vite-plus-core@0.2.4(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.6.1)(publint@0.3.17)(tsx@4.23.0)(typescript@7.0.2)(yaml@2.9.0))(typescript@7.0.2):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@7.0.2)
-    optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.2.4(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.6.1)(publint@0.3.17)(tsx@4.23.0)(typescript@7.0.2)(yaml@2.9.0)'
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.4(@types/node@24.10.13)(esbuild@0.28.1)(jiti@2.6.1)(publint@0.3.17)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0))(jsdom@26.1.0):
     dependencies:


### PR DESCRIPTION
## Summary
- replace `vite-tsconfig-paths` with Vite's native `resolve.tsconfigPaths` option
- remove the obsolete plugin dependency and lockfile entries
- preserve the existing explicit `@` alias

## Validation
- `vp check` (passes with two existing warnings outside this change)
- dev server starts on port 5173 without the plugin migration warning

## Existing issues
- package typecheck/build remain blocked by unrelated unresolved workspace exports, `@orpc/client` export mismatches, and a missing `@vibe-web/ui/globals.css` import