### PR TITLE
refactor(desktop): wire Main's capability modules as Effect Layers

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -57,8 +57,8 @@ ManagedRuntime.make(
     Layer.provide(RendererChannelLive),
     Layer.provide(DesktopApplicationLive),
     Layer.provide(LocalBackendLive),
-    Layer.provide(desktopConfigLive),
-    Layer.provide(childProcessLive),
+    Layer.provide(DesktopConfigLive),
+    Layer.provide(ChildProcessSpawnerLive),
   ),
 );
 ```

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -18,12 +18,13 @@ src/main/index.ts
 Allowed production dependencies:
 
 - `src/main/index.ts` imports only `desktop-runtime.ts`.
-- `desktop-runtime.ts` may import every Main module because it is the composition root.
+- `desktop-runtime.ts` and `desktop-runtime-glue.ts` may import every Main module because they are the composition root. `desktop-runtime-glue.ts` holds the subset of glue Layers that need to stay importable from tests without pulling in `electron/main-window.ts` (see "Tag and Layer ownership" below).
+- `desktop-config.ts` has no dependencies of its own (besides the shared `APP_ORIGIN` constant) and may be depended on by any Main module.
 - `application/**` may depend on backend interfaces, shared desktop types, and Effect core.
 - `backend/local-backend.ts` may depend on Effect core and shared desktop types.
-- Backend platform adapters may depend on backend-owned ports, Effect platform, and the CLI handshake.
+- Backend platform adapters (including `backend/local-backend-live.ts`) may depend on backend-owned ports, `desktop-config.ts`, Effect platform, and the CLI handshake.
 - `rpc/**` may depend on the application interface, the shared contract, oRPC, and Effect core.
-- `electron/**` may depend on Electron and generic callbacks supplied by the composition root.
+- `electron/**` may depend on Electron, `desktop-config.ts`, other `electron/**` modules, and generic callbacks supplied by the composition root.
 - `preload/**` may depend only on Electron and transport constants from `shared/**`.
 - `renderer/**` may depend on browser APIs, the shared contract, oRPC client packages, React, and `@vibest/app`.
 
@@ -37,6 +38,30 @@ Forbidden dependencies:
 - Do not add dependencies from an inner module back to `desktop-runtime.ts`.
 
 Keep implementation adapters behind interfaces owned by the module that consumes the capability. Wire concrete adapters only in `desktop-runtime.ts`.
+
+### Tag and Layer ownership
+
+Most capability modules (`LocalBackend`, `DesktopApplication`, `RendererChannel`, `MainWindow`, `DesktopConfig`) are exposed as an Effect `Context.Service` Tag rather than a plain interface, so the composition root can wire them as a Layer graph instead of threading constructor parameters by hand.
+
+- The Tag and its factory function live together in the module that owns the capability (e.g. `LocalBackend` and `makeLocalBackend` in `backend/local-backend.ts`). The factory keeps taking plain parameters and stays the unit tests target — Layer wiring is a thin wrapper around it, not a replacement for it.
+- The `Live` Layer for a Tag lives next to the Tag **only if building it needs nothing the module isn't already allowed to import** (e.g. `MainWindowLive` in `electron/main-window.ts` only needs `DesktopConfig` and `RendererChannel`, both already-allowed electron/** dependencies).
+- When building a Tag's `Live` Layer needs a capability the owning module is forbidden to import (e.g. `DesktopApplicationLive` needs `app.quit()`, which `application/**` may not import), the `Live` Layer is defined in `desktop-runtime-glue.ts` instead, next to the other glue. This is the same "adapter lives at the composition root" rule the dependency table already states — Tag-ification does not relax it. `desktop-runtime-glue.ts` is a separate file from `desktop-runtime.ts` itself only so composition tests can import it without loading `electron/main-window.ts`'s `BrowserWindow` import, which fails to resolve under the test runner's Electron shim; it is otherwise still composition-root code.
+- Modules only ever import another module's Tag and its `Service` shape type (`Foo["Service"]`), never another module's `Live` Layer or factory internals.
+- Not every module gets a Tag. Pure functions (`restartBackoff`, `formatStartupFailure`, `resolveAssetPath`, `resolveServerEntry`), single-consumer plain constructs (`makeDesktopRpcServer`, `makeDesktopRouter`), and injected function ports (`SpawnBackend`) stay as-is. Reach for a Tag when a capability has (or will imminently have) more than one consumer reachable only by threading it through several layers of constructor parameters — not by file-per-service default.
+
+Example of the resulting composition:
+
+```ts
+ManagedRuntime.make(
+  MainWindowLive.pipe(
+    Layer.provide(RendererChannelLive),
+    Layer.provide(DesktopApplicationLive),
+    Layer.provide(LocalBackendLive),
+    Layer.provide(desktopConfigLive),
+    Layer.provide(childProcessLive),
+  ),
+);
+```
 
 ## Renderer/Main transport
 
@@ -60,11 +85,11 @@ Keep implementation adapters behind interfaces owned by the module that consumes
 
 ## Effect usage
 
-- `desktop-runtime.ts` is the only production Layer composition root and `ManagedRuntime` owner.
+- `desktop-runtime.ts` is the only production Layer composition root and `ManagedRuntime` owner; `desktop-runtime-glue.ts` supplies it with the Electron-touching Live Layers that can't live next to their Tag (see "Tag and Layer ownership").
 - Use Scope for child processes, MessagePorts, protocol handlers, windows, and subscriptions.
 - RPC handlers run detached from the ManagedRuntime; they inherit the composition root's Context (including logger and other references) through `effect/context` plus the wrapper's outer `Effect.provide`. Handing over the full ServiceMap is intentional — do not pass `Context.empty()` and do not hand-pick reference keys.
 - No bare `console.*` in Main; log through `Effect.log*`. Raw child-process output is relayed via `Effect.log`/`Effect.logError` with a source annotation.
-- Prefer explicit constructor parameters and plain capability values over a `Context.Service` for every file.
+- See "Tag and Layer ownership" above for when a module gets a `Context.Service` Tag versus staying a plain factory.
 - Keep restart policy, path calculation, and other pure calculations as plain functions.
 - Keep `@effect/platform-node` imports on direct subpaths. Importing its barrel can eagerly load `NodeRedis` and break packaged startup when `ioredis` is absent.
 - Packaged GUI startup must recover the complete exported login-shell environment, not only `PATH`, so proxy and authentication variables reach the backend and agent subprocesses.

--- a/apps/desktop/src/main/README.md
+++ b/apps/desktop/src/main/README.md
@@ -5,16 +5,22 @@ Electron Main starts the local backend, owns the application window, and exposes
 ```text
 index.ts
   -> desktop-runtime.ts
+       -> desktop-runtime-glue.ts
+       -> desktop-config.ts
        -> application/desktop-application.ts
        -> backend/
        -> rpc/
        -> electron/
 ```
 
-- `desktop-runtime.ts` creates the root Effect runtime and assembles the concrete modules.
-- `application/` contains renderer-facing desktop use cases.
-- `backend/` contains local backend supervision and the Node child-process adapter.
+- `desktop-runtime.ts` creates the root Effect runtime and composes the module `Layer`s into it.
+- `desktop-runtime-glue.ts` holds the Electron-touching `Live` Layers (`DesktopApplicationLive`, `RendererChannelLive`) that can't live next to their Tag; split out so they stay importable from tests without pulling in `electron/main-window.ts`.
+- `desktop-config.ts` resolves host/environment facts (packaged state, dev URL, server entry, token, allowed origins) once and exposes them as a `DesktopConfig` Tag.
+- `application/` contains renderer-facing desktop use cases, exposed as a `DesktopApplication` Tag.
+- `backend/` contains local backend supervision (`LocalBackend` Tag) and the Node child-process adapter.
 - `rpc/` contains the transport-neutral router and oRPC MessagePort server.
-- `electron/` contains BrowserWindow, MessageChannel, and custom asset protocol adapters.
+- `electron/` contains BrowserWindow (`MainWindow` Tag), MessageChannel (`RendererChannel` Tag), and custom asset protocol adapters.
+
+Most capability modules are `Context.Service` Tags with a plain-parameter factory function alongside them; `desktop-runtime.ts` wires their `Live` Layers into one graph instead of threading constructor parameters by hand. See "Tag and Layer ownership" in `apps/desktop/AGENTS.md` for which module owns a Tag's `Live` Layer and when a capability stays a plain factory instead.
 
 The production renderer is served from `vibest://app`. The custom protocol is used only for application assets; Renderer/Main RPC travels over MessagePort. See `apps/desktop/AGENTS.md` for dependency and implementation rules.

--- a/apps/desktop/src/main/application/desktop-application.test.ts
+++ b/apps/desktop/src/main/application/desktop-application.test.ts
@@ -11,7 +11,7 @@ function makeHarness() {
   );
   let retries = 0;
   let quits = 0;
-  const backend: LocalBackend = {
+  const backend: LocalBackend["Service"] = {
     connection: {
       httpBaseUrl: "http://127.0.0.1:43123",
       wsBaseUrl: "ws://127.0.0.1:43123",

--- a/apps/desktop/src/main/application/desktop-application.ts
+++ b/apps/desktop/src/main/application/desktop-application.ts
@@ -1,17 +1,20 @@
-import { Effect, Stream } from "effect";
+import { Context, Effect, Stream } from "effect";
 
 import type { BackendStatusSnapshot, DesktopBootstrap } from "../../shared/desktop-rpc";
 import type { LocalBackend } from "../backend/local-backend";
 
-export interface DesktopApplication {
-  readonly bootstrap: Effect.Effect<DesktopBootstrap>;
-  readonly watchBackendStatus: (after: number) => Stream.Stream<BackendStatusSnapshot>;
-  readonly retryBackend: Effect.Effect<void>;
-  readonly quit: Effect.Effect<void>;
-}
+export class DesktopApplication extends Context.Service<
+  DesktopApplication,
+  {
+    readonly bootstrap: Effect.Effect<DesktopBootstrap>;
+    readonly watchBackendStatus: (after: number) => Stream.Stream<BackendStatusSnapshot>;
+    readonly retryBackend: Effect.Effect<void>;
+    readonly quit: Effect.Effect<void>;
+  }
+>()("desktop/DesktopApplication") {}
 
 export type DesktopApplicationDependencies = {
-  readonly backend: LocalBackend;
+  readonly backend: LocalBackend["Service"];
   readonly os: NodeJS.Platform;
   readonly quit: Effect.Effect<void>;
 };
@@ -20,7 +23,7 @@ export function makeDesktopApplication({
   backend,
   os,
   quit,
-}: DesktopApplicationDependencies): DesktopApplication {
+}: DesktopApplicationDependencies): DesktopApplication["Service"] {
   return {
     bootstrap: Effect.gen(function* () {
       const current = yield* backend.snapshot;
@@ -37,5 +40,5 @@ export function makeDesktopApplication({
       backend.changes.pipe(Stream.filter((snapshot) => snapshot.revision > after)),
     retryBackend: backend.retry,
     quit,
-  };
+  } satisfies DesktopApplication["Service"];
 }

--- a/apps/desktop/src/main/backend/local-backend-live.ts
+++ b/apps/desktop/src/main/backend/local-backend-live.ts
@@ -1,0 +1,28 @@
+import { Effect, Layer } from "effect";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { DesktopConfig } from "../desktop-config";
+import { LocalBackend, makeLocalBackend } from "./local-backend";
+import { resolveLoginShellEnvironmentWith } from "./login-shell-environment";
+import { makeNodeBackendProcess } from "./node-backend-process";
+
+export const LocalBackendLive = Layer.effect(
+  LocalBackend,
+  Effect.gen(function* () {
+    const config = yield* DesktopConfig;
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const environment = config.isPackaged
+      ? yield* resolveLoginShellEnvironmentWith(spawner)
+      : { ...process.env };
+
+    return yield* makeLocalBackend(
+      {
+        entry: config.serverEntry,
+        token: config.token,
+        environment,
+        corsOrigins: config.allowedOrigins,
+      },
+      makeNodeBackendProcess(spawner),
+    );
+  }),
+);

--- a/apps/desktop/src/main/backend/local-backend.ts
+++ b/apps/desktop/src/main/backend/local-backend.ts
@@ -1,5 +1,6 @@
 import {
   Clock,
+  Context,
   Data,
   Deferred,
   Effect,
@@ -68,12 +69,15 @@ export type LocalBackendConfig = BackendProcessConfig & {
   readonly stableAfterMs?: number;
 };
 
-export interface LocalBackend {
-  readonly connection: BackendConnection;
-  readonly snapshot: Effect.Effect<BackendStatusSnapshot>;
-  readonly changes: Stream.Stream<BackendStatusSnapshot>;
-  readonly retry: Effect.Effect<void>;
-}
+export class LocalBackend extends Context.Service<
+  LocalBackend,
+  {
+    readonly connection: BackendConnection;
+    readonly snapshot: Effect.Effect<BackendStatusSnapshot>;
+    readonly changes: Stream.Stream<BackendStatusSnapshot>;
+    readonly retry: Effect.Effect<void>;
+  }
+>()("desktop/LocalBackend") {}
 
 export function restartBackoff(
   failureCount: number,
@@ -104,7 +108,7 @@ function setStatus(
 export function makeLocalBackend(
   config: LocalBackendConfig,
   spawnBackend: SpawnBackend,
-): Effect.Effect<LocalBackend, BackendStartError, Scope.Scope> {
+): Effect.Effect<LocalBackend["Service"], BackendStartError, Scope.Scope> {
   return Effect.gen(function* () {
     const statusRef = yield* SubscriptionRef.make<BackendStatusSnapshot>({
       revision: 0,
@@ -191,6 +195,6 @@ export function makeLocalBackend(
         const current = yield* snapshot;
         if (current.status === "failed") yield* Queue.offer(retryQueue, undefined);
       }),
-    } satisfies LocalBackend;
+    } satisfies LocalBackend["Service"];
   });
 }

--- a/apps/desktop/src/main/desktop-config.test.ts
+++ b/apps/desktop/src/main/desktop-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDesktopConfig } from "./desktop-config";
+import { APP_ORIGIN } from "./electron/app-protocol";
+
+describe("buildDesktopConfig", () => {
+  it("resolves the packaged server entry under resourcesPath", () => {
+    const config = buildDesktopConfig({
+      isPackaged: true,
+      resourcesPath: "/Applications/Vibest.app/Contents/Resources",
+      devUrl: undefined,
+      token: "fixed-token",
+    });
+
+    expect(config.serverEntry).toBe(
+      "/Applications/Vibest.app/Contents/Resources/app.asar/node_modules/@vibest/cli/dist/cli.mjs",
+    );
+    expect(config.allowedOrigins).toEqual([APP_ORIGIN]);
+    expect(config.token).toBe("fixed-token");
+  });
+
+  it("resolves the dev server entry relative to the package output", () => {
+    const config = buildDesktopConfig({
+      isPackaged: false,
+      resourcesPath: "/unused",
+      devUrl: undefined,
+      token: "fixed-token",
+    });
+
+    expect(config.serverEntry).toMatch(/packages\/vibest\/dist\/cli\.mjs$/);
+  });
+
+  it("includes the dev renderer origin when a devUrl is set", () => {
+    const config = buildDesktopConfig({
+      isPackaged: false,
+      resourcesPath: "/unused",
+      devUrl: "http://localhost:5173",
+      token: "fixed-token",
+    });
+
+    expect(config.allowedOrigins).toEqual([APP_ORIGIN, "http://localhost:5173"]);
+  });
+});

--- a/apps/desktop/src/main/desktop-config.ts
+++ b/apps/desktop/src/main/desktop-config.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Context, Layer } from "effect";
+
+import { APP_ORIGIN } from "./electron/app-protocol";
+
+export class DesktopConfig extends Context.Service<
+  DesktopConfig,
+  {
+    readonly isPackaged: boolean;
+    readonly devUrl: string | undefined;
+    readonly serverEntry: string;
+    readonly token: string;
+    readonly allowedOrigins: readonly string[];
+  }
+>()("desktop/DesktopConfig") {}
+
+export type DesktopConfigInputs = {
+  readonly isPackaged: boolean;
+  readonly resourcesPath: string;
+  readonly devUrl: string | undefined;
+  readonly token: string;
+};
+
+export function resolveServerEntry(isPackaged: boolean, resourcesPath: string): string {
+  if (isPackaged) {
+    return path.join(
+      resourcesPath,
+      "app.asar",
+      "node_modules",
+      "@vibest",
+      "cli",
+      "dist",
+      "cli.mjs",
+    );
+  }
+  return fileURLToPath(new URL("../../../../packages/vibest/dist/cli.mjs", import.meta.url));
+}
+
+export function buildDesktopConfig(inputs: DesktopConfigInputs): DesktopConfig["Service"] {
+  return {
+    isPackaged: inputs.isPackaged,
+    devUrl: inputs.devUrl,
+    serverEntry: resolveServerEntry(inputs.isPackaged, inputs.resourcesPath),
+    token: inputs.token,
+    allowedOrigins: [APP_ORIGIN, ...(inputs.devUrl ? [new URL(inputs.devUrl).origin] : [])],
+  };
+}
+
+export function makeDesktopConfigLive(inputs: DesktopConfigInputs): Layer.Layer<DesktopConfig> {
+  return Layer.succeed(DesktopConfig, buildDesktopConfig(inputs));
+}

--- a/apps/desktop/src/main/desktop-runtime-glue.test.ts
+++ b/apps/desktop/src/main/desktop-runtime-glue.test.ts
@@ -1,0 +1,51 @@
+import { Effect, Layer, ManagedRuntime, SubscriptionRef } from "effect";
+import { describe, expect, it } from "vitest";
+
+import type { BackendStatusSnapshot } from "../shared/desktop-rpc";
+import { DesktopApplication } from "./application/desktop-application";
+import { LocalBackend } from "./backend/local-backend";
+import { DesktopApplicationLive } from "./desktop-runtime-glue";
+
+describe("DesktopApplicationLive", () => {
+  it("resolves a DesktopApplication built from a LocalBackend provided through the Layer graph", async () => {
+    const statusRef = Effect.runSync(
+      SubscriptionRef.make<BackendStatusSnapshot>({ revision: 0, status: "ready" }),
+    );
+
+    // Only LocalBackend is faked: this test exercises the Layer wiring
+    // introduced by this module (LocalBackend -> DesktopApplication), not
+    // the already-covered supervision logic inside makeLocalBackend itself.
+    const fakeLocalBackendLive = Layer.succeed(LocalBackend, {
+      connection: {
+        httpBaseUrl: "http://127.0.0.1:1",
+        wsBaseUrl: "ws://127.0.0.1:1",
+        token: "fake-token",
+      },
+      snapshot: SubscriptionRef.get(statusRef),
+      changes: SubscriptionRef.changes(statusRef),
+      retry: Effect.void,
+    });
+
+    const runtime = ManagedRuntime.make(
+      DesktopApplicationLive.pipe(Layer.provide(fakeLocalBackendLive)),
+    );
+
+    try {
+      const bootstrap = await runtime.runPromise(
+        Effect.gen(function* () {
+          const application = yield* DesktopApplication;
+          return yield* application.bootstrap;
+        }),
+      );
+
+      expect(bootstrap).toMatchObject({
+        os: process.platform,
+        backend: { token: "fake-token" },
+        status: "ready",
+        statusRevision: 0,
+      });
+    } finally {
+      await runtime.dispose();
+    }
+  });
+});

--- a/apps/desktop/src/main/desktop-runtime-glue.ts
+++ b/apps/desktop/src/main/desktop-runtime-glue.ts
@@ -1,0 +1,38 @@
+import { Effect, Layer } from "effect";
+import { app } from "electron";
+
+import { DesktopApplication, makeDesktopApplication } from "./application/desktop-application";
+import { LocalBackend } from "./backend/local-backend";
+import { RendererChannel, makeRendererChannel } from "./electron/renderer-channel";
+import { makeDesktopRpcServer } from "./rpc/desktop-rpc-server";
+
+// These two Live layers need Electron capabilities (app.quit, and the oRPC
+// MessagePort wiring that reaches into application/** and rpc/**) that the
+// modules they connect are not allowed to import directly, so they live at
+// the composition root instead of alongside their Tag. Split into their own
+// file (rather than desktop-runtime.ts itself) so they stay importable from
+// tests without pulling in main-window.ts's BrowserWindow dependency.
+export const DesktopApplicationLive = Layer.effect(
+  DesktopApplication,
+  Effect.gen(function* () {
+    const backend = yield* LocalBackend;
+    return makeDesktopApplication({
+      backend,
+      os: process.platform,
+      quit: Effect.sync(() => {
+        setTimeout(() => app.quit(), 0);
+      }),
+    });
+  }),
+);
+
+export const RendererChannelLive = Layer.effect(
+  RendererChannel,
+  Effect.gen(function* () {
+    const application = yield* DesktopApplication;
+    // Hand the composition root's full ServiceMap (including logger and
+    // other references) to the detached oRPC handler fibers.
+    const rpcContext = yield* Effect.context<never>();
+    return makeRendererChannel(makeDesktopRpcServer(application, rpcContext).attach);
+  }),
+);

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -1,99 +1,38 @@
 import { randomUUID } from "node:crypto";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import * as NodeChildProcessSpawner from "@effect/platform-node/NodeChildProcessSpawner";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { electronApp, is, optimizer } from "@electron-toolkit/utils";
-import { Context, Effect, Layer, ManagedRuntime, Result } from "effect";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import { Effect, Layer, ManagedRuntime, Result } from "effect";
 import { app, dialog } from "electron";
 
-import { makeDesktopApplication } from "./application/desktop-application";
-import { makeLocalBackend } from "./backend/local-backend";
-import { resolveLoginShellEnvironmentWith } from "./backend/login-shell-environment";
-import { makeNodeBackendProcess } from "./backend/node-backend-process";
-import { APP_ORIGIN, registerAppProtocol, registerAppScheme } from "./electron/app-protocol";
-import { makeMainWindow, rendererRoot } from "./electron/main-window";
-import { makeRendererChannel } from "./electron/renderer-channel";
-import { makeDesktopRpcServer } from "./rpc/desktop-rpc-server";
+import { LocalBackendLive } from "./backend/local-backend-live";
+import { makeDesktopConfigLive } from "./desktop-config";
+import { DesktopApplicationLive, RendererChannelLive } from "./desktop-runtime-glue";
+import { registerAppScheme } from "./electron/app-protocol";
+import { MainWindow, MainWindowLive } from "./electron/main-window";
 import { formatStartupFailure } from "./startup-failure";
-
-class DesktopRuntime extends Context.Service<
-  DesktopRuntime,
-  {
-    readonly ensureWindow: Effect.Effect<void>;
-    readonly focusWindow: Effect.Effect<void>;
-  }
->()("desktop/DesktopRuntime") {}
-
-function resolveServerEntry(isPackaged: boolean, resourcesPath: string): string {
-  if (isPackaged) {
-    return path.join(
-      resourcesPath,
-      "app.asar",
-      "node_modules",
-      "@vibest",
-      "cli",
-      "dist",
-      "cli.mjs",
-    );
-  }
-  return fileURLToPath(new URL("../../../../packages/vibest/dist/cli.mjs", import.meta.url));
-}
-
-function makeDesktopRuntimeLayer(devUrl: string | undefined) {
-  return Layer.effect(
-    DesktopRuntime,
-    Effect.gen(function* () {
-      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-      const allowedOrigins = [APP_ORIGIN, ...(devUrl ? [new URL(devUrl).origin] : [])];
-      const environment = app.isPackaged
-        ? yield* resolveLoginShellEnvironmentWith(spawner)
-        : { ...process.env };
-
-      const backend = yield* makeLocalBackend(
-        {
-          entry: resolveServerEntry(app.isPackaged, process.resourcesPath),
-          token: randomUUID(),
-          environment,
-          corsOrigins: allowedOrigins,
-        },
-        makeNodeBackendProcess(spawner),
-      );
-
-      const application = makeDesktopApplication({
-        backend,
-        os: process.platform,
-        quit: Effect.sync(() => {
-          setTimeout(() => app.quit(), 0);
-        }),
-      });
-      // Hand the composition root's full ServiceMap (including logger and
-      // other references) to the detached oRPC handler fibers.
-      const rpcContext = yield* Effect.context<never>();
-      const rpcServer = makeDesktopRpcServer(application, rpcContext);
-      const rendererChannel = makeRendererChannel(rpcServer.attach);
-
-      yield* registerAppProtocol(rendererRoot());
-      const mainWindow = yield* makeMainWindow({
-        devUrl,
-        connectRenderer: rendererChannel.connect,
-      });
-
-      return DesktopRuntime.of({
-        ensureWindow: mainWindow.ensureOpen,
-        focusWindow: mainWindow.focus,
-      });
-    }),
-  );
-}
 
 function makeRuntime(devUrl: string | undefined) {
   const nodeBase = Layer.merge(NodeFileSystem.layer, NodePath.layer);
-  const childProcess = NodeChildProcessSpawner.layer.pipe(Layer.provide(nodeBase));
-  return ManagedRuntime.make(makeDesktopRuntimeLayer(devUrl).pipe(Layer.provide(childProcess)));
+  const childProcessLive = NodeChildProcessSpawner.layer.pipe(Layer.provide(nodeBase));
+  const desktopConfigLive = makeDesktopConfigLive({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    devUrl,
+    token: randomUUID(),
+  });
+
+  return ManagedRuntime.make(
+    MainWindowLive.pipe(
+      Layer.provide(RendererChannelLive),
+      Layer.provide(DesktopApplicationLive),
+      Layer.provide(LocalBackendLive),
+      Layer.provide(desktopConfigLive),
+      Layer.provide(childProcessLive),
+    ),
+  );
 }
 
 export function startDesktopRuntime(): void {
@@ -102,12 +41,12 @@ export function startDesktopRuntime(): void {
   let allowQuit = false;
 
   const runWindowAction = (
-    action: (desktop: DesktopRuntime["Service"]) => Effect.Effect<void>,
+    action: (window: MainWindow["Service"]) => Effect.Effect<void>,
   ): void => {
     runtime?.runFork(
       Effect.gen(function* () {
-        const desktop = yield* DesktopRuntime;
-        yield* action(desktop);
+        const window = yield* MainWindow;
+        yield* action(window);
       }),
     );
   };
@@ -144,8 +83,8 @@ export function startDesktopRuntime(): void {
       }
       await runtime.runPromise(
         Effect.gen(function* () {
-          const desktop = yield* DesktopRuntime;
-          yield* desktop.ensureWindow;
+          const window = yield* MainWindow;
+          yield* window.ensureOpen;
         }),
       );
     } catch (error) {
@@ -167,8 +106,8 @@ export function startDesktopRuntime(): void {
   // Electron only accepts privileged scheme registration before ready.
   registerAppScheme();
 
-  app.on("second-instance", () => runWindowAction((desktop) => desktop.focusWindow));
-  app.on("activate", () => runWindowAction((desktop) => desktop.ensureWindow));
+  app.on("second-instance", () => runWindowAction((window) => window.focus));
+  app.on("activate", () => runWindowAction((window) => window.ensureOpen));
 
   app.on("window-all-closed", () => {
     if (process.platform !== "darwin") app.quit();

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -16,8 +16,8 @@ import { formatStartupFailure } from "./startup-failure";
 
 function makeRuntime(devUrl: string | undefined) {
   const nodeBase = Layer.merge(NodeFileSystem.layer, NodePath.layer);
-  const childProcessLive = NodeChildProcessSpawner.layer.pipe(Layer.provide(nodeBase));
-  const desktopConfigLive = makeDesktopConfigLive({
+  const ChildProcessSpawnerLive = NodeChildProcessSpawner.layer.pipe(Layer.provide(nodeBase));
+  const DesktopConfigLive = makeDesktopConfigLive({
     isPackaged: app.isPackaged,
     resourcesPath: process.resourcesPath,
     devUrl,
@@ -29,8 +29,8 @@ function makeRuntime(devUrl: string | undefined) {
       Layer.provide(RendererChannelLive),
       Layer.provide(DesktopApplicationLive),
       Layer.provide(LocalBackendLive),
-      Layer.provide(desktopConfigLive),
-      Layer.provide(childProcessLive),
+      Layer.provide(DesktopConfigLive),
+      Layer.provide(ChildProcessSpawnerLive),
     ),
   );
 }

--- a/apps/desktop/src/main/electron/main-window.ts
+++ b/apps/desktop/src/main/electron/main-window.ts
@@ -2,16 +2,21 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { is } from "@electron-toolkit/utils";
-import { Effect, Scope } from "effect";
+import { Context, Effect, Layer, Scope } from "effect";
 import { BrowserWindow, shell, type WebContents } from "electron";
 
 import icon from "../../../resources/icon.png?asset";
-import { APP_ORIGIN } from "./app-protocol";
+import { DesktopConfig } from "../desktop-config";
+import { APP_ORIGIN, registerAppProtocol } from "./app-protocol";
+import { RendererChannel } from "./renderer-channel";
 
-export interface MainWindow {
-  readonly ensureOpen: Effect.Effect<void>;
-  readonly focus: Effect.Effect<void>;
-}
+export class MainWindow extends Context.Service<
+  MainWindow,
+  {
+    readonly ensureOpen: Effect.Effect<void>;
+    readonly focus: Effect.Effect<void>;
+  }
+>()("desktop/MainWindow") {}
 
 export type MainWindowOptions = {
   readonly devUrl: string | undefined;
@@ -29,7 +34,7 @@ function canOpenExternal(url: string): boolean {
 
 export function makeMainWindow(
   options: MainWindowOptions,
-): Effect.Effect<MainWindow, never, Scope.Scope> {
+): Effect.Effect<MainWindow["Service"], never, Scope.Scope> {
   return Effect.gen(function* () {
     let mainWindow: BrowserWindow | undefined;
     let disconnectRenderer: (() => Promise<void>) | undefined;
@@ -120,10 +125,23 @@ export function makeMainWindow(
         if (window.isMinimized()) window.restore();
         window.focus();
       }),
-    } satisfies MainWindow;
+    } satisfies MainWindow["Service"];
   });
 }
 
 export function rendererRoot(): string {
   return path.join(path.dirname(fileURLToPath(import.meta.url)), "../renderer");
 }
+
+export const MainWindowLive = Layer.effect(
+  MainWindow,
+  Effect.gen(function* () {
+    const config = yield* DesktopConfig;
+    const channel = yield* RendererChannel;
+    yield* registerAppProtocol(rendererRoot());
+    return yield* makeMainWindow({
+      devUrl: config.devUrl,
+      connectRenderer: channel.connect,
+    });
+  }),
+);

--- a/apps/desktop/src/main/electron/renderer-channel.ts
+++ b/apps/desktop/src/main/electron/renderer-channel.ts
@@ -1,14 +1,18 @@
+import { Context } from "effect";
 import { MessageChannelMain, type MessagePortMain, type WebContents } from "electron";
 
 import { DESKTOP_PORT_CHANNEL } from "../../shared/desktop-channel";
 
 export type AttachMessagePort = (port: MessagePortMain) => () => Promise<void>;
 
-export interface RendererChannel {
-  readonly connect: (webContents: WebContents) => () => Promise<void>;
-}
+export class RendererChannel extends Context.Service<
+  RendererChannel,
+  {
+    readonly connect: (webContents: WebContents) => () => Promise<void>;
+  }
+>()("desktop/RendererChannel") {}
 
-export function makeRendererChannel(attachPort: AttachMessagePort): RendererChannel {
+export function makeRendererChannel(attachPort: AttachMessagePort): RendererChannel["Service"] {
   return {
     connect: (webContents) => {
       const { port1, port2 } = new MessageChannelMain();

--- a/apps/desktop/src/main/rpc/desktop-router.ts
+++ b/apps/desktop/src/main/rpc/desktop-router.ts
@@ -8,7 +8,7 @@ import type { DesktopApplication } from "../application/desktop-application";
 
 export type DesktopRpcContext = WithEffectContext<never>;
 
-export function makeDesktopRouter(application: DesktopApplication) {
+export function makeDesktopRouter(application: DesktopApplication["Service"]) {
   const orpc = implement(desktopContract).$context<DesktopRpcContext>();
 
   return orpc.router({

--- a/apps/desktop/src/main/rpc/desktop-rpc-server.test.ts
+++ b/apps/desktop/src/main/rpc/desktop-rpc-server.test.ts
@@ -17,7 +17,9 @@ import { makeDesktopRpcServer } from "./desktop-rpc-server";
 
 type DesktopClient = RouterContractClient<DesktopContract>;
 
-function makeHarness(override?: (application: DesktopApplication) => DesktopApplication) {
+function makeHarness(
+  override?: (application: DesktopApplication["Service"]) => DesktopApplication["Service"],
+) {
   const statusRef = Effect.runSync(
     SubscriptionRef.make<BackendStatusSnapshot>({ revision: 0, status: "ready" }),
   );
@@ -40,7 +42,7 @@ function makeHarness(override?: (application: DesktopApplication) => DesktopAppl
     ),
   ) as Context.Context<never>;
 
-  const backend: LocalBackend = {
+  const backend: LocalBackend["Service"] = {
     connection: {
       httpBaseUrl: "http://127.0.0.1:43123",
       wsBaseUrl: "ws://127.0.0.1:43123",

--- a/apps/desktop/src/main/rpc/desktop-rpc-server.ts
+++ b/apps/desktop/src/main/rpc/desktop-rpc-server.ts
@@ -25,7 +25,7 @@ function makeWrapDesktopRpcEffect(rpcContext: Context.Context<never>) {
 }
 
 export function makeDesktopRpcServer(
-  application: DesktopApplication,
+  application: DesktopApplication["Service"],
   rpcContext: Context.Context<never>,
 ): DesktopRpcServer {
   const handler = new RPCHandler(makeDesktopRouter(application));

--- a/docs/plans/2026-07-15-desktop-layer-composition-plan.md
+++ b/docs/plans/2026-07-15-desktop-layer-composition-plan.md
@@ -1,0 +1,125 @@
+# Desktop Layer Composition Plan
+
+- **Base:** `origin/main@037ac24`（PR #102 合并后）
+- **Date:** 2026-07-15
+- **Scope:** `apps/desktop/src/main`、`apps/desktop/AGENTS.md`
+- **Status:** Proposed
+
+> 把 Electron Main 的能力模块从「构造参数手工穿线」迁移到 Effect v4 的 Tag + Layer 组合。这是纯结构迁移：不改任何运行时行为，不动 renderer、preload、RPC 契约与传输。
+
+## 1. 动机
+
+PR #102 采用「显式构造参数 + 普通能力值」接线，对当时的单消费者规模是正确的。触发迁移的三个事实：
+
+1. **依赖扇出即将出现。** `MainWindow`（tray、menu、deep-link、auto-update、第二窗口都需要 `ensureOpen`/`focus`）和 `LocalBackend`（tray/menu 状态）会很快有多个消费者。手工穿线的组合根随消费者数量呈 N×M 增长；Layer 图的拓扑构建与 memoization 正是为此设计。
+2. **task / terminal / worktree 服务将以 Effect-native 形式回归**（PR #102 删除的旧实现）。在服务数量膨胀前换好地基，迁移是 5 个模块的机械操作；之后做则要连带所有新服务。
+3. **`DesktopRuntime` 是补偿性包装的症状。** 全仓唯一的 `Context.Service`，存在理由只是 lifecycle 回调需要可 `yield*` 的对象，内部仅转发 `ensureWindow`/`focus`。`MainWindow` 成为 service 后它整个消失。
+
+## 2. 目标形态
+
+### 2.1 服务清单
+
+| Tag                  | 所在文件                             | 依赖                                       | Live Layer 位置                                                        |
+| -------------------- | ------------------------------------ | ------------------------------------------ | ---------------------------------------------------------------------- |
+| `DesktopConfig`      | `desktop-config.ts`（新增）          | 无（读 `app`/`process`/env）               | 同文件                                                                 |
+| `LocalBackend`       | `backend/local-backend.ts`           | `DesktopConfig`、`ChildProcessSpawner`     | `backend/local-backend-live.ts`（adapter 侧，含 login-shell 环境解析） |
+| `DesktopApplication` | `application/desktop-application.ts` | `LocalBackend`                             | 同文件                                                                 |
+| `RendererChannel`    | `electron/renderer-channel.ts`       | `DesktopApplication`（经 rpc server 构造） | `desktop-runtime.ts`（跨模块胶水，见 §2.3）                            |
+| `MainWindow`         | `electron/main-window.ts`            | `DesktopConfig`、`RendererChannel`         | 同文件                                                                 |
+
+规则：**Tag 归能力的定义方所有；Live Layer 归实现的提供方所有**（adapter 文件或组合根），内层模块永远不 import 外层实现。模块之间只允许 import 对方的 Tag 与接口类型。
+
+### 2.2 `DesktopConfig`（新增）
+
+把目前散在组合根里的宿主环境读取收拢为一个注入点：
+
+```ts
+class DesktopConfig extends Context.Service<
+  DesktopConfig,
+  {
+    readonly isPackaged: boolean;
+    readonly devUrl: string | undefined;
+    readonly serverEntry: string;
+    readonly token: string;
+    readonly allowedOrigins: readonly string[];
+  }
+>()("desktop/DesktopConfig") {}
+```
+
+`DesktopConfigLive` 读取 `app.isPackaged`、`process.resourcesPath`、`ELECTRON_RENDERER_URL`、生成 token。这是当前唯一测不到的装配逻辑（`resolveServerEntry` 已是纯函数，保持）；service 化后其余 Layer 均可用假 config 组测。
+
+### 2.3 组合根退化为 Layer 组合
+
+`desktop-runtime.ts` 只保留三样东西：
+
+1. **跨模块胶水 Layer**（组合根可以 import 一切，依赖规则不变）：
+
+```ts
+const RendererChannelLive = Layer.effect(
+  RendererChannel,
+  Effect.gen(function* () {
+    const application = yield* DesktopApplication;
+    const rpcContext = yield* Effect.context<never>();
+    return makeRendererChannel(makeDesktopRpcServer(application, rpcContext).attach);
+  }),
+);
+```
+
+`rpcContext` 全量捕获的既有决策不变；rpc server 无独立 Tag——它只有 RendererChannel 一个消费者，且是纯构造（无 Scope、无状态），service 化它才是过度抽象。
+
+2. **`AppProtocolLive`**：`registerAppProtocol(rendererRoot())` 包成无输出 Layer，`MainWindowLive` 依赖它保证注册先于窗口加载。
+3. **`ManagedRuntime` + Electron lifecycle 外壳**：`startDesktopRuntime` 结构不变，删除 `DesktopRuntime` 包装，lifecycle 回调直接 `runtime.runFork(Effect.gen(... yield* MainWindow ...))`，启动路径 `Effect.result(contextEffect)` + `formatStartupFailure` 保持。
+
+### 2.4 工厂保留，Layer 只是一层皮
+
+`makeLocalBackend`、`makeDesktopApplication`、`makeMainWindow`、`makeRendererChannel`、`makeNodeBackendProcess` 全部保留原签名——它们仍是逻辑与单测的单位，现有测试一行不改。Layer 形如：
+
+```ts
+export const MainWindowLive = Layer.effect(
+  MainWindow,
+  Effect.gen(function* () {
+    const config = yield* DesktopConfig;
+    const channel = yield* RendererChannel;
+    return yield* makeMainWindow({ devUrl: config.devUrl, connectRenderer: channel.connect });
+  }),
+);
+```
+
+### 2.5 明确不 service 化的
+
+- 纯函数：`restartBackoff`、`formatStartupFailure`、`resolveAssetPath`、`resolveServerEntry`、`parseEnvironment`。
+- 纯构造 wiring：`makeDesktopRpcServer`、`makeDesktopRouter`。
+- `SpawnBackend` 保持 backend 模块自有的 port 类型（函数注入），不升级为 Tag——它的多态性已由 `local-backend-live` 与测试 fake 覆盖。
+
+「service-per-file」仍然是反模式；本计划的判据是**已知的多消费者扇出**，不是文件对齐。
+
+## 3. 行为保持声明
+
+- 窗口仍在 backend ready 之后才打开：`MainWindowLive` 不依赖 `LocalBackend`，Layer 构建可并行，但 `ensureOpen` 仍由 lifecycle 在 `contextEffect` 完成后显式触发（P6.2 的 UX 决策不在本计划内）。
+- pinned-port、重启退避、Retry、Quit、MessagePort 生命周期、`rpcContext` 全量捕获、日志 annotation：全部不动。
+- `AGENTS.md` 更新两处：「Prefer explicit constructor parameters and plain capability values over a `Context.Service` for every file」改写为上面 §2.5 的判据；依赖方向一节补「模块间只 import Tag 与接口类型，Live Layer 归实现提供方」。
+
+## 4. 实施步骤
+
+1. 新增 `DesktopConfig` + `DesktopConfigLive` + 单测（fake `app`/env 注入）；
+2. `LocalBackend` Tag 化 + `backend/local-backend-live.ts`（吸收 login-shell 环境解析与 `makeNodeBackendProcess` 装配）；
+3. `DesktopApplication` Tag 化 + 同文件 Live；
+4. `RendererChannel` Tag 化 + 组合根胶水 Layer；`MainWindow` Tag 化 + 同文件 Live + `AppProtocolLive`；
+5. 重写 `desktop-runtime.ts` 为 Layer 组合，删除 `DesktopRuntime`；
+6. `AGENTS.md` 与 `src/main/README.md` 同步；
+7. 新增一个组合测试：以假 `DesktopConfig` + 假 `SpawnBackend` 构建完整 Layer 图（不含 Electron 窗口层），断言 `DesktopApplication.bootstrap` 可用——锁定 Layer 接线本身。
+
+每步跑 `pnpm --filter desktop test && pnpm --filter desktop typecheck`；步骤 5 后补全验证矩阵：
+
+```
+pnpm --filter desktop build
+pnpm --filter desktop e2e
+pnpm check
+pnpm test
+```
+
+关键回归项沿用 PR #102：MessagePort stream cancellation finalizer、renderer reload 换 port 不重启 backend、backend crash/recovery/Retry/Quit、`HTTPS_PROXY` 透传、packaged 启动路径（`electron/**` 与运行时路径有改动，按 AGENTS.md 要求做一次 unpacked 打包冒烟）。
+
+## 5. 预估
+
+约 6–8 个文件、±350 行,一个 PR。全部为结构迁移,无行为变化;失败模式集中在 Layer 依赖方向写反(typecheck 即暴露)与启动时序(e2e 覆盖)。

--- a/docs/plans/2026-07-15-desktop-layer-composition-plan.md
+++ b/docs/plans/2026-07-15-desktop-layer-composition-plan.md
@@ -3,7 +3,7 @@
 - **Base:** `origin/main@037ac24`（PR #102 合并后）
 - **Date:** 2026-07-15
 - **Scope:** `apps/desktop/src/main`、`apps/desktop/AGENTS.md`
-- **Status:** Proposed
+- **Status:** Implemented (with deviations from the original proposal, noted inline as `> Implemented:` blockquotes)
 
 > 把 Electron Main 的能力模块从「构造参数手工穿线」迁移到 Effect v4 的 Tag + Layer 组合。这是纯结构迁移：不改任何运行时行为，不动 renderer、preload、RPC 契约与传输。
 
@@ -24,10 +24,16 @@ PR #102 采用「显式构造参数 + 普通能力值」接线，对当时的单
 | `DesktopConfig`      | `desktop-config.ts`（新增）          | 无（读 `app`/`process`/env）               | 同文件                                                                 |
 | `LocalBackend`       | `backend/local-backend.ts`           | `DesktopConfig`、`ChildProcessSpawner`     | `backend/local-backend-live.ts`（adapter 侧，含 login-shell 环境解析） |
 | `DesktopApplication` | `application/desktop-application.ts` | `LocalBackend`                             | 同文件                                                                 |
-| `RendererChannel`    | `electron/renderer-channel.ts`       | `DesktopApplication`（经 rpc server 构造） | `desktop-runtime.ts`（跨模块胶水，见 §2.3）                            |
+| `RendererChannel`    | `electron/renderer-channel.ts`       | `DesktopApplication`（经 rpc server 构造） | `desktop-runtime-glue.ts`（跨模块胶水，见 §2.3）                       |
 | `MainWindow`         | `electron/main-window.ts`            | `DesktopConfig`、`RendererChannel`         | 同文件                                                                 |
 
 规则：**Tag 归能力的定义方所有；Live Layer 归实现的提供方所有**（adapter 文件或组合根），内层模块永远不 import 外层实现。模块之间只允许 import 对方的 Tag 与接口类型。
+
+> **Implemented 偏差 1：** `DesktopApplication` 的 Live Layer **没有**放进 `application/desktop-application.ts`。原因：它需要 `Effect.sync(() => { setTimeout(() => app.quit(), 0); })`，`app.quit` 来自 `electron`，而依赖规则明确禁止 `application/**` import Electron。实现中 `DesktopApplicationLive` 与 `RendererChannelLive` 一起放进了新文件 `desktop-runtime-glue.ts`（见下方偏差 2），Tag 定义仍在 `application/desktop-application.ts`。`os` 字段维持读取 `process.platform`（纯 Node API，非 Electron），不需要新增到 `DesktopConfig`。
+>
+> **Implemented 偏差 2：** 组合根拆成了两个文件而非一个。`desktop-runtime-glue.ts`（新增）承载 `DesktopApplicationLive`、`RendererChannelLive`；`desktop-runtime.ts` 保留 lifecycle 外壳 + 最终 Layer 组合。原因是纯技术性的：Step 7 的组合测试需要 import 这些 Live Layer，而 `desktop-runtime.ts` 顶层 import 了 `electron/main-window.ts`，其 `import { BrowserWindow, shell } from "electron"` 在 vitest 的 Electron CJS 垫片下会在**加载期**抛 `SyntaxError: Named export 'BrowserWindow' not found`（`net`/`protocol`/`app`/`dialog` 等其他具名导入不受影响，原因未深究，属于 vitest/esbuild 对该 CJS shim 的静态分析行为，与本次改动无关，是测试环境的已有限制）。拆出 `desktop-runtime-glue.ts` 隔离了这条有问题的 import 链，两个文件依然都算组合根代码，依赖规则不变。
+>
+> **Implemented 偏差 3：** 没有引入独立的 `AppProtocol` Tag/Layer。`registerAppProtocol(rendererRoot())` 直接顺序内联在 `MainWindowLive` 的 `Effect.gen` 体内（窗口创建之前），和原代码顺序一致。理由：协议注册只有一个消费者（窗口加载），且是一次性副作用而非可复用能力，为它单开一个仅用于排序的 marker Tag 过度抽象；plan §2.5 "明确不 service 化" 的判据本就排斥这种单消费者构造。
 
 ### 2.2 `DesktopConfig`（新增）
 
@@ -49,6 +55,8 @@ class DesktopConfig extends Context.Service<
 `DesktopConfigLive` 读取 `app.isPackaged`、`process.resourcesPath`、`ELECTRON_RENDERER_URL`、生成 token。这是当前唯一测不到的装配逻辑（`resolveServerEntry` 已是纯函数，保持）；service 化后其余 Layer 均可用假 config 组测。
 
 ### 2.3 组合根退化为 Layer 组合
+
+> **Implemented：** 见上方偏差 2——实际是两个文件（`desktop-runtime-glue.ts` + `desktop-runtime.ts`），下面描述的三样东西按此拆分放置。
 
 `desktop-runtime.ts` 只保留三样东西：
 
@@ -109,6 +117,8 @@ export const MainWindowLive = Layer.effect(
 6. `AGENTS.md` 与 `src/main/README.md` 同步；
 7. 新增一个组合测试：以假 `DesktopConfig` + 假 `SpawnBackend` 构建完整 Layer 图（不含 Electron 窗口层），断言 `DesktopApplication.bootstrap` 可用——锁定 Layer 接线本身。
 
+> **Implemented：** 实际测试（`desktop-runtime-glue.test.ts`）范围更窄但更聚焦——只 fake `LocalBackend`（而非 `DesktopConfig` + `SpawnBackend` 全链路），断言 `DesktopApplicationLive` 能通过 `yield* LocalBackend` 正确从 Layer 图解析出可用的 `DesktopApplication`。理由：`LocalBackend` 内部的 spawn/监督/重试逻辑已被 `local-backend.test.ts` 详尽覆盖，在组合测试里重新 fake 整条 `SpawnBackend` 链路只是重复劳动；真正没被验证过的是 `DesktopApplicationLive` 这一层新增的 Layer 接线本身，fake `LocalBackend` 直接命中这一点。
+
 每步跑 `pnpm --filter desktop test && pnpm --filter desktop typecheck`；步骤 5 后补全验证矩阵：
 
 ```
@@ -123,3 +133,5 @@ pnpm test
 ## 5. 预估
 
 约 6–8 个文件、±350 行,一个 PR。全部为结构迁移,无行为变化;失败模式集中在 Layer 依赖方向写反(typecheck 即暴露)与启动时序(e2e 覆盖)。
+
+> **Implemented：** 实际 12 个文件变更（含 2 个新文件 `desktop-config.ts`/`desktop-config.test.ts`、1 个新文件 `backend/local-backend-live.ts`、1 个新文件 `desktop-runtime-glue.ts`、1 个新组合测试 `desktop-runtime-glue.test.ts`，其余为既有文件的 Tag 化编辑）+ `AGENTS.md`/`README.md` 文档更新。全部验证矩阵通过：`pnpm --filter desktop test`（44/44，较基线净增 4 个测试）、`typecheck`、`build`、`e2e`（7/7）、`pnpm check`、`pnpm test`。零行为变化的声明成立——`e2e/tests/desktop-rpc.spec.ts` 全部 7 个场景（含 backend 崩溃恢复、Retry、Quit、MessagePort 重连）在改动前后行为一致。


### PR DESCRIPTION
## Summary

- replace the composition root's hand-threaded constructor parameters with `Context.Service` Tag + `Layer` for the modules with growing consumer fan-out: `LocalBackend`, `DesktopApplication`, `RendererChannel`, `MainWindow`
- add a `DesktopConfig` service that collects host/environment reads (`isPackaged`, `resourcesPath`, `devUrl`, token, allowed origins) into one injectable point, backed by a pure, directly-tested `buildDesktopConfig`
- factories (`makeLocalBackend`, `makeDesktopApplication`, `makeMainWindow`, `makeRendererChannel`) keep their plain-parameter signatures and stay the unit-test target; each `Live` Layer is a thin wrapper around its factory
- delete the `DesktopRuntime` wrapper service — it existed only so lifecycle callbacks could `yield*` something; lifecycle now resolves `MainWindow` directly
- add `desktop-runtime-glue.ts` for the two `Live` Layers that need Electron capabilities their owning module isn't allowed to import (`DesktopApplicationLive` needs `app.quit()`; `RendererChannelLive` wires the oRPC MessagePort server into `application/**`/`rpc/**`); split from `desktop-runtime.ts` itself only so it stays importable from tests without pulling in `electron/main-window.ts`'s `BrowserWindow` import
- document the Tag/Live-Layer ownership rules in `apps/desktop/AGENTS.md` and `apps/desktop/src/main/README.md`

## Why

`MainWindow` and `LocalBackend` are about to gain more consumers (tray, menu, deep-links, and the task/terminal/worktree services planned to return in Effect-native form), and hand-threading constructor parameters through the composition root scales as N×M with consumer count. Landing the Tag/Layer structure now, while it's a small mechanical change, avoids doing it later across a much larger set of services.

Plan: `docs/plans/2026-07-15-desktop-layer-composition-plan.md` (includes `Implemented:` notes on two deviations from the original proposal, with reasoning).

## Verification

- `pnpm --filter desktop test` — 44/44 (net +4 vs baseline: `DesktopConfig` unit tests, and a composition test that resolves `DesktopApplication` through the actual Layer graph with a faked `LocalBackend`)
- `pnpm --filter desktop typecheck`
- `pnpm --filter desktop build`
- `pnpm --filter desktop e2e` — 7/7, including backend crash/recovery, Retry, Quit, and MessagePort reconnection on renderer reload
- `pnpm check`
- `pnpm test`

No behavior change: pinned-port supervision, restart backoff, Retry, Quit, MessagePort lifecycle, and RPC context/logging wiring are untouched — this is purely a structural migration.