### PR TITLE
refactor: use WebSocket for all RPC

### DIFF
--- a/apps/app/src/core/chat/chat-transport.test.ts
+++ b/apps/app/src/core/chat/chat-transport.test.ts
@@ -42,17 +42,13 @@ describe("ChatTransport agent requests", () => {
     let snapshotCalls = 0;
     let snapshotSawSubscription = false;
     const clients = {
-      orpcClient: {
+      rpcClient: {
         session: {
           snapshot: async () => {
             snapshotCalls += 1;
             snapshotSawSubscription = subscriptionCalls === 1;
             return snapshot;
           },
-        },
-      },
-      orpcWsClient: {
-        session: {
           events: async () => {
             subscriptionCalls += 1;
             return {
@@ -100,7 +96,7 @@ describe("ChatTransport agent requests", () => {
           },
         },
       },
-    } as unknown as Pick<AppClients, "orpcClient" | "orpcWsClient">;
+    } as unknown as Pick<AppClients, "rpcClient">;
     let deliveries = 0;
     const received: AgentRequest[] = [];
     const transport = new ChatTransport(clients);
@@ -136,16 +132,12 @@ describe("ChatTransport agent requests", () => {
       rejectAutomaticResponse = reject;
     });
     const clients = {
-      orpcClient: {
+      rpcClient: {
         session: {
           snapshot: async (): Promise<SessionSnapshot> => ({
             ...snapshot,
             pendingRequests: [emptyPlanRequest],
           }),
-        },
-      },
-      orpcWsClient: {
-        session: {
           respondToAgentRequest: async () => automaticResponse,
           events: async () => ({
             [Symbol.asyncIterator]() {
@@ -191,7 +183,7 @@ describe("ChatTransport agent requests", () => {
           }),
         },
       },
-    } as unknown as Pick<AppClients, "orpcClient" | "orpcWsClient">;
+    } as unknown as Pick<AppClients, "rpcClient">;
     const received: AgentRequest[] = [];
     const transport = new ChatTransport(clients);
 

--- a/apps/app/src/core/chat/chat-transport.ts
+++ b/apps/app/src/core/chat/chat-transport.ts
@@ -50,7 +50,7 @@ type EventSubscription = {
 
 type PromptRecovery = {
   readonly subscription: EventSubscription;
-  readonly snapshot: Awaited<ReturnType<AppClients["orpcClient"]["session"]["snapshot"]>>;
+  readonly snapshot: Awaited<ReturnType<AppClients["rpcClient"]["session"]["snapshot"]>>;
 };
 
 async function* promptChunks(
@@ -116,7 +116,7 @@ async function* promptChunks(
 }
 
 export class ChatTransport implements AiChatTransport<UIMessage> {
-  constructor(private readonly clients: Pick<AppClients, "orpcClient" | "orpcWsClient">) {}
+  constructor(private readonly clients: Pick<AppClients, "rpcClient">) {}
 
   async #openEvents(
     sessionId: string,
@@ -128,7 +128,7 @@ export class ChatTransport implements AiChatTransport<UIMessage> {
     if (signal?.aborted) abort();
     else signal?.addEventListener("abort", abort, { once: true });
     try {
-      const events = await this.clients.orpcWsClient.session.events(
+      const events = await this.clients.rpcClient.session.events(
         { sessionId, ...(after === undefined ? {} : { after }) },
         { signal: controller.signal },
       );
@@ -153,7 +153,7 @@ export class ChatTransport implements AiChatTransport<UIMessage> {
     const model = (options.body as { model?: ChatModel } | undefined)?.model ?? "sonnet";
     const initial = await this.#openEvents(options.chatId, undefined, options.abortSignal);
     try {
-      const receipt = await this.clients.orpcClient.session.prompt(
+      const receipt = await this.clients.rpcClient.session.prompt(
         { sessionId: options.chatId, input: toUserInput(message, model) },
         { signal: options.abortSignal },
       );
@@ -162,7 +162,7 @@ export class ChatTransport implements AiChatTransport<UIMessage> {
         return emptyChunkStream();
       }
       const interrupt = () => {
-        void this.clients.orpcClient.session
+        void this.clients.rpcClient.session
           .interrupt({ sessionId: options.chatId })
           .catch((error) => {
             if (!isAbortError(error)) console.error("Failed to interrupt session", error);
@@ -172,7 +172,7 @@ export class ChatTransport implements AiChatTransport<UIMessage> {
       const recover = async (after: number): Promise<PromptRecovery> => {
         const subscription = await this.#openEvents(options.chatId, after, options.abortSignal);
         try {
-          const snapshot = await this.clients.orpcClient.session.snapshot({
+          const snapshot = await this.clients.rpcClient.session.snapshot({
             sessionId: options.chatId,
           });
           return { subscription, snapshot };
@@ -214,7 +214,7 @@ export class ChatTransport implements AiChatTransport<UIMessage> {
 
     const handleRequest = async (request: AgentRequest) => {
       if (request.type === "plan" && !request.plan.trim()) {
-        void this.clients.orpcWsClient.session
+        void this.clients.rpcClient.session
           .respondToAgentRequest({
             sessionId,
             requestId: request.id,
@@ -234,7 +234,7 @@ export class ChatTransport implements AiChatTransport<UIMessage> {
     };
 
     const hydratePendingRequests = async () => {
-      const snapshot = await this.clients.orpcClient.session.snapshot({ sessionId });
+      const snapshot = await this.clients.rpcClient.session.snapshot({ sessionId });
       if (snapshot.degraded) throw new Error("Session snapshot replay is degraded");
       const pendingRequestIds = new Set(snapshot.pendingRequests.map((request) => request.id));
       for (const requestId of deliveredRequestIds) {
@@ -301,7 +301,7 @@ export class ChatTransport implements AiChatTransport<UIMessage> {
     requestId: string,
     response: AgentResponse,
   ): Promise<void> {
-    await this.clients.orpcWsClient.session.respondToAgentRequest({
+    await this.clients.rpcClient.session.respondToAgentRequest({
       sessionId,
       requestId,
       response,

--- a/apps/app/src/lib/orpc.ts
+++ b/apps/app/src/lib/orpc.ts
@@ -1,14 +1,13 @@
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
-import { createVibestClient, createVibestWsClient, type VibestClient } from "@vibest/client";
+import { createVibestClient, type VibestClient } from "@vibest/client";
 import { toast } from "sonner";
 
 import type { Platform } from "@/platform";
 
 export type AppClients = {
   queryClient: QueryClient;
-  orpcClient: VibestClient;
-  orpcWsClient: VibestClient;
+  rpcClient: VibestClient;
   orpc: ReturnType<typeof createTanstackQueryUtils<VibestClient>>;
 };
 
@@ -31,30 +30,27 @@ function createQueryClient(): QueryClient {
 }
 
 /**
- * Build the RPC clients for a host. Browser mode is same-origin, so the
- * defaults (relative `/api/rpc`, origin-derived `/ws/rpc`) are correct and no
- * credential is needed. The desktop renderer's origin is `vibest://app` while
- * its backend is on loopback, so every call is cross-origin and authenticated.
+ * Build the RPC client for a host. Browser mode is same-origin, so the
+ * origin-derived `/ws/rpc` default is correct and no credential is needed. The
+ * desktop renderer's origin is `vibest://app` while its backend is on loopback,
+ * so it connects with a ticket minted over the authenticated HTTP endpoint.
  */
 export function createAppClients(platform: Platform): AppClients {
   const queryClient = createQueryClient();
 
   if (platform.host === "web") {
-    const orpcClient = createVibestClient();
-    const orpcWsClient = createVibestWsClient();
+    const rpcClient = createVibestClient();
     return {
       queryClient,
-      orpcClient,
-      orpcWsClient,
-      orpc: createTanstackQueryUtils(orpcClient),
+      rpcClient,
+      orpc: createTanstackQueryUtils(rpcClient),
     };
   }
 
   const { httpBaseUrl, wsBaseUrl, token } = platform.backend;
   const headers = { authorization: `Bearer ${token}` };
 
-  const orpcClient = createVibestClient({ origin: httpBaseUrl, headers });
-  const orpcWsClient = createVibestWsClient({
+  const rpcClient = createVibestClient({
     url: `${wsBaseUrl}/ws/rpc`,
     getTicket: async () => {
       const response = await fetch(`${httpBaseUrl}/api/ws-ticket`, { method: "POST", headers });
@@ -66,5 +62,5 @@ export function createAppClients(platform: Platform): AppClients {
     },
   });
 
-  return { queryClient, orpcClient, orpcWsClient, orpc: createTanstackQueryUtils(orpcClient) };
+  return { queryClient, rpcClient, orpc: createTanstackQueryUtils(rpcClient) };
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,7 +2,7 @@
   "name": "@vibest/client",
   "version": "0.0.1",
   "private": true,
-  "description": "Client access layer for the Vibest server (oRPC links + typed client)",
+  "description": "WebSocket RPC client for the Vibest server",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,4 @@
 import { createORPCClient } from "@orpc/client";
-import { RPCLink } from "@orpc/client/fetch";
 import { RPCLink as WebSocketRPCLink } from "@orpc/client/websocket";
 import type { RouterContractClient } from "@orpc/contract";
 import type { Contract } from "@vibest/contract";
@@ -7,41 +6,7 @@ import type { Contract } from "@vibest/contract";
 /** A fully typed client for the Vibest server, derived from the contract. */
 export type VibestClient = RouterContractClient<Contract>;
 
-type FetchLinkUrl = NonNullable<ConstructorParameters<typeof RPCLink>[0]>["url"];
-
-type FetchLinkOrigin = NonNullable<ConstructorParameters<typeof RPCLink>[0]>["origin"];
-
 export type CreateVibestClientOptions = {
-  /**
-   * RPC path. Defaults to `/api/rpc` — clients served same-origin by the CLI
-   * server need no configuration. oRPC types this as a root-relative path, so
-   * a cross-origin caller sets `origin` alongside it, not an absolute `url`.
-   */
-  url?: FetchLinkUrl;
-  /**
-   * Absolute origin prepended to `url`, e.g. `http://127.0.0.1:41234`. The
-   * desktop renderer loads from a custom protocol, so it must point every call
-   * at the backend it spawned; browser mode is same-origin and omits this.
-   */
-  origin?: FetchLinkOrigin;
-  /**
-   * Headers sent with every call. The desktop renderer passes the per-launch
-   * bearer token here; browser mode is same-origin and needs none.
-   */
-  headers?: Record<string, string>;
-};
-
-/** HTTP client (fetch link). One request per call; streams over SSE. */
-export function createVibestClient(options: CreateVibestClientOptions = {}): VibestClient {
-  const link = new RPCLink({
-    url: options.url ?? "/api/rpc",
-    ...(options.origin ? { origin: options.origin } : {}),
-    ...(options.headers ? { headers: options.headers } : {}),
-  });
-  return createORPCClient(link);
-}
-
-export type CreateVibestWsClientOptions = {
   /** WebSocket endpoint. Defaults to `/ws/rpc` on the current origin. */
   url?: string | URL;
   /** WebSocket subprotocol; the CLI server upgrades on "vibest". */
@@ -66,7 +31,7 @@ function defaultWsUrl(): URL {
  * The link's `connect` factory. Exported so the ticket handshake is testable
  * without standing up a socket server.
  */
-export function createWsConnect(options: CreateVibestWsClientOptions): () => Promise<WebSocket> {
+export function createWsConnect(options: CreateVibestClientOptions): () => Promise<WebSocket> {
   return async () => {
     const url = new URL(options.url ?? defaultWsUrl());
     if (options.getTicket) {
@@ -81,7 +46,7 @@ export function createWsConnect(options: CreateVibestWsClientOptions): () => Pro
  * a lazy `connect` factory (oRPC 2.0.0-beta.16), so the socket is only opened
  * on first use — and re-opened, with a fresh ticket, on every reconnect.
  */
-export function createVibestWsClient(options: CreateVibestWsClientOptions = {}): VibestClient {
+export function createVibestClient(options: CreateVibestClientOptions = {}): VibestClient {
   const link = new WebSocketRPCLink({
     connect: createWsConnect(options),
   });

--- a/packages/server/src/rpc/handlers.ts
+++ b/packages/server/src/rpc/handlers.ts
@@ -2,8 +2,6 @@ import type { Buffer } from "node:buffer";
 import type * as http from "node:http";
 import type { Socket } from "node:net";
 
-import { RPCHandler as FetchRPCHandler } from "@orpc/server/fetch";
-import { RPCHandler as NodeRPCHandler } from "@orpc/server/node";
 import { RPCHandler as WsRPCHandler } from "@orpc/server/websocket";
 import { ManagedRuntime } from "effect";
 import { type WebSocket, WebSocketServer } from "ws";
@@ -11,8 +9,6 @@ import { type WebSocket, WebSocketServer } from "ws";
 import type { RpcContext } from "./context";
 import { router } from "./router";
 import { AgentRuntimeLayer } from "./runtime";
-
-const RPC_PREFIX = "/api/rpc";
 
 // Without this, a procedure that throws becomes a bare 500 with no trace of the
 // cause anywhere — the client sees "Internal Server Error" and the server says
@@ -41,55 +37,6 @@ export async function createRpcRuntime(): Promise<RpcRuntime> {
   return {
     context,
     dispose: () => (disposing ??= runtime.dispose()),
-  };
-}
-
-export function createFetchRPCHandler(rpcContext: RpcContext) {
-  const rpcHandler = new FetchRPCHandler(router, {
-    clientInterceptors: [logErrors],
-    toFetchResponse: {
-      eventStream: {
-        keepAlive: { enabled: true, comment: "ping" },
-      },
-    },
-  });
-
-  return async function handler(
-    request: Request,
-    options?: {
-      prefix?: `/${string}`;
-    },
-  ) {
-    return rpcHandler.handle(request, {
-      prefix: "/api/rpc",
-      context: rpcContext,
-      ...options,
-    });
-  };
-}
-
-export function createNodeRPCHandler(rpcContext: RpcContext) {
-  const rpcHandler = new NodeRPCHandler(router, {
-    clientInterceptors: [logErrors],
-    sendStandardResponse: {
-      eventStream: {
-        keepAlive: { enabled: true, comment: "ping" },
-      },
-    },
-  });
-
-  return async function handler(
-    request: http.IncomingMessage,
-    response: http.ServerResponse,
-    options?: {
-      prefix?: `/${string}`;
-    },
-  ) {
-    return rpcHandler.handle(request, response, {
-      prefix: RPC_PREFIX,
-      context: rpcContext,
-      ...options,
-    });
   };
 }
 

--- a/packages/server/src/rpc/index.ts
+++ b/packages/server/src/rpc/index.ts
@@ -2,8 +2,6 @@ export type { RpcContext } from "./context";
 export { AgentRuntimeLayer, ClaudeCode, ClaudeCodeLayer, Codex, CodexLayer } from "./runtime";
 export {
   createDevWsRPCHandler,
-  createFetchRPCHandler,
-  createNodeRPCHandler,
   createRpcRuntime,
   createWsRPCHandler,
   type DevWsRPCHandler,

--- a/packages/vibest/src/node/server.test.ts
+++ b/packages/vibest/src/node/server.test.ts
@@ -28,10 +28,13 @@ describe("createServer auth", () => {
     expect(response.status).toBe(200);
   });
 
-  it("rejects an unauthenticated /api/rpc call", async () => {
+  it("does not expose an HTTP RPC endpoint", async () => {
     const base = await start({ authToken: TOKEN });
-    const response = await fetch(`${base}/api/rpc/whatever`, { method: "POST" });
-    expect(response.status).toBe(401);
+    const response = await fetch(`${base}/api/rpc`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    expect(response.status).toBe(404);
   });
 
   it("rejects a wrong token", async () => {
@@ -64,7 +67,7 @@ describe("createServer auth", () => {
 describe("createServer CORS", () => {
   it("answers a preflight from an allowlisted origin", async () => {
     const base = await start({ authToken: TOKEN, corsOrigins: ["vibest://app"] });
-    const response = await fetch(`${base}/api/rpc`, {
+    const response = await fetch(`${base}/api/ws-ticket`, {
       method: "OPTIONS",
       headers: { origin: "vibest://app" },
     });
@@ -74,7 +77,7 @@ describe("createServer CORS", () => {
 
   it("refuses a preflight from an unknown origin", async () => {
     const base = await start({ authToken: TOKEN, corsOrigins: ["vibest://app"] });
-    const response = await fetch(`${base}/api/rpc`, {
+    const response = await fetch(`${base}/api/ws-ticket`, {
       method: "OPTIONS",
       headers: { origin: "https://evil.example" },
     });
@@ -83,8 +86,8 @@ describe("createServer CORS", () => {
 });
 
 describe("createServer WebSocket ticket", () => {
-  async function connect(base: string, query: string): Promise<number> {
-    const url = `${base.replace("http://", "ws://")}/ws/rpc${query}`;
+  async function connect(base: string, query: string, path = "/ws/rpc"): Promise<number> {
+    const url = `${base.replace("http://", "ws://")}${path}${query}`;
     const socket = new WebSocket(url, "vibest");
     return await new Promise<number>((resolve) => {
       socket.on("open", () => {
@@ -109,6 +112,17 @@ describe("createServer WebSocket ticket", () => {
   it("rejects an upgrade with no ticket", async () => {
     const base = await start({ authToken: TOKEN });
     expect(await connect(base, "")).toBe(401);
+  });
+
+  it("only upgrades the WebSocket RPC path without consuming the ticket", async () => {
+    const base = await start({ authToken: TOKEN });
+    const ticketResponse = await fetch(`${base}/api/ws-ticket`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    const { ticket } = (await ticketResponse.json()) as { ticket: string };
+    expect(await connect(base, `?ticket=${ticket}`, "/wrong-path")).toBe(404);
+    expect(await connect(base, `?ticket=${ticket}`)).toBe(200);
   });
 
   it("rejects a replayed ticket", async () => {

--- a/packages/vibest/src/node/server.ts
+++ b/packages/vibest/src/node/server.ts
@@ -4,7 +4,7 @@ import { createServer as createHttpServer } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { createNodeRPCHandler, createRpcRuntime, createWsRPCHandler } from "@vibest/server/rpc";
+import { createRpcRuntime, createWsRPCHandler } from "@vibest/server/rpc";
 import sirv from "sirv";
 import type { WebSocket } from "ws";
 import { WebSocketServer } from "ws";
@@ -60,7 +60,6 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
   const { authToken, corsOrigins = [] } = options;
 
   const rpcRuntime = await createRpcRuntime();
-  const rpcHandler = createNodeRPCHandler(rpcRuntime.context);
   const wsHandler = createWsRPCHandler(rpcRuntime.context);
   const tickets = createTicketStore();
 
@@ -112,13 +111,9 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
         return;
       }
 
-      if (pathname === "/api/rpc" || pathname.startsWith("/api/rpc/")) {
-        const { matched } = await rpcHandler(req, res, {
-          prefix: "/api/rpc",
-        });
-        if (matched) {
-          return;
-        }
+      if (pathname.startsWith("/api/")) {
+        notFound(res);
+        return;
       }
 
       serveUI(req, res);
@@ -178,10 +173,16 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
       if (protocol && ["vite-ping", "vite-hmr"].includes(protocol)) return;
     }
 
+    const requestUrl = new URL(req.url ?? "/", "http://localhost");
+    if (requestUrl.pathname !== "/ws/rpc") {
+      socket.write("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+
     if (authToken !== undefined) {
       // A WS handshake carries no Authorization header, so the renderer proves
       // itself with a single-use ticket minted over the authenticated HTTP link.
-      const requestUrl = new URL(req.url ?? "/", "http://localhost");
       if (!tickets.consume(requestUrl.searchParams.get("ticket"))) {
         socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
         socket.destroy();


### PR DESCRIPTION
## Summary

- use one WebSocket-backed RPC client for chat calls and TanStack Query utilities
- remove the HTTP RPC client and server handlers while keeping health, ticket, and static HTTP routes
- restrict WebSocket upgrades to `/ws/rpc` and keep tickets valid after requests to the wrong path

## Testing

- `pnpm check`
- `pnpm test`
- `pnpm --filter @vibest/app build`
- `pnpm --filter @vibest/cli build`
- `pnpm --filter desktop build`
- `pnpm --filter desktop e2e` — 7 passed
- live smoke test: `/api/rpc` returned 404 and an RPC call over `/ws/rpc` succeeded