### PR TITLE
feat(app): add React Scan in dev for render highlighting

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -52,6 +52,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "code-inspector-plugin": "latest",
     "react-grab": "^0.1.48",
+    "react-scan": "^0.5.7",
     "typescript": "^7.0.2",
     "vite": "catalog:",
     "vitest": "catalog:"

--- a/apps/app/src/app-interface.tsx
+++ b/apps/app/src/app-interface.tsx
@@ -20,6 +20,14 @@ if (import.meta.env.DEV) {
   void import("react-grab");
 }
 
+// Dev only: highlights components as they re-render so you can spot wasted
+// renders. Loaded just after React (a tick later than react-scan's ideal
+// "before React" position), so it may miss the very first render but catches
+// everything after. Dead-code-eliminated from production. See https://react-scan.com.
+if (import.meta.env.DEV) {
+  void import("react-scan").then(({ scan }) => scan());
+}
+
 /** Shared application entry. PlatformProvider is the host seam above it. */
 export function AppInterface({ server }: { server?: ServerConnection }): ReactElement {
   usePlatform();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       react-grab:
         specifier: ^0.1.48
         version: 0.1.48(react@19.2.7)
+      react-scan:
+        specifier: ^0.5.7
+        version: 0.5.7(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -10987,7 +10990,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -11004,7 +11007,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## What

Adds [React Scan](https://react-scan.com) in **development only**. It highlights components as they re-render, making wasted/unnecessary renders easy to spot. Companion to React Grab (#112).

## How

- `react-scan` (`^0.5.7`) as a **devDependency** of `@vibest/app`.
- Wired the same way as React Grab — a `import.meta.env.DEV`-guarded dynamic import in the shared `app-interface.tsx`, so both the web dev server and the Electron renderer pick it up, and it's dead-code-eliminated from both production builds.
- Uses the main entry with an explicit `scan()` call rather than the `react-scan/auto` subpath: `auto`'s `development` export condition points at a `dist/auto.mjs` that 0.5.7 doesn't actually ship, so it fails to resolve under Vite.

React Scan installs into the React DevTools hook, which ideally happens before React loads. This dev-only dynamic import lands a tick after React, so it can miss the very first render but instruments everything after — an accepted tradeoff to keep production clean (chosen over the docs' before-React static import).

## Verification

- `pnpm typecheck` — clean.
- `pnpm build` — succeeds; `dist/` contains **zero** references to react-scan (branch eliminated).
- **Runtime (web dev):** `window.__REACT_SCAN__` present with `ReactScanInternals` and its toolbar mounted, alongside React Grab, no console/dev-server errors.