### PR TITLE
feat(app): sidebar + floating card app shell

### DIFF
--- a/apps/app/src/components/layout/app-sidebar.tsx
+++ b/apps/app/src/components/layout/app-sidebar.tsx
@@ -11,8 +11,7 @@ import {
 } from "@vibest/ui/components/sidebar";
 import { Blocks, FolderCode, MessageSquare, Pin, Search, SquarePen } from "lucide-react";
 
-// Static placeholder lists — this is a layout shell with sample mock data.
-// Real conversation data needs a `session.list` endpoint that doesn't exist yet.
+// Placeholder mock data — no session.list endpoint yet.
 const PINNED = [
   "Refactor auth module",
   "Fix flaky integration tests",
@@ -25,16 +24,11 @@ const SAMPLE_CHATS = ["Landing page redesign", "Database migration plan", "Onboa
 export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
   return (
     <Sidebar variant="inset" collapsible="offcanvas" className="md:p-1.5">
-      {/*
-       * Empty top band, same height as the card header (routes/__root.tsx, h-10).
-       * The pinned collapse toggle (rendered in __root.tsx) floats over its
-       * top-left, beside the macOS traffic lights; this band just reserves the
-       * space. Kept on web too for a consistent top edge across hosts.
-       */}
+      {/* Reserves the traffic-light / pinned-toggle row (see __root.tsx). */}
       <SidebarHeader className="h-10" />
 
       <SidebarContent>
-        {/* Primary nav — only New chat is wired; the rest are placeholders. */}
+        {/* Only New chat is wired; the rest are placeholders. */}
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
@@ -66,7 +60,6 @@ export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {/* Pinned — placeholder rows. */}
         <SidebarGroup>
           <SidebarGroupLabel>Pinned</SidebarGroupLabel>
           <SidebarGroupContent>
@@ -83,7 +76,6 @@ export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {/* Projects — placeholder groups and rows. */}
         <SidebarGroup>
           <SidebarGroupLabel>Project</SidebarGroupLabel>
           <SidebarGroupContent>

--- a/apps/app/src/components/layout/app-sidebar.tsx
+++ b/apps/app/src/components/layout/app-sidebar.tsx
@@ -1,0 +1,121 @@
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@vibest/ui/components/sidebar";
+import { Blocks, FolderCode, MessageSquare, Pin, Search, SquarePen } from "lucide-react";
+
+// Static placeholder lists — this is a layout shell with sample mock data.
+// Real conversation data needs a `session.list` endpoint that doesn't exist yet.
+const PINNED = [
+  "Refactor auth module",
+  "Fix flaky integration tests",
+  "API pagination design",
+  "Release checklist",
+];
+const PROJECT_CHATS = ["Set up CI pipeline", "Add dark mode support", "Improve search performance"];
+const SAMPLE_CHATS = ["Landing page redesign", "Database migration plan", "Onboarding flow copy"];
+
+export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
+  return (
+    <Sidebar variant="inset" collapsible="offcanvas" className="md:p-1.5">
+      {/*
+       * Empty top band, same height as the card header (routes/__root.tsx, h-10).
+       * The pinned collapse toggle (rendered in __root.tsx) floats over its
+       * top-left, beside the macOS traffic lights; this band just reserves the
+       * space. Kept on web too for a consistent top edge across hosts.
+       */}
+      <SidebarHeader className="h-10" />
+
+      <SidebarContent>
+        {/* Primary nav — only New chat is wired; the rest are placeholders. */}
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton onClick={onNewChat}>
+                  <SquarePen />
+                  <span>New chat</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <Search />
+                  <span>Search</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <FolderCode />
+                  <span>Project info</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>
+                  <Blocks />
+                  <span>Skills &amp; plugins</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        {/* Pinned — placeholder rows. */}
+        <SidebarGroup>
+          <SidebarGroupLabel>Pinned</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {PINNED.map((title) => (
+                <SidebarMenuItem key={title}>
+                  <SidebarMenuButton className="text-muted-foreground">
+                    <Pin />
+                    <span>{title}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        {/* Projects — placeholder groups and rows. */}
+        <SidebarGroup>
+          <SidebarGroupLabel>Project</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {PROJECT_CHATS.map((title) => (
+                <SidebarMenuItem key={title}>
+                  <SidebarMenuButton className="text-muted-foreground">
+                    <MessageSquare />
+                    <span>{title}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarGroup>
+          <SidebarGroupLabel>sample-project</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {SAMPLE_CHATS.map((title) => (
+                <SidebarMenuItem key={title}>
+                  <SidebarMenuButton className="text-muted-foreground">
+                    <MessageSquare />
+                    <span>{title}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  );
+}

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -3,13 +3,8 @@
 
 @source "../node_modules/@vibest/ui";
 
-/*
- * Scan this app's own source. Tailwind's automatic content detection is relative
- * to the Vite root, but the Electron desktop renderer's root is apps/desktop/src/
- * renderer — it never sees apps/app/src. This explicit @source makes the CSS
- * self-sufficient so app-only utilities (e.g. the inset card margin in
- * routes/__root.tsx) are generated for every host, web and desktop alike.
- */
+/* Scan our own src explicitly: the desktop renderer's Vite root is
+ * apps/desktop, so auto-detection alone misses app-only utilities. */
 @source ".";
 
 :root {

--- a/apps/app/src/index.css
+++ b/apps/app/src/index.css
@@ -3,6 +3,15 @@
 
 @source "../node_modules/@vibest/ui";
 
+/*
+ * Scan this app's own source. Tailwind's automatic content detection is relative
+ * to the Vite root, but the Electron desktop renderer's root is apps/desktop/src/
+ * renderer — it never sees apps/app/src. This explicit @source makes the CSS
+ * self-sufficient so app-only utilities (e.g. the inset card margin in
+ * routes/__root.tsx) are generated for every host, web and desktop alike.
+ */
+@source ".";
+
 :root {
   --sidebar: hsl(0 0% 98%);
 

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -26,8 +26,7 @@ export const Route = createRootRouteWithContext<RouterAppContext>()({
   component: RootLayout,
 });
 
-// The whole app lives inside this shell: a left sidebar and a floating card
-// panel. Every route — landing, session, everything — renders in the card.
+// Global shell: left sidebar + floating card panel; every route renders in the card.
 function RootLayout() {
   const isFetching = useRouterState({ select: (s) => s.isLoading });
   const { orpcQueryUtils } = Route.useRouteContext();
@@ -49,36 +48,29 @@ function RootLayout() {
       <AppSidebar onNewChat={handleNewChat} />
       <CardPanel isFetching={isFetching} />
       {/*
-       * One pinned toggle for every state. The sidebar is offcanvas, so a toggle
-       * living inside it would vanish on collapse; swapping between a sidebar
-       * copy and a card-header copy also flickers on toggle. A single fixed
-       * button at the traffic-light row stays put — no mount/unmount, no jump.
-       * top-11 (32px button) centers it on window-Y 27, the traffic-light line;
-       * left-22 clears the macOS traffic lights with a small gap.
+       * Single fixed toggle for every state: the offcanvas sidebar would carry
+       * an inside toggle off-screen on collapse, and swapping two copies
+       * flickers. top-11/left-22 sits it on the macOS traffic-light row.
        */}
       <SidebarTrigger className="fixed top-[11px] left-22 z-30" />
     </SidebarProvider>
   );
 }
 
-// The floating card. Split out so it can read sidebar state via useSidebar()
-// (a hook only usable below SidebarProvider).
+// Split out so it can read sidebar state via useSidebar().
 function CardPanel({ isFetching }: { isFetching: boolean }) {
   const { state, isMobile } = useSidebar();
-  // Collapsed on desktop, the card slides left under the pinned toggle and the
-  // macOS traffic lights — pad the header start so the title clears them.
+  // Collapsed, the card slides under the toggle + traffic lights — pad so the
+  // title clears them.
   const collapsedDesktop = !isMobile && state === "collapsed";
 
   return (
     <SidebarInset className="flex min-h-0 flex-col overflow-hidden border md:peer-data-[variant=inset]:m-1.5 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-1.5">
       <header
         className={cn(
-          // The bottom divider is an inset box-shadow, not a border: it takes no
-          // layout space, so it can't eat into this flex box and pull the
-          // centered title off the traffic-light line.
-          // transition-[padding] animates the collapse-time shift in sync with
-          // the sidebar slide (matching its duration-200 ease-linear), so the
-          // title glides aside to make room for the lights instead of jumping.
+          // Divider is a box-shadow (no layout space) so it can't nudge the
+          // title off the light line; transition animates the collapse-time
+          // padding shift in sync with the sidebar slide.
           "flex h-10 shrink-0 items-center gap-2 px-4 shadow-[inset_0_-1px_0_var(--color-border)] transition-[padding] duration-200 ease-linear",
           collapsedDesktop && "ps-30",
         )}

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -1,6 +1,19 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { createRootRouteWithContext, Outlet, useRouterState } from "@tanstack/react-router";
+import {
+  createRootRouteWithContext,
+  Outlet,
+  useNavigate,
+  useRouterState,
+} from "@tanstack/react-router";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+  useSidebar,
+} from "@vibest/ui/components/sidebar";
+import { cn } from "@vibest/ui/lib/utils";
 
+import { AppSidebar } from "@/components/layout/app-sidebar";
 import Loader from "@/components/loader";
 import type { AppClients } from "@/lib/orpc";
 
@@ -13,11 +26,71 @@ export const Route = createRootRouteWithContext<RouterAppContext>()({
   component: RootLayout,
 });
 
+// The whole app lives inside this shell: a left sidebar and a floating card
+// panel. Every route — landing, session, everything — renders in the card.
 function RootLayout() {
   const isFetching = useRouterState({ select: (s) => s.isLoading });
+  const { orpcQueryUtils } = Route.useRouteContext();
+  const navigate = useNavigate();
+
+  const handleNewChat = async () => {
+    try {
+      const { sessionId } = await orpcQueryUtils.session.create.call({
+        harnessAgentId: "claude-code",
+      });
+      navigate({ to: "/session/$sessionId", params: { sessionId } });
+    } catch (error) {
+      console.error("Failed to create session", error);
+    }
+  };
+
   return (
-    <div className="flex h-svh w-full">
-      <main className="flex-1 overflow-hidden">{isFetching ? <Loader /> : <Outlet />}</main>
-    </div>
+    <SidebarProvider>
+      <AppSidebar onNewChat={handleNewChat} />
+      <CardPanel isFetching={isFetching} />
+      {/*
+       * One pinned toggle for every state. The sidebar is offcanvas, so a toggle
+       * living inside it would vanish on collapse; swapping between a sidebar
+       * copy and a card-header copy also flickers on toggle. A single fixed
+       * button at the traffic-light row stays put — no mount/unmount, no jump.
+       * top-11 (32px button) centers it on window-Y 27, the traffic-light line;
+       * left-22 clears the macOS traffic lights with a small gap.
+       */}
+      <SidebarTrigger className="fixed top-[11px] left-22 z-30" />
+    </SidebarProvider>
+  );
+}
+
+// The floating card. Split out so it can read sidebar state via useSidebar()
+// (a hook only usable below SidebarProvider).
+function CardPanel({ isFetching }: { isFetching: boolean }) {
+  const { state, isMobile } = useSidebar();
+  // Collapsed on desktop, the card slides left under the pinned toggle and the
+  // macOS traffic lights — pad the header start so the title clears them.
+  const collapsedDesktop = !isMobile && state === "collapsed";
+
+  return (
+    <SidebarInset className="flex min-h-0 flex-col overflow-hidden border md:peer-data-[variant=inset]:m-1.5 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-1.5">
+      <header
+        className={cn(
+          // The bottom divider is an inset box-shadow, not a border: it takes no
+          // layout space, so it can't eat into this flex box and pull the
+          // centered title off the traffic-light line.
+          // transition-[padding] animates the collapse-time shift in sync with
+          // the sidebar slide (matching its duration-200 ease-linear), so the
+          // title glides aside to make room for the lights instead of jumping.
+          "flex h-10 shrink-0 items-center gap-2 px-4 shadow-[inset_0_-1px_0_var(--color-border)] transition-[padding] duration-200 ease-linear",
+          collapsedDesktop && "ps-30",
+        )}
+      >
+        <div className="flex items-center gap-2 text-sm">
+          <span className="font-medium">New chat</span>
+          <span className="text-muted-foreground">Playground</span>
+        </div>
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {isFetching ? <Loader /> : <Outlet />}
+      </div>
+    </SidebarInset>
   );
 }

--- a/apps/app/src/routes/session/$sessionId.tsx
+++ b/apps/app/src/routes/session/$sessionId.tsx
@@ -9,7 +9,6 @@ export const Route = createFileRoute("/session/$sessionId")({
 function Component() {
   const { sessionId } = Route.useParams();
 
-  // The shell (sidebar + card panel + header) lives in the root route; this
-  // route is just the chat filling the card.
+  // The shell lives in the root route; this is just the chat filling the card.
   return <Chat className="mx-auto w-full max-w-4xl min-w-80" sessionId={sessionId} />;
 }

--- a/apps/app/src/routes/session/$sessionId.tsx
+++ b/apps/app/src/routes/session/$sessionId.tsx
@@ -1,5 +1,4 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Button } from "@vibest/ui/components/button";
+import { createFileRoute } from "@tanstack/react-router";
 
 import { Chat } from "@/components/chat";
 
@@ -9,29 +8,8 @@ export const Route = createFileRoute("/session/$sessionId")({
 
 function Component() {
   const { sessionId } = Route.useParams();
-  const { orpcQueryUtils } = Route.useRouteContext();
-  const navigate = useNavigate();
 
-  const handleNewSession = async () => {
-    try {
-      // Create new session and navigate
-      const { sessionId: newSessionId } = await orpcQueryUtils.session.create.call({
-        harnessAgentId: "claude-code",
-      });
-      navigate({ to: "/session/$sessionId", params: { sessionId: newSessionId } });
-    } catch (error) {
-      console.error("Failed to start a new session", error);
-    }
-  };
-
-  return (
-    <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b p-2">
-        <Button size="sm" className="ml-auto" variant="outline" onClick={handleNewSession}>
-          New Session
-        </Button>
-      </div>
-      <Chat className="mx-auto w-full max-w-4xl min-w-80" sessionId={sessionId} />
-    </div>
-  );
+  // The shell (sidebar + card panel + header) lives in the root route; this
+  // route is just the chat filling the card.
+  return <Chat className="mx-auto w-full max-w-4xl min-w-80" sessionId={sessionId} />;
 }

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 
 import * as NodeChildProcessSpawner from "@effect/platform-node/NodeChildProcessSpawner";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
@@ -44,7 +45,7 @@ export function startDesktopRuntime(): void {
   const remoteDebugPort = process.env["VIBEST_REMOTE_DEBUG_PORT"];
   if (remoteDebugPort) {
     app.commandLine.appendSwitch("remote-debugging-port", remoteDebugPort);
-    app.setPath("userData", `${app.getPath("temp")}/vibest-debug-${remoteDebugPort}`);
+    app.setPath("userData", path.join(app.getPath("temp"), `vibest-debug-${remoteDebugPort}`));
   }
 
   let runtime: ReturnType<typeof makeRuntime> | undefined;

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import path from "node:path";
 
 import * as NodeChildProcessSpawner from "@effect/platform-node/NodeChildProcessSpawner";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
@@ -12,6 +11,7 @@ import { makeDesktopConfigLive } from "./desktop-config";
 import { DesktopApplicationLive, RendererChannelLive } from "./desktop-runtime-glue";
 import { registerAppScheme } from "./electron/app-protocol";
 import { MainWindow, MainWindowLive } from "./electron/main-window";
+import { vibestTempPath } from "./lib/utils";
 import { LocalServerLive } from "./server/local-server-live";
 import { formatStartupFailure } from "./startup-failure";
 
@@ -45,7 +45,7 @@ export function startDesktopRuntime(): void {
   const remoteDebugPort = process.env["VIBEST_REMOTE_DEBUG_PORT"];
   if (remoteDebugPort) {
     app.commandLine.appendSwitch("remote-debugging-port", remoteDebugPort);
-    app.setPath("userData", path.join(app.getPath("temp"), `vibest-debug-${remoteDebugPort}`));
+    app.setPath("userData", vibestTempPath(`debug-${remoteDebugPort}`));
   }
 
   let runtime: ReturnType<typeof makeRuntime> | undefined;

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -40,8 +40,8 @@ export function startDesktopRuntime(): void {
   const isE2E = process.env["VIBEST_E2E"] === "1";
   if (isE2E && process.platform === "darwin") app.setActivationPolicy("accessory");
 
-  // Opt-in remote debugging for CDP tools (agent-browser). Isolates userData so
-  // the single-instance lock doesn't collide with another running build.
+  // Opt-in CDP remote debugging (agent-browser); isolated userData avoids the
+  // single-instance lock.
   const remoteDebugPort = process.env["VIBEST_REMOTE_DEBUG_PORT"];
   if (remoteDebugPort) {
     app.commandLine.appendSwitch("remote-debugging-port", remoteDebugPort);

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -39,6 +39,14 @@ export function startDesktopRuntime(): void {
   const isE2E = process.env["VIBEST_E2E"] === "1";
   if (isE2E && process.platform === "darwin") app.setActivationPolicy("accessory");
 
+  // Opt-in remote debugging for CDP tools (agent-browser). Isolates userData so
+  // the single-instance lock doesn't collide with another running build.
+  const remoteDebugPort = process.env["VIBEST_REMOTE_DEBUG_PORT"];
+  if (remoteDebugPort) {
+    app.commandLine.appendSwitch("remote-debugging-port", remoteDebugPort);
+    app.setPath("userData", `${app.getPath("temp")}/vibest-debug-${remoteDebugPort}`);
+  }
+
   let runtime: ReturnType<typeof makeRuntime> | undefined;
   let disposing = false;
   let allowQuit = false;

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -45,7 +45,7 @@ export function startDesktopRuntime(): void {
   const remoteDebugPort = process.env["VIBEST_REMOTE_DEBUG_PORT"];
   if (remoteDebugPort) {
     app.commandLine.appendSwitch("remote-debugging-port", remoteDebugPort);
-    app.setPath("userData", vibestTempPath(`debug-${remoteDebugPort}`));
+    app.setPath("userData", vibestTempPath(`remote-debugging-${remoteDebugPort}`));
   }
 
   let runtime: ReturnType<typeof makeRuntime> | undefined;

--- a/apps/desktop/src/main/electron/main-window.ts
+++ b/apps/desktop/src/main/electron/main-window.ts
@@ -57,7 +57,10 @@ export function makeMainWindow(
         show: false,
         autoHideMenuBar: true,
         titleBarStyle: "hiddenInset",
-        trafficLightPosition: { x: 16, y: 16 },
+        // Vertically center the ~14px traffic lights in the card header (routes/__root.tsx).
+        // header top = inset card m-1.5 (6px) + border (1px) = 7px; header h-10 = 40px.
+        // y = (7 + 40/2) - 14/2 = 27 - 7 = 20  → 13px clearance above and below.
+        trafficLightPosition: { x: 22, y: 20 },
         ...(process.platform === "linux" ? { icon } : {}),
         webPreferences: {
           preload: path.join(path.dirname(fileURLToPath(import.meta.url)), "../preload/index.js"),

--- a/apps/desktop/src/main/electron/main-window.ts
+++ b/apps/desktop/src/main/electron/main-window.ts
@@ -57,9 +57,7 @@ export function makeMainWindow(
         show: false,
         autoHideMenuBar: true,
         titleBarStyle: "hiddenInset",
-        // Vertically center the ~14px traffic lights in the card header (routes/__root.tsx).
-        // header top = inset card m-1.5 (6px) + border (1px) = 7px; header h-10 = 40px.
-        // y = (7 + 40/2) - 14/2 = 27 - 7 = 20  → 13px clearance above and below.
+        // y=20 centers the ~14px traffic lights on the header row (see __root.tsx).
         trafficLightPosition: { x: 22, y: 20 },
         ...(process.platform === "linux" ? { icon } : {}),
         webPreferences: {

--- a/apps/desktop/src/main/lib/utils.ts
+++ b/apps/desktop/src/main/lib/utils.ts
@@ -2,12 +2,7 @@ import path from "node:path";
 
 import { app } from "electron";
 
-/**
- * Build a path under the OS temp directory, namespaced with a `vibest-desktop-`
- * prefix. For throwaway data that must stay out of the app's real userData and
- * is fine to be cleaned up by the OS — e.g. an isolated userData dir for CDP
- * debugging.
- */
+/** Path under the OS temp dir, prefixed `vibest-desktop-`, for throwaway data. */
 export function vibestTempPath(name: string): string {
   return path.join(app.getPath("temp"), `vibest-desktop-${name}`);
 }

--- a/apps/desktop/src/main/lib/utils.ts
+++ b/apps/desktop/src/main/lib/utils.ts
@@ -1,0 +1,13 @@
+import path from "node:path";
+
+import { app } from "electron";
+
+/**
+ * Build a path under the OS temp directory, namespaced with a `vibest-desktop-`
+ * prefix. For throwaway data that must stay out of the app's real userData and
+ * is fine to be cleaned up by the OS — e.g. an isolated userData dir for CDP
+ * debugging.
+ */
+export function vibestTempPath(name: string): string {
+  return path.join(app.getPath("temp"), `vibest-desktop-${name}`);
+}


### PR DESCRIPTION
## What

Restructures the root layout into a global shell — a left inset sidebar and a floating card panel — that every route renders inside.

## Changes

**App**
- New `AppSidebar` with placeholder nav + conversation lists. Only *New chat* is wired; the rest await a `session.list` endpoint.
- Shell moved into `__root.tsx` so landing / session / everything renders in the card; the session route is simplified to a bare `<Chat>`.
- A **single pinned collapse toggle** at a fixed screen position aligned with the macOS traffic lights. Because the sidebar is offcanvas (fully slides away), a toggle living inside it would vanish on collapse and swapping copies flickered — one fixed button never mounts/unmounts.
- The card-header start padding **animates on collapse** (in sync with the sidebar slide) so the title glides aside to clear the toggle + traffic lights.
- The header divider is an inset `box-shadow` (no layout space) so it can't pull the title off the traffic-light center line.
- Placeholder UI labels are in English.

**Desktop**
- Hidden-inset title bar with the traffic lights positioned on the header center line.
- Opt-in `VIBEST_REMOTE_DEBUG_PORT` enabling CDP remote debugging with an isolated `userData` dir — no effect unless the env var is set. Used for verifying the layout against the real window chrome.

**Tailwind**
- Explicit `@source` for apps/app's own `src`, so app-only utilities (e.g. the inset-card margin) are generated in the Electron renderer build — its Vite root is `apps/desktop/src/renderer` and doesn't scan `apps/app`.

## Verification

Alignment of traffic lights / toggle / title was measured by pixel centroid on the real macOS window (2× Retina, captured by window-ID) in both collapsed and expanded states — all land on the same line within sub-pixel tolerance. Lint clean.

## Notes

- This is a layout shell with static mock data; no backend changes.
- The `VIBEST_REMOTE_DEBUG_PORT` affordance is a dev/test tool — happy to split it out if you'd prefer it not ride along.