### PR TITLE
feat(app): make window chrome draggable in desktop shell

### DIFF
--- a/apps/app/src/components/layout/app-sidebar.tsx
+++ b/apps/app/src/components/layout/app-sidebar.tsx
@@ -24,13 +24,9 @@ const SAMPLE_CHATS = ["Landing page redesign", "Database migration plan", "Onboa
 export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
   return (
     <Sidebar variant="inset" collapsible="offcanvas" className="md:p-1.5">
-      {/* Reserves the traffic-light / pinned-toggle row (see __root.tsx).
-          Doubles as a window drag strip in the desktop shell; the
-          -webkit-app-region property is an inert no-op in the browser. */}
+      {/* Reserves the traffic-light / pinned-toggle row (see __root.tsx). */}
       <SidebarHeader className="h-10 [-webkit-app-region:drag]" />
 
-      {/* The nav list is the sidebar's real content, so it opts out of window
-          dragging; the header and any surrounding space stay draggable. */}
       <SidebarContent className="[-webkit-app-region:no-drag]">
         {/* Only New chat is wired; the rest are placeholders. */}
         <SidebarGroup>

--- a/apps/app/src/components/layout/app-sidebar.tsx
+++ b/apps/app/src/components/layout/app-sidebar.tsx
@@ -24,10 +24,14 @@ const SAMPLE_CHATS = ["Landing page redesign", "Database migration plan", "Onboa
 export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
   return (
     <Sidebar variant="inset" collapsible="offcanvas" className="md:p-1.5">
-      {/* Reserves the traffic-light / pinned-toggle row (see __root.tsx). */}
-      <SidebarHeader className="h-10" />
+      {/* Reserves the traffic-light / pinned-toggle row (see __root.tsx).
+          Doubles as a window drag strip in the desktop shell; the
+          -webkit-app-region property is an inert no-op in the browser. */}
+      <SidebarHeader className="h-10 [-webkit-app-region:drag]" />
 
-      <SidebarContent>
+      {/* The nav list is the sidebar's real content, so it opts out of window
+          dragging; the header and any surrounding space stay draggable. */}
+      <SidebarContent className="[-webkit-app-region:no-drag]">
         {/* Only New chat is wired; the rest are placeholders. */}
         <SidebarGroup>
           <SidebarGroupContent>

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -44,10 +44,7 @@ function RootLayout() {
   };
 
   return (
-    // The background behind the panels is the window drag surface, so the gaps
-    // the inset layout leaves (top margin, around the card) still drag. The
-    // content panels below opt back out with no-drag; -webkit-app-region is an
-    // inert no-op in the browser.
+    // -webkit-app-region drags the desktop window (no-op in the browser).
     <SidebarProvider className="[-webkit-app-region:drag]">
       <AppSidebar onNewChat={handleNewChat} />
       <CardPanel isFetching={isFetching} />
@@ -56,7 +53,6 @@ function RootLayout() {
        * an inside toggle off-screen on collapse, and swapping two copies
        * flickers. top-11/left-22 sits it on the macOS traffic-light row.
        */}
-      {/* no-drag carves a clickable hole out of the header drag strip below it. */}
       <SidebarTrigger className="fixed top-[11px] left-22 z-30 [-webkit-app-region:no-drag]" />
     </SidebarProvider>
   );
@@ -75,8 +71,7 @@ function CardPanel({ isFetching }: { isFetching: boolean }) {
         className={cn(
           // Divider is a box-shadow (no layout space) so it can't nudge the
           // title off the light line; transition animates the collapse-time
-          // padding shift in sync with the sidebar slide. Doubles as a window
-          // drag strip in the desktop shell (inert no-op in the browser).
+          // padding shift in sync with the sidebar slide.
           "flex h-10 shrink-0 items-center gap-2 px-4 shadow-[inset_0_-1px_0_var(--color-border)] transition-[padding] duration-200 ease-linear [-webkit-app-region:drag]",
           collapsedDesktop && "ps-30",
         )}

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -44,7 +44,11 @@ function RootLayout() {
   };
 
   return (
-    <SidebarProvider>
+    // The background behind the panels is the window drag surface, so the gaps
+    // the inset layout leaves (top margin, around the card) still drag. The
+    // content panels below opt back out with no-drag; -webkit-app-region is an
+    // inert no-op in the browser.
+    <SidebarProvider className="[-webkit-app-region:drag]">
       <AppSidebar onNewChat={handleNewChat} />
       <CardPanel isFetching={isFetching} />
       {/*
@@ -52,7 +56,8 @@ function RootLayout() {
        * an inside toggle off-screen on collapse, and swapping two copies
        * flickers. top-11/left-22 sits it on the macOS traffic-light row.
        */}
-      <SidebarTrigger className="fixed top-[11px] left-22 z-30" />
+      {/* no-drag carves a clickable hole out of the header drag strip below it. */}
+      <SidebarTrigger className="fixed top-[11px] left-22 z-30 [-webkit-app-region:no-drag]" />
     </SidebarProvider>
   );
 }
@@ -65,13 +70,14 @@ function CardPanel({ isFetching }: { isFetching: boolean }) {
   const collapsedDesktop = !isMobile && state === "collapsed";
 
   return (
-    <SidebarInset className="flex min-h-0 flex-col overflow-hidden border md:peer-data-[variant=inset]:m-1.5 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-1.5">
+    <SidebarInset className="flex min-h-0 flex-col overflow-hidden border [-webkit-app-region:no-drag] md:peer-data-[variant=inset]:m-1.5 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-1.5">
       <header
         className={cn(
           // Divider is a box-shadow (no layout space) so it can't nudge the
           // title off the light line; transition animates the collapse-time
-          // padding shift in sync with the sidebar slide.
-          "flex h-10 shrink-0 items-center gap-2 px-4 shadow-[inset_0_-1px_0_var(--color-border)] transition-[padding] duration-200 ease-linear",
+          // padding shift in sync with the sidebar slide. Doubles as a window
+          // drag strip in the desktop shell (inert no-op in the browser).
+          "flex h-10 shrink-0 items-center gap-2 px-4 shadow-[inset_0_-1px_0_var(--color-border)] transition-[padding] duration-200 ease-linear [-webkit-app-region:drag]",
           collapsedDesktop && "ps-30",
         )}
       >


### PR DESCRIPTION
## Summary

Adds `-webkit-app-region` drag hints so the app shell window can be dragged from its chrome when running inside the desktop shell, while keeping interactive regions clickable. These properties are inert no-ops in the browser.

- Sidebar header (`app-sidebar.tsx`) becomes a drag strip; the nav list opts back out with `no-drag`.
- Root background (`__root.tsx` `SidebarProvider`) is the drag surface for the inset gaps; content panels (`SidebarInset`) opt out.
- Card header doubles as a drag strip.
- The `SidebarTrigger` carves a clickable `no-drag` hole out of the header strip.

## Test plan

- [ ] Verify window drags from header / background in the desktop shell
- [ ] Verify nav items, sidebar trigger, and card content remain clickable
- [ ] Verify no visual/behavioral change in the browser