### PR TITLE
fix(desktop): give dev its own userData so it can start alongside an installed build

### DIFF
--- a/apps/desktop/e2e/tests/desktop-rpc.spec.ts
+++ b/apps/desktop/e2e/tests/desktop-rpc.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { createReadStream, existsSync, readFileSync, statSync } from "node:fs";
+import { createReadStream, existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { createServer } from "node:http";
 import path from "node:path";
 
@@ -119,7 +119,8 @@ test("gives a reloaded renderer document a new MessagePort", async ({ electronAp
   expect(serverPid(electronApp.process().pid)).toBe(pid);
 });
 
-test("boots the development HTTP renderer through MessagePort", async () => {
+// oxlint-disable-next-line no-empty-pattern -- required by Playwright's fixture API
+test("boots the development HTTP renderer through MessagePort", async ({}, testInfo) => {
   const rendererRoot = path.join(import.meta.dirname, "../../dist/renderer");
   const server = createServer((request, response) => {
     const requested = path.join(
@@ -145,8 +146,15 @@ test("boots the development HTTP renderer through MessagePort", async () => {
   if (!address || typeof address === "string") throw new Error("Development server did not bind");
   const origin = `http://127.0.0.1:${address.port}`;
 
+  // Own userData so its single-instance lock can't collide with a real `dev`.
+  const userData = path.join(testInfo.outputPath(), "user-data");
+  mkdirSync(userData, { recursive: true });
+
   const app = await electron.launch({
-    args: [path.join(import.meta.dirname, "../../dist/main/index.js")],
+    args: [
+      path.join(import.meta.dirname, "../../dist/main/index.js"),
+      `--user-data-dir=${userData}`,
+    ],
     env: {
       ...process.env,
       NODE_ENV: "development",

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -46,6 +46,14 @@ export function startDesktopRuntime(): void {
   if (remoteDebugPort) {
     app.commandLine.appendSwitch("remote-debugging-port", remoteDebugPort);
     app.setPath("userData", vibestTempPath(`remote-debugging-${remoteDebugPort}`));
+  } else if (is.dev) {
+    // Dev and the packaged build share one app identity, so they'd share the
+    // single-instance lock (a file under userData). On macOS an installed
+    // Vibest.app keeps running after its window closes (see window-all-closed
+    // below), so it holds that lock — and every `dev` launch would fail the
+    // requestSingleInstanceLock() check below and quit on startup. Give dev its
+    // own userData dir so it gets an independent lock (and separate state).
+    app.setPath("userData", `${app.getPath("userData")}-dev`);
   }
 
   let runtime: ReturnType<typeof makeRuntime> | undefined;

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -52,7 +52,7 @@ export function startDesktopRuntime(): void {
     // closes). Suffix with the git worktree name so parallel dev instances from
     // different worktrees don't collide. E2E is excluded — it passes its own
     // --user-data-dir.
-    const slug = devWorktreeSlug();
+    const slug = Effect.runSync(devWorktreeSlug);
     const devUserData = slug
       ? `${app.getPath("userData")}-dev-${slug}`
       : `${app.getPath("userData")}-dev`;

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -11,7 +11,7 @@ import { makeDesktopConfigLive } from "./desktop-config";
 import { DesktopApplicationLive, RendererChannelLive } from "./desktop-runtime-glue";
 import { registerAppScheme } from "./electron/app-protocol";
 import { MainWindow, MainWindowLive } from "./electron/main-window";
-import { vibestTempPath } from "./lib/utils";
+import { devWorktreeSlug, vibestTempPath } from "./lib/utils";
 import { LocalServerLive } from "./server/local-server-live";
 import { formatStartupFailure } from "./startup-failure";
 
@@ -46,14 +46,17 @@ export function startDesktopRuntime(): void {
   if (remoteDebugPort) {
     app.commandLine.appendSwitch("remote-debugging-port", remoteDebugPort);
     app.setPath("userData", vibestTempPath(`remote-debugging-${remoteDebugPort}`));
-  } else if (is.dev) {
-    // Dev and the packaged build share one app identity, so they'd share the
-    // single-instance lock (a file under userData). On macOS an installed
-    // Vibest.app keeps running after its window closes (see window-all-closed
-    // below), so it holds that lock — and every `dev` launch would fail the
-    // requestSingleInstanceLock() check below and quit on startup. Give dev its
-    // own userData dir so it gets an independent lock (and separate state).
-    app.setPath("userData", `${app.getPath("userData")}-dev`);
+  } else if (is.dev && !isE2E) {
+    // Give dev its own userData so its single-instance lock is independent of an
+    // installed build (which on macOS keeps holding the lock after its window
+    // closes). Suffix with the git worktree name so parallel dev instances from
+    // different worktrees don't collide. E2E is excluded — it passes its own
+    // --user-data-dir.
+    const slug = devWorktreeSlug();
+    const devUserData = slug
+      ? `${app.getPath("userData")}-dev-${slug}`
+      : `${app.getPath("userData")}-dev`;
+    app.setPath("userData", devUserData);
   }
 
   let runtime: ReturnType<typeof makeRuntime> | undefined;

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -11,7 +11,7 @@ import { makeDesktopConfigLive } from "./desktop-config";
 import { DesktopApplicationLive, RendererChannelLive } from "./desktop-runtime-glue";
 import { registerAppScheme } from "./electron/app-protocol";
 import { MainWindow, MainWindowLive } from "./electron/main-window";
-import { devWorktreeSlug, vibestTempPath } from "./lib/utils";
+import { devUserDataPath, devWorktreeSlug, vibestTempPath } from "./lib/utils";
 import { LocalServerLive } from "./server/local-server-live";
 import { formatStartupFailure } from "./startup-failure";
 
@@ -49,14 +49,10 @@ export function startDesktopRuntime(): void {
   } else if (is.dev && !isE2E) {
     // Give dev its own userData so its single-instance lock is independent of an
     // installed build (which on macOS keeps holding the lock after its window
-    // closes). Suffix with the git worktree name so parallel dev instances from
+    // closes). Key it on the git worktree so parallel dev instances from
     // different worktrees don't collide. E2E is excluded — it passes its own
     // --user-data-dir.
-    const slug = Effect.runSync(devWorktreeSlug);
-    const devUserData = slug
-      ? `${app.getPath("userData")}-dev-${slug}`
-      : `${app.getPath("userData")}-dev`;
-    app.setPath("userData", devUserData);
+    app.setPath("userData", devUserDataPath(Effect.runSync(devWorktreeSlug)));
   }
 
   let runtime: ReturnType<typeof makeRuntime> | undefined;

--- a/apps/desktop/src/main/lib/utils.ts
+++ b/apps/desktop/src/main/lib/utils.ts
@@ -10,6 +10,17 @@ export function vibestTempPath(name: string): string {
 }
 
 /**
+ * userData dir for a dev checkout. Lives in `Vibest Dev/<worktree>`, a sibling
+ * of the packaged app's userData dir (`Vibest`) — not the generic `desktop` dir
+ * the dev app name would otherwise produce, and separate from prod so the two
+ * don't share a single-instance lock. `slug` is the git worktree name; outside a
+ * checkout it falls back to a shared `default` dir.
+ */
+export function devUserDataPath(slug: string | undefined): string {
+  return path.join(app.getPath("appData"), "Vibest Dev", slug ?? "default");
+}
+
+/**
  * Basename of the current git worktree, sanitized for a path segment (e.g.
  * `dapper-mochi`). Used to key each dev checkout's userData dir. Not
  * `basename(cwd)` — dev's cwd is `apps/desktop`, identical across worktrees.

--- a/apps/desktop/src/main/lib/utils.ts
+++ b/apps/desktop/src/main/lib/utils.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 
 import { app } from "electron";
@@ -5,4 +6,23 @@ import { app } from "electron";
 /** Path under the OS temp dir, prefixed `vibest-desktop-`, for throwaway data. */
 export function vibestTempPath(name: string): string {
   return path.join(app.getPath("temp"), `vibest-desktop-${name}`);
+}
+
+/**
+ * Basename of the current git worktree, sanitized for a path segment (e.g.
+ * `dapper-mochi`). Used to key each dev checkout's userData dir. Not
+ * `basename(cwd)` — dev's cwd is `apps/desktop`, identical across worktrees.
+ * Undefined outside a git checkout.
+ */
+export function devWorktreeSlug(): string | undefined {
+  try {
+    const top = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const slug = path.basename(top).replace(/[^a-zA-Z0-9._-]/g, "-");
+    return slug.length > 0 ? slug : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/apps/desktop/src/main/lib/utils.ts
+++ b/apps/desktop/src/main/lib/utils.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
+import { Effect } from "effect";
 import { app } from "electron";
 
 /** Path under the OS temp dir, prefixed `vibest-desktop-`, for throwaway data. */
@@ -12,17 +13,18 @@ export function vibestTempPath(name: string): string {
  * Basename of the current git worktree, sanitized for a path segment (e.g.
  * `dapper-mochi`). Used to key each dev checkout's userData dir. Not
  * `basename(cwd)` — dev's cwd is `apps/desktop`, identical across worktrees.
- * Undefined outside a git checkout.
+ * Succeeds with undefined outside a git checkout. Synchronous (execFileSync) so
+ * it can run in the pre-`whenReady` bootstrap, before any runtime exists.
  */
-export function devWorktreeSlug(): string | undefined {
-  try {
-    const top = execFileSync("git", ["rev-parse", "--show-toplevel"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
+export const devWorktreeSlug: Effect.Effect<string | undefined> = Effect.try(() =>
+  execFileSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim(),
+).pipe(
+  Effect.map((top) => {
     const slug = path.basename(top).replace(/[^a-zA-Z0-9._-]/g, "-");
     return slug.length > 0 ? slug : undefined;
-  } catch {
-    return undefined;
-  }
-}
+  }),
+  Effect.catch(() => Effect.succeed(undefined)),
+);


### PR DESCRIPTION
## Bug

After running a packaged Vibest build, `dev --filter=desktop` would no longer start — the dev window never appears.

## Root cause

Dev and the packaged build share one app identity, so they share the Electron **single-instance lock** (a `SingletonLock` file under `userData`, `~/Library/Application Support/desktop`). On macOS, `window-all-closed` deliberately does **not** quit the app (`desktop-runtime.ts`), so an installed `Vibest.app` keeps running in the background after you close its window and **holds that lock**. Every subsequent `dev` launch then fails `requestSingleInstanceLock()` and quits immediately on startup — which looks like "dev won't start anymore."

Verified locally: with `/Applications/Vibest.app` running, its `SingletonLock ⇒ …-<pid>` matched the live app's PID, and the dev Electron process exited right after start.

## Fix

In dev, point `userData` at a `-dev` sibling directory so dev gets an **independent** single-instance lock (and separate state), mirroring the existing remote-debugging branch that already isolates `userData` for the same reason. Prod/packaged behavior is unchanged.

## Verification

With `Vibest.app` still running (holding `…/desktop/SingletonLock`), `turbo run dev --filter=desktop` now boots fully: the backend comes up (`vibest listening on 127.0.0.1:<port>`), the window opens, and dev creates its own `…/desktop-dev/SingletonLock` pointing at the dev process — two independent locks coexisting. Typecheck and oxlint pass.