### PR TITLE
feat(server): expose workspace-confined file reads over oRPC

### DIFF
--- a/apps/app/src/components/projects/import-project-dialog.tsx
+++ b/apps/app/src/components/projects/import-project-dialog.tsx
@@ -33,7 +33,7 @@ export function ImportProjectDialog({ onClose }: { onClose: () => void }) {
   const queryClient = useQueryClient();
 
   const listing = useQuery({
-    ...orpcQueryUtils.project.listDirectories.queryOptions({
+    ...orpcQueryUtils.fs.browse.queryOptions({
       input: path === null ? {} : { path },
     }),
     placeholderData: keepPreviousData,

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./fs": "./src/fs.ts",
     "./session": "./src/session.ts",
     "./session-events": "./src/session-events.ts"
   },

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -344,10 +344,10 @@ export const DirectoryEntrySchema = Schema.Struct({
 });
 export type DirectoryEntry = typeof DirectoryEntrySchema.Type;
 
-export const ListDirectoriesInputSchema = Schema.Struct({
+export const BrowseInputSchema = Schema.Struct({
   path: Schema.optionalKey(Schema.String),
 });
-export const ListDirectoriesResultSchema = Schema.Struct({
+export const BrowseResultSchema = Schema.Struct({
   path: Schema.String,
   parent: Schema.Union([Schema.String, Schema.Null]),
   directories: Schema.Array(DirectoryEntrySchema),

--- a/packages/contract/src/fs.ts
+++ b/packages/contract/src/fs.ts
@@ -10,14 +10,12 @@ const CwdPathInput = Schema.Struct({
 });
 
 /**
- * File-system access. `readFileString` / `readDirectory` are confined to the
- * caller-supplied `cwd` (backed by `WorkspaceFSService`); `browse` is rootless —
- * a folder picker that may list any directory but returns names only, no
- * contents.
+ * File-system access. `readFileString` is confined to the caller-supplied `cwd`
+ * (backed by `FileSystemService`); `browse` is rootless — a folder picker that
+ * may list any directory but returns names only, no contents.
  */
 export const fsContract = {
   readFileString: oc.input(toStandardSchema(CwdPathInput)).output(type<string>()),
-  readDirectory: oc.input(toStandardSchema(CwdPathInput)).output(type<ReadonlyArray<string>>()),
   /** Browse immediate subdirectories of `path` (default: the home directory). */
   browse: oc
     .input(toStandardSchema(BrowseInputSchema))

--- a/packages/contract/src/fs.ts
+++ b/packages/contract/src/fs.ts
@@ -1,7 +1,7 @@
 import { oc, type } from "@orpc/contract";
 import { Schema } from "effect";
 
-import { toStandardSchema } from "./domain";
+import { BrowseInputSchema, BrowseResultSchema, toStandardSchema } from "./domain";
 
 // `path` is resolved relative to `cwd` and confined within it on the server.
 const CwdPathInput = Schema.Struct({
@@ -10,10 +10,16 @@ const CwdPathInput = Schema.Struct({
 });
 
 /**
- * Read-only file access, backed by the server's `WorkspaceFSService`. Every read
- * is confined to the caller-supplied `cwd`.
+ * File-system access. `readFileString` / `readDirectory` are confined to the
+ * caller-supplied `cwd` (backed by `WorkspaceFSService`); `browse` is rootless —
+ * a folder picker that may list any directory but returns names only, no
+ * contents.
  */
 export const fsContract = {
   readFileString: oc.input(toStandardSchema(CwdPathInput)).output(type<string>()),
   readDirectory: oc.input(toStandardSchema(CwdPathInput)).output(type<ReadonlyArray<string>>()),
+  /** Browse immediate subdirectories of `path` (default: the home directory). */
+  browse: oc
+    .input(toStandardSchema(BrowseInputSchema))
+    .output(toStandardSchema(BrowseResultSchema)),
 };

--- a/packages/contract/src/fs.ts
+++ b/packages/contract/src/fs.ts
@@ -1,0 +1,19 @@
+import { oc, type } from "@orpc/contract";
+import { Schema } from "effect";
+
+import { toStandardSchema } from "./domain";
+
+// `path` is resolved relative to `cwd` and confined within it on the server.
+const CwdPathInput = Schema.Struct({
+  cwd: Schema.String,
+  path: Schema.String,
+});
+
+/**
+ * Read-only file access, backed by the server's `WorkspaceFSService`. Every read
+ * is confined to the caller-supplied `cwd`.
+ */
+export const fsContract = {
+  readFileString: oc.input(toStandardSchema(CwdPathInput)).output(type<string>()),
+  readDirectory: oc.input(toStandardSchema(CwdPathInput)).output(type<ReadonlyArray<string>>()),
+};

--- a/packages/contract/src/fs.ts
+++ b/packages/contract/src/fs.ts
@@ -9,15 +9,36 @@ const CwdPathInput = Schema.Struct({
   path: Schema.String,
 });
 
+const pathData = toStandardSchema(Schema.Struct({ path: Schema.String }));
+
+// Typed failures the client can branch on, instead of an opaque 500.
+const readErrors = {
+  PATH_ESCAPE: {
+    data: toStandardSchema(Schema.Struct({ cwd: Schema.String, path: Schema.String })),
+  },
+  NOT_FILE: { data: pathData },
+  FILE_TOO_LARGE: {
+    data: toStandardSchema(
+      Schema.Struct({ path: Schema.String, size: Schema.Number, limit: Schema.Number }),
+    ),
+  },
+  BINARY_FILE: { data: pathData },
+  READ_FAILED: { data: pathData },
+};
+
 /**
  * File-system access. `readFileString` is confined to the caller-supplied `cwd`
  * (backed by `FileSystemService`); `browse` is rootless — a folder picker that
  * may list any directory but returns names only, no contents.
  */
 export const fsContract = {
-  readFileString: oc.input(toStandardSchema(CwdPathInput)).output(type<string>()),
+  readFileString: oc
+    .input(toStandardSchema(CwdPathInput))
+    .errors(readErrors)
+    .output(type<string>()),
   /** Browse immediate subdirectories of `path` (default: the home directory). */
   browse: oc
     .input(toStandardSchema(BrowseInputSchema))
+    .errors({ READ_FAILED: { data: pathData } })
     .output(toStandardSchema(BrowseResultSchema)),
 };

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -1,3 +1,4 @@
+import { fsContract } from "./fs";
 import { sessionContract } from "./session";
 
 export * from "./domain";
@@ -5,8 +6,9 @@ export * from "./session-events";
 
 export const contract = {
   session: sessionContract,
+  fs: fsContract,
 };
 export type Contract = typeof contract;
 
-export { sessionContract };
+export { fsContract, sessionContract };
 export type { SessionEventStreamItem } from "./session";

--- a/packages/contract/src/project.ts
+++ b/packages/contract/src/project.ts
@@ -1,21 +1,11 @@
 import { oc } from "@orpc/contract";
 import { Schema } from "effect";
 
-import {
-  CreateProjectInputSchema,
-  ListDirectoriesInputSchema,
-  ListDirectoriesResultSchema,
-  ProjectSchema,
-  toStandardSchema,
-} from "./domain";
+import { CreateProjectInputSchema, ProjectSchema, toStandardSchema } from "./domain";
 
 export const projectContract = {
   list: oc.output(toStandardSchema(Schema.Array(ProjectSchema))),
   create: oc
     .input(toStandardSchema(CreateProjectInputSchema))
     .output(toStandardSchema(ProjectSchema)),
-  /** Browse immediate subdirectories of `path` (default: the home directory). */
-  listDirectories: oc
-    .input(toStandardSchema(ListDirectoriesInputSchema))
-    .output(toStandardSchema(ListDirectoriesResultSchema)),
 };

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -20,15 +20,39 @@ export class StoreWriteError extends Data.TaggedError("StoreWriteError")<{
   readonly cause: unknown;
 }> {}
 
-export class FileReadError extends Data.TaggedError("FileReadError")<{
-  readonly path: string;
-  readonly cause: unknown;
-}> {}
-
 export class GitError extends Data.TaggedError("GitError")<{
   readonly cause: unknown;
 }> {}
 
 export class InvalidSessionId extends Data.TaggedError("InvalidSessionId")<{
   readonly sessionId: string;
+}> {}
+
+/** A requested path resolves outside its `cwd` (via `..` or a symlink). */
+export class WorkspacePathEscape extends Data.TaggedError("WorkspacePathEscape")<{
+  readonly cwd: string;
+  readonly path: string;
+}> {}
+
+/** The path exists but is not a regular file (e.g. a directory). */
+export class WorkspaceNotFile extends Data.TaggedError("WorkspaceNotFile")<{
+  readonly path: string;
+}> {}
+
+/** The file is larger than the read limit; rejected rather than truncated. */
+export class WorkspaceFileTooLarge extends Data.TaggedError("WorkspaceFileTooLarge")<{
+  readonly path: string;
+  readonly size: number;
+  readonly limit: number;
+}> {}
+
+/** The file contains a NUL byte, so we treat it as binary and refuse to read it as text. */
+export class WorkspaceBinaryFile extends Data.TaggedError("WorkspaceBinaryFile")<{
+  readonly path: string;
+}> {}
+
+/** An underlying `FileSystem` read failed (missing, permission, etc.). */
+export class WorkspaceReadError extends Data.TaggedError("WorkspaceReadError")<{
+  readonly path: string;
+  readonly cause: unknown;
 }> {}

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -28,12 +28,6 @@ export class InvalidSessionId extends Data.TaggedError("InvalidSessionId")<{
   readonly sessionId: string;
 }> {}
 
-/** A file read failed (used by the project folder browser). */
-export class FileReadError extends Data.TaggedError("FileReadError")<{
-  readonly path: string;
-  readonly cause: unknown;
-}> {}
-
 /** A requested path resolves outside its `cwd` (via `..` or a symlink). */
 export class WorkspacePathEscape extends Data.TaggedError("WorkspacePathEscape")<{
   readonly cwd: string;

--- a/packages/server/src/fs/index.ts
+++ b/packages/server/src/fs/index.ts
@@ -1,1 +1,1 @@
-export { WorkspaceFSService, WorkspaceFSServiceLayer } from "./service";
+export { FileSystemService, FileSystemServiceLayer } from "./service";

--- a/packages/server/src/fs/index.ts
+++ b/packages/server/src/fs/index.ts
@@ -1,1 +1,1 @@
-export { FSService, FSServiceLayer, type GrepMatch } from "./service";
+export { WorkspaceFSService, WorkspaceFSServiceLayer } from "./service";

--- a/packages/server/src/fs/service.ts
+++ b/packages/server/src/fs/service.ts
@@ -1,103 +1,111 @@
-import { readFile, readdir } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 
-import { Context, Effect, Layer } from "effect";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { Context, Effect, FileSystem, Layer } from "effect";
 
-import { FileReadError } from "../errors";
+import {
+  WorkspaceBinaryFile,
+  WorkspaceFileTooLarge,
+  WorkspaceNotFile,
+  WorkspacePathEscape,
+  WorkspaceReadError,
+} from "../errors";
 
-export interface GrepMatch {
-  readonly file: string;
-  readonly line: number;
-  readonly text: string;
-}
+/** Largest file we will read as text; larger files are rejected, not truncated. */
+const MAX_FILE_BYTES = 1024 * 1024; // 1 MiB
 
-const IGNORED = new Set([".git", "node_modules"]);
-
-/** Recursively collect file paths under `dir` (absolute), skipping IGNORED dirs. */
-const walk = async (dir: string): Promise<Array<string>> => {
-  const out: Array<string> = [];
-  const entries = await readdir(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      if (IGNORED.has(entry.name)) continue;
-      out.push(...(await walk(join(dir, entry.name))));
-    } else if (entry.isFile()) {
-      out.push(join(dir, entry.name));
-    }
-  }
-  return out;
-};
+/** A NUL byte marks the content as binary, so we refuse to read it as text. */
+const NUL = String.fromCharCode(0);
 
 /**
- * `fs` module — read-only file access. No write/watch operations and (for now)
- * no path-boundary protection (design §8).
+ * Lexical containment: is `child` at or beneath `parent`? Rejects `..` escapes
+ * and absolute paths that point elsewhere. (Same check opencode's `FSUtil.contains`
+ * and t3code's `WorkspacePaths` use.)
  */
-export class FSService extends Context.Service<
-  FSService,
+const contains = (parent: string, child: string): boolean => {
+  const rel = relative(parent, child);
+  return rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`));
+};
+
+type ReadFileError =
+  | WorkspacePathEscape
+  | WorkspaceNotFile
+  | WorkspaceFileTooLarge
+  | WorkspaceBinaryFile
+  | WorkspaceReadError;
+
+/**
+ * `WorkspaceFSService` — read-only file access confined to a caller-supplied
+ * `cwd`. Built on the effect `FileSystem`, but unlike a raw passthrough it
+ * enforces a path boundary (lexical + realpath, defeating `..` and symlink
+ * escapes) and read guardrails (regular-file-only, size cap, binary rejection).
+ * All failures are typed on the effect error channel.
+ */
+export class WorkspaceFSService extends Context.Service<
+  WorkspaceFSService,
   {
-    readonly readFile: (path: string) => Effect.Effect<string, FileReadError>;
-    /** Recursive listing of files under `dir`, as paths relative to `dir`. */
-    readonly tree: (dir: string) => Effect.Effect<ReadonlyArray<string>, FileReadError>;
-    /** Substring search over file contents under `dir`. */
-    readonly grep: (
-      pattern: string,
-      dir: string,
-    ) => Effect.Effect<ReadonlyArray<GrepMatch>, FileReadError>;
-    /** Search file paths (not contents) under `dir` by substring. */
-    readonly search: (
-      query: string,
-      dir: string,
-    ) => Effect.Effect<ReadonlyArray<string>, FileReadError>;
+    /** Read `path` (relative to `cwd`) as UTF-8 text. */
+    readonly readFileString: (cwd: string, path: string) => Effect.Effect<string, ReadFileError>;
+    /** List the entries of the directory `path` (relative to `cwd`). */
+    readonly readDirectory: (
+      cwd: string,
+      path: string,
+    ) => Effect.Effect<ReadonlyArray<string>, WorkspacePathEscape | WorkspaceReadError>;
   }
->()("FSService") {}
+>()("WorkspaceFSService") {}
 
-export const FSServiceLayer: Layer.Layer<FSService> = Layer.sync(FSService, () => ({
-  readFile: (path) =>
-    Effect.tryPromise({
-      try: () => readFile(path, "utf8"),
-      catch: (cause) => new FileReadError({ path, cause }),
-    }),
+export const WorkspaceFSServiceLayer: Layer.Layer<WorkspaceFSService> = Layer.effect(
+  WorkspaceFSService,
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
 
-  tree: (dir) =>
-    Effect.tryPromise({
-      try: async () => {
-        const files = await walk(dir);
-        return files.map((f) => relative(dir, f));
-      },
-      catch: (cause) => new FileReadError({ path: dir, cause }),
-    }),
+    const readErr = (path: string) => (cause: unknown) => new WorkspaceReadError({ path, cause });
 
-  grep: (pattern, dir) =>
-    Effect.tryPromise({
-      try: async () => {
-        const files = await walk(dir);
-        const matches: Array<GrepMatch> = [];
-        for (const file of files) {
-          let content: string;
-          try {
-            content = await readFile(file, "utf8");
-          } catch {
-            continue; // skip unreadable/binary files
-          }
-          const lines = content.split("\n");
-          for (let i = 0; i < lines.length; i++) {
-            const text = lines[i] ?? "";
-            if (text.includes(pattern)) {
-              matches.push({ file: relative(dir, file), line: i + 1, text });
-            }
-          }
+    // Resolve `path` against `cwd` and confine it there both lexically and after
+    // realpath — the first stops `..`, the second stops symlinks pointing out.
+    const resolveWithin = (cwd: string, path: string) =>
+      Effect.gen(function* () {
+        // `cwd` is the trusted root and must be absolute; `path` must be relative
+        // to it (an absolute `path` would silently ignore `cwd`).
+        if (!isAbsolute(cwd) || isAbsolute(path)) {
+          return yield* new WorkspacePathEscape({ cwd, path });
         }
-        return matches;
-      },
-      catch: (cause) => new FileReadError({ path: dir, cause }),
-    }),
+        const absolute = resolve(cwd, path);
+        if (!contains(cwd, absolute)) {
+          return yield* new WorkspacePathEscape({ cwd, path });
+        }
+        const realRoot = yield* fs.realPath(cwd).pipe(Effect.mapError(readErr(path)));
+        const realTarget = yield* fs.realPath(absolute).pipe(Effect.mapError(readErr(path)));
+        if (!contains(realRoot, realTarget)) {
+          return yield* new WorkspacePathEscape({ cwd, path });
+        }
+        return absolute;
+      });
 
-  search: (query, dir) =>
-    Effect.tryPromise({
-      try: async () => {
-        const files = await walk(dir);
-        return files.map((f) => relative(dir, f)).filter((p) => p.includes(query));
-      },
-      catch: (cause) => new FileReadError({ path: dir, cause }),
-    }),
-}));
+    return {
+      readFileString: (cwd, path) =>
+        Effect.gen(function* () {
+          const absolute = yield* resolveWithin(cwd, path);
+          const info = yield* fs.stat(absolute).pipe(Effect.mapError(readErr(path)));
+          if (info.type !== "File") {
+            return yield* new WorkspaceNotFile({ path });
+          }
+          const size = Number(info.size);
+          if (size > MAX_FILE_BYTES) {
+            return yield* new WorkspaceFileTooLarge({ path, size, limit: MAX_FILE_BYTES });
+          }
+          const content = yield* fs.readFileString(absolute).pipe(Effect.mapError(readErr(path)));
+          if (content.includes(NUL)) {
+            return yield* new WorkspaceBinaryFile({ path });
+          }
+          return content;
+        }),
+
+      readDirectory: (cwd, path) =>
+        Effect.gen(function* () {
+          const absolute = yield* resolveWithin(cwd, path);
+          return yield* fs.readDirectory(absolute).pipe(Effect.mapError(readErr(path)));
+        }),
+    };
+  }),
+).pipe(Layer.provide(NodeFileSystem.layer));

--- a/packages/server/src/fs/service.ts
+++ b/packages/server/src/fs/service.ts
@@ -12,7 +12,7 @@ import {
 } from "../errors";
 
 /** Largest file we will read as text; larger files are rejected, not truncated. */
-const MAX_FILE_BYTES = 1024 * 1024; // 1 MiB
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MiB
 
 /** A NUL byte marks the content as binary, so we refuse to read it as text. */
 const NUL = String.fromCharCode(0);

--- a/packages/server/src/fs/service.ts
+++ b/packages/server/src/fs/service.ts
@@ -35,27 +35,22 @@ type ReadFileError =
   | WorkspaceReadError;
 
 /**
- * `WorkspaceFSService` — read-only file access confined to a caller-supplied
+ * `FileSystemService` — read-only file access confined to a caller-supplied
  * `cwd`. Built on the effect `FileSystem`, but unlike a raw passthrough it
  * enforces a path boundary (lexical + realpath, defeating `..` and symlink
  * escapes) and read guardrails (regular-file-only, size cap, binary rejection).
  * All failures are typed on the effect error channel.
  */
-export class WorkspaceFSService extends Context.Service<
-  WorkspaceFSService,
+export class FileSystemService extends Context.Service<
+  FileSystemService,
   {
     /** Read `path` (relative to `cwd`) as UTF-8 text. */
     readonly readFileString: (cwd: string, path: string) => Effect.Effect<string, ReadFileError>;
-    /** List the entries of the directory `path` (relative to `cwd`). */
-    readonly readDirectory: (
-      cwd: string,
-      path: string,
-    ) => Effect.Effect<ReadonlyArray<string>, WorkspacePathEscape | WorkspaceReadError>;
   }
->()("WorkspaceFSService") {}
+>()("FileSystemService") {}
 
-export const WorkspaceFSServiceLayer: Layer.Layer<WorkspaceFSService> = Layer.effect(
-  WorkspaceFSService,
+export const FileSystemServiceLayer: Layer.Layer<FileSystemService> = Layer.effect(
+  FileSystemService,
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
 
@@ -99,12 +94,6 @@ export const WorkspaceFSServiceLayer: Layer.Layer<WorkspaceFSService> = Layer.ef
             return yield* new WorkspaceBinaryFile({ path });
           }
           return content;
-        }),
-
-      readDirectory: (cwd, path) =>
-        Effect.gen(function* () {
-          const absolute = yield* resolveWithin(cwd, path);
-          return yield* fs.readDirectory(absolute).pipe(Effect.mapError(readErr(path)));
         }),
     };
   }),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,7 +1,7 @@
 import { Layer } from "effect";
 
 import { EventBusLayer } from "./events";
-import { FSServiceLayer } from "./fs";
+import { WorkspaceFSServiceLayer } from "./fs";
 import { GitServiceLayer } from "./git";
 import { McpRepositoryLayer, McpServiceLayer } from "./mcp";
 import { ProjectRepositoryLayer, ProjectServiceLayer } from "./project";
@@ -32,6 +32,6 @@ export const HarnessAgentDomainLayer = Layer.mergeAll(
   ProviderServiceLayer.pipe(Layer.provide(ProviderRepositoryLayer)),
   McpServiceLayer.pipe(Layer.provide(McpRepositoryLayer)),
   EventBusLayer,
-  FSServiceLayer,
+  WorkspaceFSServiceLayer,
   GitServiceLayer,
 );

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,7 +1,7 @@
 import { Layer } from "effect";
 
 import { EventBusLayer } from "./events";
-import { WorkspaceFSServiceLayer } from "./fs";
+import { FileSystemServiceLayer } from "./fs";
 import { GitServiceLayer } from "./git";
 import { McpRepositoryLayer, McpServiceLayer } from "./mcp";
 import { ProjectRepositoryLayer, ProjectServiceLayer } from "./project";
@@ -32,6 +32,6 @@ export const HarnessAgentDomainLayer = Layer.mergeAll(
   ProviderServiceLayer.pipe(Layer.provide(ProviderRepositoryLayer)),
   McpServiceLayer.pipe(Layer.provide(McpRepositoryLayer)),
   EventBusLayer,
-  WorkspaceFSServiceLayer,
+  FileSystemServiceLayer,
   GitServiceLayer,
 );

--- a/packages/server/src/rpc/context.ts
+++ b/packages/server/src/rpc/context.ts
@@ -3,10 +3,10 @@ import type { HarnessAgentSessionService } from "@vibest/harness/runtime";
 import type { FileSystem } from "effect/FileSystem";
 
 import type { EventBus } from "../events";
-import type { WorkspaceFSService } from "../fs";
+import type { FileSystemService } from "../fs";
 import type { ProjectService } from "../project";
 
 /** Services every RPC procedure may `yield*`. */
 export type RpcContext = WithEffectContext<
-  EventBus | FileSystem | HarnessAgentSessionService | ProjectService | WorkspaceFSService
+  EventBus | FileSystem | HarnessAgentSessionService | ProjectService | FileSystemService
 >;

--- a/packages/server/src/rpc/context.ts
+++ b/packages/server/src/rpc/context.ts
@@ -2,6 +2,9 @@ import type { WithEffectContext } from "@orpc/experimental-effect";
 import type { HarnessAgentSessionService } from "@vibest/harness/runtime";
 
 import type { EventBus } from "../events";
+import type { WorkspaceFSService } from "../fs";
 
 /** Services every RPC procedure may `yield*`. */
-export type RpcContext = WithEffectContext<EventBus | HarnessAgentSessionService>;
+export type RpcContext = WithEffectContext<
+  EventBus | HarnessAgentSessionService | WorkspaceFSService
+>;

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -1,11 +1,20 @@
 import "@orpc/experimental-effect/extensions/effect";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
 import { implement } from "@orpc/server";
 import { fsContract } from "@vibest/contract/fs";
+import { Effect } from "effect";
+import { FileSystem } from "effect/FileSystem";
 
+import { FileReadError } from "../errors";
 import { WorkspaceFSService } from "../fs";
 import type { RpcContext } from "./context";
 
 const orpc = implement(fsContract).$context<RpcContext>();
+
+// Directories the folder browser never shows (beyond dotfolders).
+const IGNORED_DIRS = new Set(["node_modules"]);
 
 export const fsRouter = orpc.router({
   readFileString: orpc.readFileString.effect(function* ({ input }) {
@@ -15,6 +24,34 @@ export const fsRouter = orpc.router({
   readDirectory: orpc.readDirectory.effect(function* ({ input }) {
     const fs = yield* WorkspaceFSService;
     return yield* fs.readDirectory(input.cwd, input.path);
+  }),
+  browse: orpc.browse.effect(function* ({ input }) {
+    const fs = yield* FileSystem;
+    const path = resolve(input.path ?? homedir());
+    // Folder-picker policy (owned here, not a shared fs service): directories
+    // only, hide dotfolders and node_modules, sorted by name.
+    const names = yield* fs
+      .readDirectory(path)
+      .pipe(Effect.mapError((cause) => new FileReadError({ path, cause })));
+    const candidates = names.filter((name) => !name.startsWith(".") && !IGNORED_DIRS.has(name));
+    // readDirectory yields names only, so stat each to keep just directories. A
+    // failing stat (e.g. broken symlink) drops that entry rather than the list.
+    const flagged = yield* Effect.forEach(
+      candidates,
+      (name) =>
+        fs.stat(join(path, name)).pipe(
+          Effect.map((info) => info.type === "Directory"),
+          Effect.catch(() => Effect.succeed(false)),
+          Effect.map((isDirectory) => ({ name, isDirectory })),
+        ),
+      { concurrency: "unbounded" },
+    );
+    const directories = flagged
+      .filter((e) => e.isDirectory)
+      .map((e) => ({ name: e.name, path: join(path, e.name) }));
+    directories.sort((a, b) => a.name.localeCompare(b.name));
+    const parent = dirname(path);
+    return { path, parent: parent === path ? null : parent, directories };
   }),
 });
 

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -8,7 +8,7 @@ import { Effect } from "effect";
 import { FileSystem } from "effect/FileSystem";
 
 import { FileReadError } from "../errors";
-import { WorkspaceFSService } from "../fs";
+import { FileSystemService } from "../fs";
 import type { RpcContext } from "./context";
 
 const orpc = implement(fsContract).$context<RpcContext>();
@@ -18,12 +18,8 @@ const IGNORED_DIRS = new Set(["node_modules"]);
 
 export const fsRouter = orpc.router({
   readFileString: orpc.readFileString.effect(function* ({ input }) {
-    const fs = yield* WorkspaceFSService;
+    const fs = yield* FileSystemService;
     return yield* fs.readFileString(input.cwd, input.path);
-  }),
-  readDirectory: orpc.readDirectory.effect(function* ({ input }) {
-    const fs = yield* WorkspaceFSService;
-    return yield* fs.readDirectory(input.cwd, input.path);
   }),
   browse: orpc.browse.effect(function* ({ input }) {
     const fs = yield* FileSystem;

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -7,7 +7,6 @@ import { fsContract } from "@vibest/contract/fs";
 import { Effect } from "effect";
 import { FileSystem } from "effect/FileSystem";
 
-import { FileReadError } from "../errors";
 import { FileSystemService } from "../fs";
 import type { RpcContext } from "./context";
 
@@ -17,18 +16,32 @@ const orpc = implement(fsContract).$context<RpcContext>();
 const IGNORED_DIRS = new Set(["node_modules"]);
 
 export const fsRouter = orpc.router({
-  readFileString: orpc.readFileString.effect(function* ({ input }) {
+  readFileString: orpc.readFileString.effect(function* ({ input, errors }) {
     const fs = yield* FileSystemService;
-    return yield* fs.readFileString(input.cwd, input.path);
+    // Map the service's typed effect errors onto the contract's declared errors,
+    // so the client gets a code + data instead of a generic 500.
+    return yield* fs.readFileString(input.cwd, input.path).pipe(
+      Effect.catchTags({
+        WorkspacePathEscape: (e) =>
+          Effect.fail(errors.PATH_ESCAPE({ data: { cwd: e.cwd, path: e.path } })),
+        WorkspaceNotFile: (e) => Effect.fail(errors.NOT_FILE({ data: { path: e.path } })),
+        WorkspaceFileTooLarge: (e) =>
+          Effect.fail(
+            errors.FILE_TOO_LARGE({ data: { path: e.path, size: e.size, limit: e.limit } }),
+          ),
+        WorkspaceBinaryFile: (e) => Effect.fail(errors.BINARY_FILE({ data: { path: e.path } })),
+        WorkspaceReadError: (e) => Effect.fail(errors.READ_FAILED({ data: { path: e.path } })),
+      }),
+    );
   }),
-  browse: orpc.browse.effect(function* ({ input }) {
+  browse: orpc.browse.effect(function* ({ input, errors }) {
     const fs = yield* FileSystem;
     const path = resolve(input.path ?? homedir());
     // Folder-picker policy (owned here, not a shared fs service): directories
     // only, hide dotfolders and node_modules, sorted by name.
     const names = yield* fs
       .readDirectory(path)
-      .pipe(Effect.mapError((cause) => new FileReadError({ path, cause })));
+      .pipe(Effect.mapError(() => errors.READ_FAILED({ data: { path } })));
     const candidates = names.filter((name) => !name.startsWith(".") && !IGNORED_DIRS.has(name));
     // readDirectory yields names only, so stat each to keep just directories. A
     // failing stat (e.g. broken symlink) drops that entry rather than the list.

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -1,0 +1,21 @@
+import "@orpc/experimental-effect/extensions/effect";
+import { implement } from "@orpc/server";
+import { fsContract } from "@vibest/contract/fs";
+
+import { WorkspaceFSService } from "../fs";
+import type { RpcContext } from "./context";
+
+const orpc = implement(fsContract).$context<RpcContext>();
+
+export const fsRouter = orpc.router({
+  readFileString: orpc.readFileString.effect(function* ({ input }) {
+    const fs = yield* WorkspaceFSService;
+    return yield* fs.readFileString(input.cwd, input.path);
+  }),
+  readDirectory: orpc.readDirectory.effect(function* ({ input }) {
+    const fs = yield* WorkspaceFSService;
+    return yield* fs.readDirectory(input.cwd, input.path);
+  }),
+});
+
+export type FsRouter = typeof fsRouter;

--- a/packages/server/src/rpc/project.ts
+++ b/packages/server/src/rpc/project.ts
@@ -1,20 +1,11 @@
 import "@orpc/experimental-effect/extensions/effect";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-
 import { implement } from "@orpc/server";
 import { projectContract } from "@vibest/contract/project";
-import { Effect } from "effect";
-import { FileSystem } from "effect/FileSystem";
 
-import { FileReadError } from "../errors";
 import { ProjectService } from "../project";
 import type { RpcContext } from "./context";
 
 const orpc = implement(projectContract).$context<RpcContext>();
-
-// Directories the folder browser never shows (beyond dotfolders).
-const IGNORED_DIRS = new Set(["node_modules"]);
 
 export const projectRouter = orpc.router({
   list: orpc.list.effect(function* () {
@@ -24,33 +15,5 @@ export const projectRouter = orpc.router({
   create: orpc.create.effect(function* ({ input }) {
     const projects = yield* ProjectService;
     return yield* projects.create(input);
-  }),
-  listDirectories: orpc.listDirectories.effect(function* ({ input }) {
-    const fs = yield* FileSystem;
-    const path = resolve(input.path ?? homedir());
-    // Folder-picker policy (owned here, not a shared fs service): directories
-    // only, hide dotfolders and node_modules, sorted by name.
-    const names = yield* fs
-      .readDirectory(path)
-      .pipe(Effect.mapError((cause) => new FileReadError({ path, cause })));
-    const candidates = names.filter((name) => !name.startsWith(".") && !IGNORED_DIRS.has(name));
-    // readDirectory yields names only, so stat each to keep just directories. A
-    // failing stat (e.g. broken symlink) drops that entry rather than the list.
-    const flagged = yield* Effect.forEach(
-      candidates,
-      (name) =>
-        fs.stat(join(path, name)).pipe(
-          Effect.map((info) => info.type === "Directory"),
-          Effect.catch(() => Effect.succeed(false)),
-          Effect.map((isDirectory) => ({ name, isDirectory })),
-        ),
-      { concurrency: "unbounded" },
-    );
-    const directories = flagged
-      .filter((e) => e.isDirectory)
-      .map((e) => ({ name: e.name, path: join(path, e.name) }));
-    directories.sort((a, b) => a.name.localeCompare(b.name));
-    const parent = dirname(path);
-    return { path, parent: parent === path ? null : parent, directories };
   }),
 });

--- a/packages/server/src/rpc/router.ts
+++ b/packages/server/src/rpc/router.ts
@@ -1,11 +1,13 @@
 import { os } from "@orpc/server";
 
 import type { RpcContext } from "./context";
+import { fsRouter } from "./fs";
 import { sessionRouter } from "./session";
 
 const orpc = os.$context<RpcContext>();
 
 export const router = orpc.router({
   session: sessionRouter,
+  fs: fsRouter,
 });
 export type Router = typeof router;

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -16,6 +16,7 @@ import {
 import { Context, Effect, Layer } from "effect";
 
 import { EventBusLayer } from "../events";
+import { WorkspaceFSServiceLayer } from "../fs";
 
 export class ClaudeCode extends Context.Service<ClaudeCode, ClaudeCodeAgent>()("ClaudeCode") {}
 export class Codex extends Context.Service<Codex, CodexAgent>()("Codex") {}
@@ -59,4 +60,8 @@ const SessionServiceLayer = HarnessAgentSessionServiceLayer.pipe(
   Layer.provide(EventBusLayer),
 );
 
-export const AgentRuntimeLayer = Layer.merge(EventBusLayer, SessionServiceLayer);
+export const AgentRuntimeLayer = Layer.mergeAll(
+  EventBusLayer,
+  SessionServiceLayer,
+  WorkspaceFSServiceLayer,
+);

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -17,7 +17,7 @@ import { Context, Effect, Layer } from "effect";
 
 import { PathsLayer } from "../config/paths";
 import { EventBusLayer } from "../events";
-import { WorkspaceFSServiceLayer } from "../fs";
+import { FileSystemServiceLayer } from "../fs";
 import { ProjectModuleLayer } from "../project";
 
 export class ClaudeCode extends Context.Service<ClaudeCode, ClaudeCodeAgent>()("ClaudeCode") {}
@@ -65,7 +65,7 @@ const SessionServiceLayer = HarnessAgentSessionServiceLayer.pipe(
 export const AgentRuntimeLayer = Layer.mergeAll(
   EventBusLayer,
   SessionServiceLayer,
-  WorkspaceFSServiceLayer,
+  FileSystemServiceLayer,
   ProjectModuleLayer.pipe(Layer.provide(PathsLayer)),
   NodeFileSystem.layer,
 );

--- a/packages/server/test/fs.test.ts
+++ b/packages/server/test/fs.test.ts
@@ -1,67 +1,83 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { FSService, FSServiceLayer } from "../src/index";
+import { WorkspaceFSService, WorkspaceFSServiceLayer } from "../src/index";
 
-describe("FSService", () => {
-  let dir: string;
+describe("WorkspaceFSService", () => {
+  let cwd: string;
+  let outside: string;
   beforeEach(async () => {
-    dir = await mkdtemp(join(tmpdir(), "vibest-fs-"));
-    await writeFile(join(dir, "a.txt"), "hello\nworld");
-    await mkdir(join(dir, "sub"), { recursive: true });
-    await writeFile(join(dir, "sub", "b.txt"), "foobar");
-    await mkdir(join(dir, "node_modules"), { recursive: true });
-    await writeFile(join(dir, "node_modules", "skip.txt"), "ignored");
+    cwd = await mkdtemp(join(tmpdir(), "vibest-fs-"));
+    outside = await mkdtemp(join(tmpdir(), "vibest-out-"));
+    await writeFile(join(cwd, "a.txt"), "hello\nworld");
+    await mkdir(join(cwd, "sub"), { recursive: true });
+    await writeFile(join(outside, "secret.txt"), "top secret");
+    await symlink(join(outside, "secret.txt"), join(cwd, "link"));
+    await writeFile(join(cwd, "bin"), Buffer.from([104, 0, 105])); // "h\0i"
   });
   afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
+    await rm(cwd, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
   });
 
-  const run = <A, E>(program: Effect.Effect<A, E, FSService>) =>
-    Effect.runPromise(Effect.provide(program, FSServiceLayer));
+  const run = <A, E>(program: Effect.Effect<A, E, WorkspaceFSService>) =>
+    Effect.runPromise(Effect.provide(program, WorkspaceFSServiceLayer));
 
-  it("reads a file", async () => {
-    const content = await run(
-      Effect.gen(function* () {
-        const fs = yield* FSService;
-        return yield* fs.readFile(join(dir, "a.txt"));
-      }),
+  // Run a program expected to fail and surface the error's `_tag` (or a sentinel
+  // if it unexpectedly succeeds).
+  const errorTag = <A, E extends { readonly _tag: string }>(
+    program: Effect.Effect<A, E, WorkspaceFSService>,
+  ) =>
+    run(
+      program.pipe(
+        Effect.match({
+          onFailure: (e) => e._tag,
+          onSuccess: () => "no-error",
+        }),
+      ),
     );
-    expect(content).toBe("hello\nworld");
+
+  const readFile = (path: string) =>
+    Effect.gen(function* () {
+      const fs = yield* WorkspaceFSService;
+      return yield* fs.readFileString(cwd, path);
+    });
+
+  it("reads a file relative to cwd", async () => {
+    expect(await run(readFile("a.txt"))).toBe("hello\nworld");
   });
 
-  it("trees files recursively, skipping node_modules", async () => {
-    const tree = await run(
-      Effect.gen(function* () {
-        const fs = yield* FSService;
-        return yield* fs.tree(dir);
-      }),
-    );
-    expect(new Set(tree)).toEqual(new Set(["a.txt", join("sub", "b.txt")]));
+  it("rejects an absolute path", async () => {
+    expect(await errorTag(readFile(join(outside, "secret.txt")))).toBe("WorkspacePathEscape");
   });
 
-  it("greps file contents", async () => {
-    const matches = await run(
+  it("lists a directory", async () => {
+    const entries = await run(
       Effect.gen(function* () {
-        const fs = yield* FSService;
-        return yield* fs.grep("world", dir);
+        const fs = yield* WorkspaceFSService;
+        return yield* fs.readDirectory(cwd, ".");
       }),
     );
-    expect(matches).toHaveLength(1);
-    expect(matches[0]).toEqual({ file: "a.txt", line: 2, text: "world" });
+    expect(new Set(entries)).toEqual(new Set(["a.txt", "sub", "link", "bin"]));
   });
 
-  it("searches file paths by name", async () => {
-    const found = await run(
-      Effect.gen(function* () {
-        const fs = yield* FSService;
-        return yield* fs.search("b.txt", dir);
-      }),
-    );
-    expect(found).toEqual([join("sub", "b.txt")]);
+  it("rejects a `..` escape", async () => {
+    expect(await errorTag(readFile("../escape.txt"))).toBe("WorkspacePathEscape");
+  });
+
+  it("rejects a symlink pointing outside cwd", async () => {
+    expect(await errorTag(readFile("link"))).toBe("WorkspacePathEscape");
+  });
+
+  it("rejects a directory read as a file", async () => {
+    expect(await errorTag(readFile("sub"))).toBe("WorkspaceNotFile");
+  });
+
+  it("rejects a binary file", async () => {
+    expect(await errorTag(readFile("bin"))).toBe("WorkspaceBinaryFile");
   });
 });

--- a/packages/server/test/fs.test.ts
+++ b/packages/server/test/fs.test.ts
@@ -5,9 +5,9 @@ import { join } from "node:path";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { WorkspaceFSService, WorkspaceFSServiceLayer } from "../src/index";
+import { FileSystemService, FileSystemServiceLayer } from "../src/index";
 
-describe("WorkspaceFSService", () => {
+describe("FileSystemService", () => {
   let cwd: string;
   let outside: string;
   beforeEach(async () => {
@@ -24,13 +24,13 @@ describe("WorkspaceFSService", () => {
     await rm(outside, { recursive: true, force: true });
   });
 
-  const run = <A, E>(program: Effect.Effect<A, E, WorkspaceFSService>) =>
-    Effect.runPromise(Effect.provide(program, WorkspaceFSServiceLayer));
+  const run = <A, E>(program: Effect.Effect<A, E, FileSystemService>) =>
+    Effect.runPromise(Effect.provide(program, FileSystemServiceLayer));
 
   // Run a program expected to fail and surface the error's `_tag` (or a sentinel
   // if it unexpectedly succeeds).
   const errorTag = <A, E extends { readonly _tag: string }>(
-    program: Effect.Effect<A, E, WorkspaceFSService>,
+    program: Effect.Effect<A, E, FileSystemService>,
   ) =>
     run(
       program.pipe(
@@ -43,7 +43,7 @@ describe("WorkspaceFSService", () => {
 
   const readFile = (path: string) =>
     Effect.gen(function* () {
-      const fs = yield* WorkspaceFSService;
+      const fs = yield* FileSystemService;
       return yield* fs.readFileString(cwd, path);
     });
 
@@ -53,16 +53,6 @@ describe("WorkspaceFSService", () => {
 
   it("rejects an absolute path", async () => {
     expect(await errorTag(readFile(join(outside, "secret.txt")))).toBe("WorkspacePathEscape");
-  });
-
-  it("lists a directory", async () => {
-    const entries = await run(
-      Effect.gen(function* () {
-        const fs = yield* WorkspaceFSService;
-        return yield* fs.readDirectory(cwd, ".");
-      }),
-    );
-    expect(new Set(entries)).toEqual(new Set(["a.txt", "sub", "link", "bin"]));
   });
 
   it("rejects a `..` escape", async () => {

--- a/packages/server/test/rpc-fs.test.ts
+++ b/packages/server/test/rpc-fs.test.ts
@@ -1,0 +1,33 @@
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { makeRpcTestHarness } from "./rpc-harness";
+
+describe("fs router", () => {
+  it("browses sorted subdirectories with parent, hiding dotfolders and node_modules", async () => {
+    const home = mkdtempSync(join(tmpdir(), "vibest-home-"));
+    const dir = mkdtempSync(join(tmpdir(), "vibest-browse-"));
+    mkdirSync(join(dir, "beta"));
+    mkdirSync(join(dir, "alpha"));
+    mkdirSync(join(dir, ".hidden"));
+    mkdirSync(join(dir, "node_modules"));
+    const h = makeRpcTestHarness(home);
+    try {
+      const listing = await h.client.fs.browse({ path: dir });
+      expect(listing.path).toBe(dir);
+      expect(listing.parent).toBe(dirname(dir));
+      expect(listing.directories).toEqual([
+        { name: "alpha", path: join(dir, "alpha") },
+        { name: "beta", path: join(dir, "beta") },
+      ]);
+
+      const root = await h.client.fs.browse({ path: "/" });
+      expect(root.parent).toBeNull();
+    } finally {
+      await h.dispose();
+    }
+  });
+});

--- a/packages/server/test/rpc-project.test.ts
+++ b/packages/server/test/rpc-project.test.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, mkdtempSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -19,30 +19,6 @@ describe("project router", () => {
       expect(again.id).toBe(created.id);
 
       await expect(h.client.project.list()).resolves.toEqual([created]);
-    } finally {
-      await h.dispose();
-    }
-  });
-
-  it("browses sorted subdirectories with parent, hiding dotfolders and node_modules", async () => {
-    const home = mkdtempSync(join(tmpdir(), "vibest-home-"));
-    const dir = mkdtempSync(join(tmpdir(), "vibest-browse-"));
-    mkdirSync(join(dir, "beta"));
-    mkdirSync(join(dir, "alpha"));
-    mkdirSync(join(dir, ".hidden"));
-    mkdirSync(join(dir, "node_modules"));
-    const h = makeRpcTestHarness(home);
-    try {
-      const listing = await h.client.project.listDirectories({ path: dir });
-      expect(listing.path).toBe(dir);
-      expect(listing.parent).toBe(dirname(dir));
-      expect(listing.directories).toEqual([
-        { name: "alpha", path: join(dir, "alpha") },
-        { name: "beta", path: join(dir, "beta") },
-      ]);
-
-      const root = await h.client.project.listDirectories({ path: "/" });
-      expect(root.parent).toBeNull();
     } finally {
       await h.dispose();
     }


### PR DESCRIPTION
## What

Adds an `fs` RPC group backed by a new `WorkspaceFSService`, built on the effect `FileSystem` (not raw `node:fs`). The app gets `fs.readFileString` / `fs.readDirectory` on the typed client automatically (derived from the contract).

## Security model

Every read is confined to a caller-supplied `cwd`, mirroring the path-boundary approach used by opencode (`FSUtil.contains`) and t3code (`WorkspacePaths` + double-realpath):

- `path` is resolved against `cwd`; rejected if **absolute** or escaping via `..`
- `cwd` and the target are both `realpath`'d and re-checked → **defeats symlink escapes**
- `cwd` itself must be absolute (the trusted root)
- read guardrails: **regular-file-only**, **1 MiB size cap** (rejected, not truncated), **NUL-byte binary rejection**
- all failures are typed on the effect error channel (`WorkspacePathEscape`, `WorkspaceNotFile`, `WorkspaceFileTooLarge`, `WorkspaceBinaryFile`, `WorkspaceReadError`)

## API

```ts
await client.fs.readFileString({ cwd, path: "src/index.ts" });
await client.fs.readDirectory({ cwd, path: "." });
```

## Tests

`packages/server/test/fs.test.ts` covers: normal read, directory listing, and rejection of `..` traversal, absolute paths, symlink escapes, directory-as-file, and binary files.

## Follow-ups (not in this PR)

- `browse` endpoint for project import (rootless, returns only `{ name, isDirectory }`, no file contents)
- Origin allowlist on the WS upgrade — the compensating control for browser mode, where `cwd` is client-chosen and there is no token