### PR TITLE
feat(session): persist session metadata to disk

### DIFF
--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -363,9 +363,9 @@ export const CreateManagedSessionResultSchema = Schema.Struct({
   sessionId: Schema.String,
   harnessAgentId: HarnessAgentIdSchema,
   // Backend session id (claude-code SDK session / codex threadId). Distinct from
-  // the vibest-internal `sessionId`; used to resume the backend. `optionalKey`
-  // until the runtime is wired to surface it (see SessionRecord below).
-  harnessSessionId: Schema.optionalKey(Schema.String),
+  // the vibest-internal `sessionId`; used to resume the backend. Always present
+  // on a freshly created session — the adapter opens the backend eagerly.
+  harnessSessionId: Schema.String,
 });
 export type CreateManagedSessionResult = typeof CreateManagedSessionResultSchema.Type;
 
@@ -373,9 +373,10 @@ export const ResumeManagedSessionInputSchema = Schema.Struct({
   sessionId: Schema.String,
   harnessAgentId: HarnessAgentIdSchema,
   workspacePath: Schema.optionalKey(Schema.String),
-  // The backend id to hand the adapter. When absent, callers fall back to
-  // `sessionId` (legacy behaviour, where the two were the same value).
-  harnessSessionId: Schema.optionalKey(Schema.String),
+  // The backend id to hand the adapter. Required — the caller resumes from a
+  // listed session, which always carries it (a session with no backend id was
+  // never opened and can only be created, not resumed).
+  harnessSessionId: Schema.String,
 });
 export type ResumeManagedSessionInput = typeof ResumeManagedSessionInputSchema.Type;
 
@@ -406,9 +407,9 @@ export type ListSessionsInput = typeof ListSessionsInputSchema.Type;
 
 /**
  * A session list item: the persisted record plus display fields merged live
- * from the backend. `harnessMissing` is derived (backend has no record for
- * `harnessSessionId`) — never persisted. `title`/`updatedAt` are absent until
- * the adapter surfaces session info (phase 2).
+ * from the backend. `transcriptMissing` is derived (the backend no longer has
+ * the transcript behind `harnessSessionId`) — never persisted. `title`/
+ * `updatedAt` are absent until the adapter surfaces session info (phase 2).
  */
 export const SessionSummarySchema = Schema.Struct({
   sessionId: Schema.String,
@@ -420,7 +421,7 @@ export const SessionSummarySchema = Schema.Struct({
   createdAt: Schema.String,
   title: Schema.optionalKey(Schema.String),
   updatedAt: Schema.optionalKey(Schema.Number),
-  harnessMissing: Schema.Boolean,
+  transcriptMissing: Schema.Boolean,
 });
 export type SessionSummary = typeof SessionSummarySchema.Type;
 

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -362,6 +362,10 @@ export type CreateManagedSessionInput = typeof CreateManagedSessionInputSchema.T
 export const CreateManagedSessionResultSchema = Schema.Struct({
   sessionId: Schema.String,
   harnessAgentId: HarnessAgentIdSchema,
+  // Backend session id (claude-code SDK session / codex threadId). Distinct from
+  // the vibest-internal `sessionId`; used to resume the backend. `optionalKey`
+  // until the runtime is wired to surface it (see SessionRecord below).
+  harnessSessionId: Schema.optionalKey(Schema.String),
 });
 export type CreateManagedSessionResult = typeof CreateManagedSessionResultSchema.Type;
 
@@ -369,8 +373,56 @@ export const ResumeManagedSessionInputSchema = Schema.Struct({
   sessionId: Schema.String,
   harnessAgentId: HarnessAgentIdSchema,
   workspacePath: Schema.optionalKey(Schema.String),
+  // The backend id to hand the adapter. When absent, callers fall back to
+  // `sessionId` (legacy behaviour, where the two were the same value).
+  harnessSessionId: Schema.optionalKey(Schema.String),
 });
 export type ResumeManagedSessionInput = typeof ResumeManagedSessionInputSchema.Type;
+
+/**
+ * Persisted session metadata — vibest's own record, one file per session at
+ * `storage/sessions/<projectId>/<sessionId>.json`. Holds only what the backend
+ * harness cannot: the vibest-internal id, its mapping to the backend id, the
+ * owning project, the workspace it was opened against, and vibest-owned state
+ * (`archived`). Display data (title, timestamps) is fetched live from the
+ * backend and merged at list time — never persisted here, to avoid drift.
+ */
+export const SessionRecordSchema = Schema.Struct({
+  /** vibest-internal id (uuid v7) — the file name and primary key. */
+  sessionId: Schema.String,
+  /** Backend id used to resume; absent for a draft not yet opened. */
+  harnessSessionId: Schema.optionalKey(Schema.String),
+  harnessAgentId: HarnessAgentIdSchema,
+  projectId: Schema.String,
+  /** Workspace path the session was opened against (the backend's cwd key). */
+  cwd: Schema.String,
+  archived: Schema.Boolean,
+  createdAt: Schema.String,
+});
+export type SessionRecord = typeof SessionRecordSchema.Type;
+
+export const ListSessionsInputSchema = Schema.Struct({ projectId: Schema.String });
+export type ListSessionsInput = typeof ListSessionsInputSchema.Type;
+
+/**
+ * A session list item: the persisted record plus display fields merged live
+ * from the backend. `harnessMissing` is derived (backend has no record for
+ * `harnessSessionId`) — never persisted. `title`/`updatedAt` are absent until
+ * the adapter surfaces session info (phase 2).
+ */
+export const SessionSummarySchema = Schema.Struct({
+  sessionId: Schema.String,
+  harnessSessionId: Schema.optionalKey(Schema.String),
+  harnessAgentId: HarnessAgentIdSchema,
+  projectId: Schema.String,
+  cwd: Schema.String,
+  archived: Schema.Boolean,
+  createdAt: Schema.String,
+  title: Schema.optionalKey(Schema.String),
+  updatedAt: Schema.optionalKey(Schema.Number),
+  harnessMissing: Schema.Boolean,
+});
+export type SessionSummary = typeof SessionSummarySchema.Type;
 
 export const SessionIdInputSchema = Schema.Struct({ sessionId: Schema.String });
 export const PromptSessionInputSchema = Schema.Struct({

--- a/packages/contract/src/session.ts
+++ b/packages/contract/src/session.ts
@@ -1,8 +1,10 @@
 import { eventIterator, oc, type } from "@orpc/contract";
+import { Schema } from "effect";
 
 import {
   CreateManagedSessionInputSchema,
   CreateManagedSessionResultSchema,
+  ListSessionsInputSchema,
   PromptReceiptSchema,
   PromptSessionInputSchema,
   RespondToAgentRequestInputSchema,
@@ -10,6 +12,7 @@ import {
   SessionCapabilitiesSchema,
   SessionEventsInputSchema,
   SessionIdInputSchema,
+  SessionSummarySchema,
   toStandardSchema,
   type SessionEnvelope,
   type SessionSnapshot,
@@ -21,6 +24,10 @@ export type SessionEventStreamItem =
   | { readonly type: "gap"; readonly cursor: number; readonly terminal: boolean };
 
 export const sessionContract = {
+  /** vibest's persisted sessions for a project, merged with live backend display data. */
+  list: oc
+    .input(toStandardSchema(ListSessionsInputSchema))
+    .output(toStandardSchema(Schema.Array(SessionSummarySchema))),
   create: oc
     .input(toStandardSchema(CreateManagedSessionInputSchema))
     .output(toStandardSchema(CreateManagedSessionResultSchema)),

--- a/packages/harness/src/claude-code/agent.ts
+++ b/packages/harness/src/claude-code/agent.ts
@@ -74,6 +74,16 @@ export interface ClaudeCodeAgent {
     readonly resume: (
       sessionId: string,
     ) => Effect.Effect<{ readonly sessionId: string }, ClaudeAgentFailure>;
+    /**
+     * Reads stored session metadata (title, recency) from the SDK's on-disk
+     * history without opening a live session — `null` when it's unknown. `dir`
+     * scopes the lookup to a workspace. Lets persisted sessions get live display
+     * data, so the adapter never has to reach into the SDK itself.
+     */
+    readonly getSessionInfo: (
+      sessionId: string,
+      options?: { readonly dir?: string },
+    ) => Effect.Effect<ClaudeSessionInfo, ClaudeSdkError>;
     readonly prompt: (input: {
       readonly sessionId: string;
       readonly message: sdk.SDKUserMessage["message"];
@@ -538,6 +548,11 @@ export const makeClaudeCodeAgent = ({
             }
             yield* Deferred.succeed(pending.deferred, result);
             return true;
+          }),
+        getSessionInfo: (sessionId, options) =>
+          Effect.tryPromise<ClaudeSessionInfo, ClaudeSdkError>({
+            try: () => getSessionInfo(sessionId, options?.dir ? { dir: options.dir } : undefined),
+            catch: (cause) => sdkError("get-session-info", cause),
           }),
         setModel: (sessionId, model) =>
           callQuery(sessionId, "set-model", (sdkQuery) => sdkQuery.setModel(model)),

--- a/packages/harness/src/claude-code/runtime/adapter.ts
+++ b/packages/harness/src/claude-code/runtime/adapter.ts
@@ -1,5 +1,4 @@
 import type * as sdk from "@anthropic-ai/claude-agent-sdk";
-import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
 import { Effect, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 
@@ -400,21 +399,20 @@ export const makeClaudeCodeAdapter = (agent: ClaudeCodeAgent): HarnessAgentAdapt
       Effect.flatMap(({ sessionId }) => makeSession(agent, sessionId)),
     ),
   getSessionInfo: (harnessSessionId, workspacePath) =>
-    Effect.tryPromise({
-      try: () =>
-        getSessionInfo(harnessSessionId, workspacePath ? { dir: workspacePath } : undefined),
-      catch: (cause) => operationError(harnessSessionId, "get-session-info", cause),
-    }).pipe(
-      Effect.map(
-        (info): SessionInfoResult =>
-          info
-            ? {
-                _tag: "found",
-                // customTitle (user /rename) wins over the auto summary; both fall
-                // back to undefined title if empty.
-                info: { title: info.customTitle ?? info.summary, updatedAt: info.lastModified },
-              }
-            : { _tag: "missing" },
+    agent.session
+      .getSessionInfo(harnessSessionId, workspacePath ? { dir: workspacePath } : undefined)
+      .pipe(
+        Effect.mapError((cause) => operationError(harnessSessionId, "get-session-info", cause)),
+        Effect.map(
+          (info): SessionInfoResult =>
+            info
+              ? {
+                  _tag: "found",
+                  // customTitle (user /rename) wins over the auto summary; both fall
+                  // back to undefined title if empty.
+                  info: { title: info.customTitle ?? info.summary, updatedAt: info.lastModified },
+                }
+              : { _tag: "missing" },
+        ),
       ),
-    ),
 });

--- a/packages/harness/src/claude-code/runtime/adapter.ts
+++ b/packages/harness/src/claude-code/runtime/adapter.ts
@@ -1,4 +1,5 @@
 import type * as sdk from "@anthropic-ai/claude-agent-sdk";
+import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
 import { Effect, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 
@@ -7,6 +8,7 @@ import type {
   HarnessAgentAdapter,
   HarnessAgentSession,
   SessionCapabilities,
+  SessionInfoResult,
   UserInput,
 } from "../../runtime/adapter";
 import {
@@ -396,5 +398,23 @@ export const makeClaudeCodeAdapter = (agent: ClaudeCodeAgent): HarnessAgentAdapt
           : new AgentOpenError({ harnessAgentId: "claude-code", cause }),
       ),
       Effect.flatMap(({ sessionId }) => makeSession(agent, sessionId)),
+    ),
+  getSessionInfo: (harnessSessionId, workspacePath) =>
+    Effect.tryPromise({
+      try: () =>
+        getSessionInfo(harnessSessionId, workspacePath ? { dir: workspacePath } : undefined),
+      catch: (cause) => operationError(harnessSessionId, "get-session-info", cause),
+    }).pipe(
+      Effect.map(
+        (info): SessionInfoResult =>
+          info
+            ? {
+                _tag: "found",
+                // customTitle (user /rename) wins over the auto summary; both fall
+                // back to undefined title if empty.
+                info: { title: info.customTitle ?? info.summary, updatedAt: info.lastModified },
+              }
+            : { _tag: "missing" },
+      ),
     ),
 });

--- a/packages/harness/src/codex/agent.ts
+++ b/packages/harness/src/codex/agent.ts
@@ -13,6 +13,7 @@ import { drainQueue, streamFromQueueOne } from "../runtime/queue-stream";
 import type { AgentRequest, AgentResponse } from "../types/request";
 import type { ServerNotification, ServerRequest } from "./protocol";
 import type {
+  ThreadReadResponse,
   ThreadResumeResponse,
   ThreadStartResponse,
   TurnStartResponse,
@@ -123,6 +124,14 @@ export interface CodexAgent {
       readonly sessionId: string;
       readonly workspacePath?: string;
     }) => Effect.Effect<{ readonly sessionId: string }, CodexTransportFailure>;
+    /**
+     * Reads a thread's stored metadata (title, recency) straight from the
+     * app-server's history — works for threads that aren't loaded as live
+     * sessions, so persisted sessions can be given live display data.
+     */
+    readonly read: (config: {
+      readonly sessionId: string;
+    }) => Effect.Effect<ThreadReadResponse["thread"], CodexTransportFailure>;
     readonly prompt: (input: {
       readonly sessionId: string;
       readonly text: string;
@@ -550,6 +559,14 @@ export const makeCodexAgentWithDependencies = <R>(
               sandbox: "workspace-write",
             });
             return yield* registerSession(response.thread.id, generation);
+          }),
+        read: (config) =>
+          Effect.gen(function* () {
+            const transport = yield* holder.ensure;
+            const response = yield* transport.request<ThreadReadResponse>("thread/read", {
+              threadId: config.sessionId,
+            });
+            return response.thread;
           }),
         prompt: (input) =>
           Effect.gen(function* () {

--- a/packages/harness/src/codex/runtime/adapter.ts
+++ b/packages/harness/src/codex/runtime/adapter.ts
@@ -2,7 +2,12 @@ import { Effect, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 
 import type { SessionEvent } from "../../event-manifest";
-import type { HarnessAgentAdapter, HarnessAgentSession, UserInput } from "../../runtime/adapter";
+import type {
+  HarnessAgentAdapter,
+  HarnessAgentSession,
+  SessionInfoResult,
+  UserInput,
+} from "../../runtime/adapter";
 import {
   AgentOpenError,
   AgentOperationError,
@@ -224,4 +229,7 @@ export const makeCodexAdapter = (agent: CodexAgent): HarnessAgentAdapter => ({
       ),
       Effect.flatMap(({ sessionId }) => makeSession(agent, sessionId)),
     ),
+  // TODO: codex exposes thread title via thread/list|read on the app-server;
+  // surface it here so persisted codex sessions get live display data too.
+  getSessionInfo: () => Effect.succeed<SessionInfoResult>({ _tag: "unsupported" }),
 });

--- a/packages/harness/src/codex/runtime/adapter.ts
+++ b/packages/harness/src/codex/runtime/adapter.ts
@@ -12,6 +12,7 @@ import {
   AgentOpenError,
   AgentOperationError,
   AgentRequestUnavailable,
+  CodexRpcError,
   SessionClosed,
   SessionNotResumable,
   TurnAlreadyRunning,
@@ -229,7 +230,25 @@ export const makeCodexAdapter = (agent: CodexAgent): HarnessAgentAdapter => ({
       ),
       Effect.flatMap(({ sessionId }) => makeSession(agent, sessionId)),
     ),
-  // TODO: codex exposes thread title via thread/list|read on the app-server;
-  // surface it here so persisted codex sessions get live display data too.
-  getSessionInfo: () => Effect.succeed<SessionInfoResult>({ _tag: "unsupported" }),
+  getSessionInfo: (harnessSessionId) =>
+    agent.session.read({ sessionId: harnessSessionId }).pipe(
+      Effect.map((thread): SessionInfoResult => {
+        const title = thread.name ?? thread.preview;
+        return {
+          _tag: "found",
+          info: {
+            ...(title ? { title } : {}),
+            // Codex reports thread timestamps in seconds; callers expect ms.
+            updatedAt: thread.updatedAt * 1000,
+          },
+        };
+      }),
+      // A well-formed "not found" reply means the thread's history is gone;
+      // any other transport failure is a real error the caller degrades.
+      Effect.catch((cause) =>
+        cause instanceof CodexRpcError
+          ? Effect.succeed<SessionInfoResult>({ _tag: "missing" })
+          : Effect.fail(operationError(harnessSessionId, "get-session-info", cause)),
+      ),
+    ),
 });

--- a/packages/harness/src/pi/runtime/adapter.ts
+++ b/packages/harness/src/pi/runtime/adapter.ts
@@ -2,7 +2,12 @@ import { Effect, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 
 import type { SessionEvent } from "../../event-manifest";
-import type { HarnessAgentAdapter, HarnessAgentSession, UserInput } from "../../runtime/adapter";
+import type {
+  HarnessAgentAdapter,
+  HarnessAgentSession,
+  SessionInfoResult,
+  UserInput,
+} from "../../runtime/adapter";
 import {
   AgentOpenError,
   AgentOperationError,
@@ -227,4 +232,5 @@ export const makePiAdapter = (agent: PiAgent): HarnessAgentAdapter => ({
       ),
       Effect.flatMap(({ sessionId }) => makeSession(agent, sessionId)),
     ),
+  getSessionInfo: () => Effect.succeed<SessionInfoResult>({ _tag: "unsupported" }),
 });

--- a/packages/harness/src/runtime/adapter.ts
+++ b/packages/harness/src/runtime/adapter.ts
@@ -49,6 +49,23 @@ export type AvailabilityResult = {
   readonly reason?: string;
 };
 
+/** Live display data for a session, fetched from the backend at list time. */
+export type HarnessSessionInfo = {
+  readonly title?: string;
+  readonly updatedAt?: number;
+};
+
+/**
+ * Result of looking up a persisted session's backend info:
+ * - `found`       — backend still has it; `info` carries display fields
+ * - `missing`     — backend transcript is gone (deleted); not resumable
+ * - `unsupported` — this adapter can't query session info (treat as unknown)
+ */
+export type SessionInfoResult =
+  | { readonly _tag: "found"; readonly info: HarnessSessionInfo }
+  | { readonly _tag: "missing" }
+  | { readonly _tag: "unsupported" };
+
 export interface HarnessAgentSession {
   readonly sessionId: string;
   readonly harnessAgentId: HarnessAgentId;
@@ -86,4 +103,12 @@ export interface HarnessAgentAdapter {
     SessionNotResumable | AgentUnavailable | ExecutableNotFound | AgentOpenError,
     Scope.Scope
   >;
+  /**
+   * Look up live display info for a persisted session by backend id, without
+   * opening it. `workspacePath` (the session's cwd) narrows the backend search.
+   */
+  readonly getSessionInfo: (
+    harnessSessionId: string,
+    workspacePath?: string,
+  ) => Effect.Effect<SessionInfoResult, AgentOperationError>;
 }

--- a/packages/harness/src/runtime/session-service.ts
+++ b/packages/harness/src/runtime/session-service.ts
@@ -362,9 +362,8 @@ export const makeHarnessAgentSessionService = (
             mode._tag === "Open"
               ? adapter.open(mode.input)
               : adapter.resume({
-                  // Adapters resume by backend id; fall back to `sessionId` for
-                  // legacy records written before the two were split.
-                  sessionId: mode.input.harnessSessionId ?? mode.input.sessionId,
+                  // Adapters resume by backend id, distinct from our internal id.
+                  sessionId: mode.input.harnessSessionId,
                   workspacePath: mode.input.workspacePath,
                 })
           ).pipe(Effect.provideService(Scope.Scope, sessionScope));

--- a/packages/harness/src/runtime/session-service.ts
+++ b/packages/harness/src/runtime/session-service.ts
@@ -10,6 +10,7 @@ import type {
   HarnessAgentSession,
   PromptReceipt,
   SessionCapabilities,
+  SessionInfoResult,
   UserInput,
 } from "./adapter";
 import {
@@ -19,6 +20,7 @@ import {
   AgentUnavailable,
   CapabilityUnsupported,
   type CreateSessionError,
+  type HarnessAgentNotFound,
   type ResumeSessionError,
   SessionClosed,
   SessionNotFound,
@@ -46,6 +48,11 @@ type Projection = {
 };
 
 type ManagedSession = {
+  /** vibest-internal id — the `active`/`inFlight`/`closing` map key and the id
+   *  every envelope and cold operation uses. */
+  readonly sessionId: string;
+  /** Backend id (`session.sessionId`) — what the adapter needs to resume. */
+  readonly harnessSessionId: string;
   readonly session: HarnessAgentSession;
   readonly scope: Scope.Closeable;
   readonly pump: Fiber.Fiber<void>;
@@ -118,6 +125,13 @@ export type HarnessAgentSessionServiceShape = {
   readonly getStatus: (sessionId: string) => Effect.Effect<SessionStatus, SessionNotFound>;
   readonly getSnapshot: (sessionId: string) => Effect.Effect<SessionSnapshot, SessionNotFound>;
   readonly close: (sessionId: string) => Effect.Effect<void>;
+  /** Look up live backend display info for a persisted session (cold — the
+   *  session need not be active). Delegates to the owning adapter. */
+  readonly getSessionInfo: (
+    harnessAgentId: HarnessAgentId,
+    harnessSessionId: string,
+    workspacePath?: string,
+  ) => Effect.Effect<SessionInfoResult, HarnessAgentNotFound | AgentOperationError>;
 };
 
 export class HarnessAgentSessionService extends Context.Service<
@@ -232,6 +246,7 @@ export const makeHarnessAgentSessionService = (
         );
 
     const startManaged = (
+      sessionId: string,
       session: HarnessAgentSession,
       sessionScope: Scope.Closeable,
     ): Effect.Effect<{
@@ -242,15 +257,19 @@ export const makeHarnessAgentSessionService = (
         const projection = yield* Ref.make(initialProjection());
         const pumpDone = yield* Deferred.make<void>();
         const activation = yield* Deferred.make<void>();
+        // The adapter stamps envelopes with its backend id; rewrite them to the
+        // vibest-internal id so everything downstream (subscribers, cold ops)
+        // speaks one id.
+        const events = session.events.pipe(Stream.map((draft) => ({ ...draft, sessionId })));
         const pumpEffect = Deferred.await(activation).pipe(
-          Effect.andThen(Stream.runForEach(session.events, (draft) => publish(projection, draft))),
+          Effect.andThen(Stream.runForEach(events, (draft) => publish(projection, draft))),
           Effect.catch((error) =>
             publish(projection, {
               harnessAgentId: session.harnessAgentId,
-              sessionId: session.sessionId,
+              sessionId,
               body: {
                 type: "session.crashed",
-                sessionId: session.sessionId,
+                sessionId,
                 reason: error.message,
               },
             }),
@@ -261,7 +280,7 @@ export const makeHarnessAgentSessionService = (
                 Ref.get(projection).pipe(
                   Effect.flatMap((current) =>
                     current.status.status === "crashed"
-                      ? Effect.forkIn(close(session.sessionId), ownerScope).pipe(Effect.asVoid)
+                      ? Effect.forkIn(close(sessionId), ownerScope).pipe(Effect.asVoid)
                       : Effect.void,
                   ),
                 ),
@@ -271,20 +290,28 @@ export const makeHarnessAgentSessionService = (
         );
         const pump = yield* Effect.forkIn(pumpEffect, sessionScope);
         return {
-          managed: { session, scope: sessionScope, pump, pumpDone, projection },
+          managed: {
+            sessionId,
+            harnessSessionId: session.sessionId,
+            session,
+            scope: sessionScope,
+            pump,
+            pumpDone,
+            projection,
+          },
           activate: Deferred.succeed(activation, undefined).pipe(Effect.asVoid),
         };
       });
 
     const register = (candidate: ManagedSession) =>
       Ref.modify(state, (current) => {
-        const existing = current.active.get(candidate.session.sessionId);
+        const existing = current.active.get(candidate.sessionId);
         if (existing) return [existing, current] as const;
         return [
           candidate,
           {
             ...current,
-            active: new Map(current.active).set(candidate.session.sessionId, candidate),
+            active: new Map(current.active).set(candidate.sessionId, candidate),
           },
         ] as const;
       }).pipe(
@@ -328,15 +355,20 @@ export const makeHarnessAgentSessionService = (
         const adapter = yield* checkAvailable(harnessAgentId);
         const sessionScope = yield* Scope.fork(ownerScope, "sequential");
         return yield* Effect.gen(function* () {
+          // vibest-internal id: freshly minted on open, or the caller's own id on
+          // resume. Distinct from the adapter's backend id (`session.sessionId`).
+          const sessionId = mode._tag === "Open" ? uuid() : mode.input.sessionId;
           const session = yield* (
             mode._tag === "Open"
               ? adapter.open(mode.input)
               : adapter.resume({
-                  sessionId: mode.input.sessionId,
+                  // Adapters resume by backend id; fall back to `sessionId` for
+                  // legacy records written before the two were split.
+                  sessionId: mode.input.harnessSessionId ?? mode.input.sessionId,
                   workspacePath: mode.input.workspacePath,
                 })
           ).pipe(Effect.provideService(Scope.Scope, sessionScope));
-          const candidate = yield* startManaged(session, sessionScope);
+          const candidate = yield* startManaged(sessionId, session, sessionScope);
           const managed = yield* register(candidate.managed);
           if (managed === candidate.managed) yield* candidate.activate;
           return managed;
@@ -487,7 +519,8 @@ export const makeHarnessAgentSessionService = (
       create: (harnessAgentId, input) =>
         build({ _tag: "Open", harnessAgentId, input }).pipe(
           Effect.map((managed) => ({
-            sessionId: managed.session.sessionId,
+            sessionId: managed.sessionId,
+            harnessSessionId: managed.harnessSessionId,
             harnessAgentId: managed.session.harnessAgentId,
           })),
           Effect.mapError((error) =>
@@ -544,6 +577,12 @@ export const makeHarnessAgentSessionService = (
           ),
         ),
       close,
+      getSessionInfo: (harnessAgentId, harnessSessionId, workspacePath) =>
+        registry
+          .get(harnessAgentId)
+          .pipe(
+            Effect.flatMap((adapter) => adapter.getSessionInfo(harnessSessionId, workspacePath)),
+          ),
     } satisfies HarnessAgentSessionServiceShape;
   });
 

--- a/packages/harness/src/types/session.ts
+++ b/packages/harness/src/types/session.ts
@@ -1,13 +1,7 @@
 export type { SessionSnapshot, SessionStatus } from "@vibest/contract";
 
-export type SessionSummary = {
-  sessionId: string;
-  harnessAgentId: import("@vibest/contract").HarnessAgentId;
-  title?: string;
-  archived: boolean;
-  createdAt: string;
-  updatedAt: string;
-};
+// The session record/summary shape is owned by @vibest/contract
+// (`SessionRecord` / `SessionSummary`); no local placeholder here.
 
 export type UserInput = { text: string };
 export type CreateSessionConfig = { workspacePath: string };

--- a/packages/harness/test/codex/agent.test.ts
+++ b/packages/harness/test/codex/agent.test.ts
@@ -82,6 +82,14 @@ rl.on("line", (line) => {
     send({ id: msg.id, result: null });
   }
   if (msg.method === "thread/unsubscribe") send({ id: msg.id, result: null });
+  if (msg.method === "thread/read") {
+    if (msg.params.threadId === "th_missing") {
+      send({ id: msg.id, error: { code: -32000, message: "thread not found" } });
+      return;
+    }
+    const name = msg.params.threadId === "th_untitled" ? null : "My Thread";
+    send({ id: msg.id, result: { thread: { id: msg.params.threadId, name, preview: "first message", updatedAt: 1700 } } });
+  }
 });
 `;
 
@@ -186,6 +194,36 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
         ["start", "text-start", "text-delta", "text-end", "data-turn/completed", "finish"],
       );
       yield* agent.session.abort(sessionId);
+    }),
+  );
+
+  it.effect("surfaces thread metadata as session info", () =>
+    Effect.gen(function* () {
+      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const result = yield* makeCodexAdapter(agent).getSessionInfo("th_1");
+      NodeAssert.equal(result._tag, "found");
+      if (result._tag === "found") {
+        NodeAssert.equal(result.info.title, "My Thread");
+        // Codex timestamps are seconds; the adapter reports milliseconds.
+        NodeAssert.equal(result.info.updatedAt, 1_700_000);
+      }
+    }),
+  );
+
+  it.effect("falls back to the thread preview when it has no title", () =>
+    Effect.gen(function* () {
+      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const result = yield* makeCodexAdapter(agent).getSessionInfo("th_untitled");
+      NodeAssert.equal(result._tag, "found");
+      if (result._tag === "found") NodeAssert.equal(result.info.title, "first message");
+    }),
+  );
+
+  it.effect("maps an unknown thread to missing session info", () =>
+    Effect.gen(function* () {
+      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const result = yield* makeCodexAdapter(agent).getSessionInfo("th_missing");
+      NodeAssert.equal(result._tag, "missing");
     }),
   );
 

--- a/packages/harness/test/runtime/registry.test.ts
+++ b/packages/harness/test/runtime/registry.test.ts
@@ -10,6 +10,7 @@ const claude = {
   id: "claude-code",
   descriptor: { id: "claude-code", name: "Claude Code" },
   checkAvailability: Effect.succeed({ available: true }),
+  getSessionInfo: () => Effect.succeed({ _tag: "unsupported" as const }),
   open: () => Effect.die("not used"),
   resume: () => Effect.die("not used"),
 } satisfies HarnessAgentAdapter;

--- a/packages/harness/test/runtime/session-service.test.ts
+++ b/packages/harness/test/runtime/session-service.test.ts
@@ -98,6 +98,7 @@ const makeFixture = Effect.gen(function* () {
     id: "claude-code",
     descriptor: { id: "claude-code", name: "Claude Code" },
     checkAvailability: Effect.succeed({ available: true }),
+    getSessionInfo: () => Effect.succeed({ _tag: "unsupported" as const }),
     open: () => makeSession("created-session"),
     resume: ({ sessionId }) =>
       Ref.update(resumeCalls, (current) => current + 1).pipe(

--- a/packages/harness/test/runtime/session-service.test.ts
+++ b/packages/harness/test/runtime/session-service.test.ts
@@ -183,7 +183,11 @@ it.effect("tears down a session after its event stream reports a crash", () =>
 it.effect("single-flights resume in owner scope when the first waiter cancels", () =>
   Effect.gen(function* () {
     const fixture = yield* makeFixture;
-    const input = { sessionId: "resumed-session", harnessAgentId: "claude-code" } as const;
+    const input = {
+      sessionId: "resumed-session",
+      harnessAgentId: "claude-code",
+      harnessSessionId: "resumed-backend",
+    } as const;
     const first = yield* Effect.forkChild(fixture.service.resume(input));
     const second = yield* Effect.forkChild(fixture.service.resume(input));
 
@@ -223,6 +227,7 @@ it.effect("waits for an in-flight close before resuming the same session id", ()
       fixture.service.resume({
         sessionId: created.sessionId,
         harnessAgentId: "claude-code",
+        harnessSessionId: created.harnessSessionId,
       }),
     );
 
@@ -249,7 +254,11 @@ it.effect("waits for an in-flight close before resuming the same session id", ()
 it.effect("closes a session that is still being resumed", () =>
   Effect.gen(function* () {
     const fixture = yield* makeFixture;
-    const input = { sessionId: "resumed-session", harnessAgentId: "claude-code" } as const;
+    const input = {
+      sessionId: "resumed-session",
+      harnessAgentId: "claude-code",
+      harnessSessionId: "resumed-backend",
+    } as const;
     const resume = yield* Effect.forkChild(fixture.service.resume(input));
     yield* Effect.eventually(
       Ref.get(fixture.resumeCalls).pipe(

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -4,29 +4,37 @@ import { join } from "node:path";
 import { Context, Layer } from "effect";
 
 /**
- * Resolved filesystem locations the runtime persists to. Injected as a service
- * so tests can point it at a temp dir instead of `~/.vibest`.
+ * Resolved persistence locations, injected as a service so tests can point it
+ * at a temp dir instead of `~/.vibest`. It owns every path the runtime touches
+ * so no consumer hand-builds one:
  *
- * - `projects.json` lives under `storage/` (a data collection)
- * - `config.json` lives directly under the home root (single config file)
+ * - `projectsStore` — the projects collection file under `storage/`
+ * - `configStore` — the single config file at the home root
+ * - `sessionStoreDir(projectId)` — the directory holding a project's session
+ *   records; `sessionStoreFile(projectId, sessionId)` — a single record's file
  */
 export class Paths extends Context.Service<
   Paths,
   {
     readonly home: string;
-    readonly projectsFile: string;
-    readonly configFile: string;
-    /** Root of the per-project session record tree (`storage/sessions`). */
-    readonly sessionsDir: string;
+    readonly projectsStore: string;
+    readonly configStore: string;
+    readonly sessionStoreDir: (projectId: string) => string;
+    readonly sessionStoreFile: (projectId: string, sessionId: string) => string;
   }
 >()("Paths") {}
 
-const resolve = (home: string) => ({
-  home,
-  projectsFile: join(home, "storage", "projects.json"),
-  configFile: join(home, "config.json"),
-  sessionsDir: join(home, "storage", "sessions"),
-});
+const resolve = (home: string) => {
+  const sessionsRoot = join(home, "storage", "sessions");
+  return {
+    home,
+    projectsStore: join(home, "storage", "projects.json"),
+    configStore: join(home, "config.json"),
+    sessionStoreDir: (projectId: string) => join(sessionsRoot, projectId),
+    sessionStoreFile: (projectId: string, sessionId: string) =>
+      join(sessionsRoot, projectId, `${sessionId}.json`),
+  };
+};
 
 /** Point the runtime at an explicit home directory (used in tests). */
 export const layerPaths = (home: string): Layer.Layer<Paths> =>

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -16,6 +16,8 @@ export class Paths extends Context.Service<
     readonly home: string;
     readonly projectsFile: string;
     readonly configFile: string;
+    /** Root of the per-project session record tree (`storage/sessions`). */
+    readonly sessionsDir: string;
   }
 >()("Paths") {}
 
@@ -23,6 +25,7 @@ const resolve = (home: string) => ({
   home,
   projectsFile: join(home, "storage", "projects.json"),
   configFile: join(home, "config.json"),
+  sessionsDir: join(home, "storage", "sessions"),
 });
 
 /** Point the runtime at an explicit home directory (used in tests). */

--- a/packages/server/src/infra/json-store.ts
+++ b/packages/server/src/infra/json-store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 import { Effect } from "effect";
 
@@ -42,6 +42,45 @@ export const writeJsonAtomic = (
       const tmp = `${file}.${randomUUID()}.tmp`;
       await writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
       await rename(tmp, file);
+    },
+    catch: (cause) => new StoreWriteError({ file, cause }),
+  });
+
+/**
+ * Read every `*.json` file in a directory, parsed as `A`. A missing directory
+ * yields `[]` (the collection just hasn't been written to yet). A malformed
+ * file fails the whole read with `StoreReadError`.
+ */
+export const readJsonDir = <A>(dir: string): Effect.Effect<ReadonlyArray<A>, StoreReadError> =>
+  Effect.tryPromise({
+    try: async () => {
+      let names: string[];
+      try {
+        names = await readdir(dir);
+      } catch (cause) {
+        if (isEnoent(cause)) return [];
+        throw cause;
+      }
+      const out: A[] = [];
+      for (const name of names) {
+        if (!name.endsWith(".json")) continue;
+        const raw = await readFile(join(dir, name), "utf8");
+        out.push(JSON.parse(raw) as A);
+      }
+      return out;
+    },
+    catch: (cause) => new StoreReadError({ file: dir, cause }),
+  });
+
+/** Delete a file. A file that is already gone is not an error. */
+export const removeFile = (file: string): Effect.Effect<void, StoreWriteError> =>
+  Effect.tryPromise({
+    try: async () => {
+      try {
+        await rm(file);
+      } catch (cause) {
+        if (!isEnoent(cause)) throw cause;
+      }
     },
     catch: (cause) => new StoreWriteError({ file, cause }),
   });

--- a/packages/server/src/mcp/repository.ts
+++ b/packages/server/src/mcp/repository.ts
@@ -23,13 +23,13 @@ export const McpRepositoryLayer: Layer.Layer<McpRepository, never, Paths> = Laye
   McpRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
-    const readConfig = () => readJson<RuntimeConfig>(paths.configFile, {});
+    const readConfig = () => readJson<RuntimeConfig>(paths.configStore, {});
     return {
       list: () => readConfig().pipe(Effect.map((config) => config.mcp ?? [])),
       save: (servers) =>
         Effect.gen(function* () {
           const config = yield* readConfig();
-          yield* writeJsonAtomic(paths.configFile, {
+          yield* writeJsonAtomic(paths.configStore, {
             ...config,
             mcp: servers,
           });

--- a/packages/server/src/project/repository.ts
+++ b/packages/server/src/project/repository.ts
@@ -22,8 +22,8 @@ export const ProjectRepositoryLayer: Layer.Layer<ProjectRepository, never, Paths
   Effect.gen(function* () {
     const paths = yield* Paths;
     return {
-      list: () => readJson<ReadonlyArray<Project>>(paths.projectsFile, []),
-      save: (projects) => writeJsonAtomic(paths.projectsFile, projects),
+      list: () => readJson<ReadonlyArray<Project>>(paths.projectsStore, []),
+      save: (projects) => writeJsonAtomic(paths.projectsStore, projects),
     };
   }),
 );

--- a/packages/server/src/project/service.ts
+++ b/packages/server/src/project/service.ts
@@ -16,6 +16,8 @@ export class ProjectService extends Context.Service<
   {
     readonly list: () => Effect.Effect<ReadonlyArray<Project>, StoreReadError>;
     readonly findById: (id: string) => Effect.Effect<Project, StoreReadError | ProjectNotFound>;
+    /** The project registered at a workspace path, if any (paths are resolved). */
+    readonly findByPath: (path: string) => Effect.Effect<Project | undefined, StoreReadError>;
     /** `name` defaults to the folder's basename. */
     readonly create: (input: {
       readonly name?: string;
@@ -44,6 +46,13 @@ export const ProjectServiceLayer: Layer.Layer<ProjectService, never, ProjectRepo
               return yield* Effect.fail(new ProjectNotFound({ projectId: id }));
             }
             return found;
+          }),
+
+        findByPath: (path) =>
+          Effect.gen(function* () {
+            const projects = yield* repo.list();
+            const target = resolvePath(path);
+            return projects.find((p) => resolvePath(p.path) === target);
           }),
 
         create: (input) =>

--- a/packages/server/src/provider/repository.ts
+++ b/packages/server/src/provider/repository.ts
@@ -24,13 +24,13 @@ export const ProviderRepositoryLayer: Layer.Layer<ProviderRepository, never, Pat
   ProviderRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
-    const readConfig = () => readJson<RuntimeConfig>(paths.configFile, {});
+    const readConfig = () => readJson<RuntimeConfig>(paths.configStore, {});
     return {
       list: () => readConfig().pipe(Effect.map((config) => config.provider ?? [])),
       save: (providers) =>
         Effect.gen(function* () {
           const config = yield* readConfig();
-          yield* writeJsonAtomic(paths.configFile, {
+          yield* writeJsonAtomic(paths.configStore, {
             ...config,
             provider: providers,
           });

--- a/packages/server/src/rpc/context.ts
+++ b/packages/server/src/rpc/context.ts
@@ -5,8 +5,14 @@ import type { FileSystem } from "effect/FileSystem";
 import type { EventBus } from "../events";
 import type { FileSystemService } from "../fs";
 import type { ProjectService } from "../project";
+import type { SessionRepository } from "../session";
 
 /** Services every RPC procedure may `yield*`. */
 export type RpcContext = WithEffectContext<
-  EventBus | FileSystem | HarnessAgentSessionService | ProjectService | FileSystemService
+  | EventBus
+  | FileSystem
+  | HarnessAgentSessionService
+  | ProjectService
+  | FileSystemService
+  | SessionRepository
 >;

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -19,6 +19,7 @@ import { PathsLayer } from "../config/paths";
 import { EventBusLayer } from "../events";
 import { FileSystemServiceLayer } from "../fs";
 import { ProjectModuleLayer } from "../project";
+import { SessionRepositoryLayer } from "../session";
 
 export class ClaudeCode extends Context.Service<ClaudeCode, ClaudeCodeAgent>()("ClaudeCode") {}
 export class Codex extends Context.Service<Codex, CodexAgent>()("Codex") {}
@@ -67,5 +68,6 @@ export const AgentRuntimeLayer = Layer.mergeAll(
   SessionServiceLayer,
   FileSystemServiceLayer,
   ProjectModuleLayer.pipe(Layer.provide(PathsLayer)),
+  SessionRepositoryLayer.pipe(Layer.provide(PathsLayer)),
   NodeFileSystem.layer,
 );

--- a/packages/server/src/rpc/session.ts
+++ b/packages/server/src/rpc/session.ts
@@ -1,6 +1,4 @@
 import "@orpc/experimental-effect/extensions/effect";
-import { resolve } from "node:path";
-
 import { implement } from "@orpc/server";
 import { sessionContract } from "@vibest/contract/session";
 import { HarnessAgentSessionService } from "@vibest/harness/runtime";
@@ -15,34 +13,25 @@ import { streamToAsyncGenerator } from "./stream";
 
 const orpc = implement(sessionContract).$context<RpcContext>();
 
-/** The registered project whose folder a session was opened against, if any. */
-const projectForPath = (workspacePath: string) =>
-  Effect.gen(function* () {
-    const projects = yield* ProjectService;
-    const all = yield* projects.list();
-    const target = resolve(workspacePath);
-    return all.find((p) => resolve(p.path) === target);
-  });
-
 export const sessionRouter = orpc.router({
   list: orpc.list.effect(function* ({ input }) {
     const repo = yield* SessionRepository;
     const sessions = yield* HarnessAgentSessionService;
     const records = yield* repo.list(input.projectId);
     // vibest's records are the authoritative list; merge live backend display
-    // data (title/updatedAt) and derive harnessMissing per record. A failed
+    // data (title/updatedAt) and derive transcriptMissing per record. A failed
     // lookup degrades to "unknown" so one bad session can't sink the whole list.
     return yield* Effect.forEach(
       records,
       (record) =>
         Effect.gen(function* () {
-          if (!record.harnessSessionId) return { ...record, harnessMissing: false };
+          if (!record.harnessSessionId) return { ...record, transcriptMissing: false };
           const info = yield* sessions
             .getSessionInfo(record.harnessAgentId, record.harnessSessionId, record.cwd)
             .pipe(Effect.catch(() => Effect.succeed({ _tag: "unsupported" as const })));
           return info._tag === "found"
-            ? { ...record, ...info.info, harnessMissing: false }
-            : { ...record, harnessMissing: info._tag === "missing" };
+            ? { ...record, ...info.info, transcriptMissing: false }
+            : { ...record, transcriptMissing: info._tag === "missing" };
         }),
       { concurrency: "unbounded" },
     );
@@ -54,8 +43,9 @@ export const sessionRouter = orpc.router({
     // Persist a record under its owning project so the session survives restarts
     // and can be listed/resumed. A session opened against a path that isn't a
     // registered project isn't persisted — there's no project to list it under.
-    const project = yield* projectForPath(workspacePath);
-    if (project && result.harnessSessionId) {
+    const projects = yield* ProjectService;
+    const project = yield* projects.findByPath(workspacePath);
+    if (project) {
       const repo = yield* SessionRepository;
       yield* repo.save({
         sessionId: result.sessionId,
@@ -71,18 +61,8 @@ export const sessionRouter = orpc.router({
   }),
   resume: orpc.resume.effect(function* ({ input }) {
     const sessions = yield* HarnessAgentSessionService;
-    // Adapters resume by backend id. Prefer the caller's harnessSessionId, else
-    // recover it from the persisted record via the session's workspace path.
-    let harnessSessionId = input.harnessSessionId;
-    if (!harnessSessionId && input.workspacePath) {
-      const project = yield* projectForPath(input.workspacePath);
-      if (project) {
-        const repo = yield* SessionRepository;
-        const record = yield* repo.get(project.id, input.sessionId);
-        harnessSessionId = record?.harnessSessionId;
-      }
-    }
-    yield* sessions.resume({ ...input, harnessSessionId });
+    // The caller resumes a listed session, so it already carries the backend id.
+    yield* sessions.resume(input);
   }),
   prompt: orpc.prompt.effect(function* ({ input }) {
     const sessions = yield* HarnessAgentSessionService;

--- a/packages/server/src/rpc/session.ts
+++ b/packages/server/src/rpc/session.ts
@@ -1,26 +1,88 @@
 import "@orpc/experimental-effect/extensions/effect";
+import { resolve } from "node:path";
+
 import { implement } from "@orpc/server";
 import { sessionContract } from "@vibest/contract/session";
 import { HarnessAgentSessionService } from "@vibest/harness/runtime";
-import { Stream } from "effect";
+import { Effect, Stream } from "effect";
 
 import { EventBus } from "../events";
+import { ProjectService } from "../project";
+import { SessionRepository } from "../session";
 import type { RpcContext } from "./context";
 import { openRawEventSubscription } from "./session-stream";
 import { streamToAsyncGenerator } from "./stream";
 
 const orpc = implement(sessionContract).$context<RpcContext>();
 
+/** The registered project whose folder a session was opened against, if any. */
+const projectForPath = (workspacePath: string) =>
+  Effect.gen(function* () {
+    const projects = yield* ProjectService;
+    const all = yield* projects.list();
+    const target = resolve(workspacePath);
+    return all.find((p) => resolve(p.path) === target);
+  });
+
 export const sessionRouter = orpc.router({
+  list: orpc.list.effect(function* ({ input }) {
+    const repo = yield* SessionRepository;
+    const sessions = yield* HarnessAgentSessionService;
+    const records = yield* repo.list(input.projectId);
+    // vibest's records are the authoritative list; merge live backend display
+    // data (title/updatedAt) and derive harnessMissing per record. A failed
+    // lookup degrades to "unknown" so one bad session can't sink the whole list.
+    return yield* Effect.forEach(
+      records,
+      (record) =>
+        Effect.gen(function* () {
+          if (!record.harnessSessionId) return { ...record, harnessMissing: false };
+          const info = yield* sessions
+            .getSessionInfo(record.harnessAgentId, record.harnessSessionId, record.cwd)
+            .pipe(Effect.catch(() => Effect.succeed({ _tag: "unsupported" as const })));
+          return info._tag === "found"
+            ? { ...record, ...info.info, harnessMissing: false }
+            : { ...record, harnessMissing: info._tag === "missing" };
+        }),
+      { concurrency: "unbounded" },
+    );
+  }),
   create: orpc.create.effect(function* ({ input }) {
     const sessions = yield* HarnessAgentSessionService;
-    return yield* sessions.create(input.harnessAgentId, {
-      workspacePath: input.workspacePath ?? process.cwd(),
-    });
+    const workspacePath = input.workspacePath ?? process.cwd();
+    const result = yield* sessions.create(input.harnessAgentId, { workspacePath });
+    // Persist a record under its owning project so the session survives restarts
+    // and can be listed/resumed. A session opened against a path that isn't a
+    // registered project isn't persisted — there's no project to list it under.
+    const project = yield* projectForPath(workspacePath);
+    if (project && result.harnessSessionId) {
+      const repo = yield* SessionRepository;
+      yield* repo.save({
+        sessionId: result.sessionId,
+        harnessSessionId: result.harnessSessionId,
+        harnessAgentId: result.harnessAgentId,
+        projectId: project.id,
+        cwd: workspacePath,
+        archived: false,
+        createdAt: new Date().toISOString(),
+      });
+    }
+    return result;
   }),
   resume: orpc.resume.effect(function* ({ input }) {
     const sessions = yield* HarnessAgentSessionService;
-    yield* sessions.resume(input);
+    // Adapters resume by backend id. Prefer the caller's harnessSessionId, else
+    // recover it from the persisted record via the session's workspace path.
+    let harnessSessionId = input.harnessSessionId;
+    if (!harnessSessionId && input.workspacePath) {
+      const project = yield* projectForPath(input.workspacePath);
+      if (project) {
+        const repo = yield* SessionRepository;
+        const record = yield* repo.get(project.id, input.sessionId);
+        harnessSessionId = record?.harnessSessionId;
+      }
+    }
+    yield* sessions.resume({ ...input, harnessSessionId });
   }),
   prompt: orpc.prompt.effect(function* ({ input }) {
     const sessions = yield* HarnessAgentSessionService;

--- a/packages/server/src/session/index.ts
+++ b/packages/server/src/session/index.ts
@@ -1,1 +1,2 @@
 export { makeSessionId, parseSessionId, type ParsedSessionId } from "./id";
+export { SessionRepository, SessionRepositoryLayer } from "./repository";

--- a/packages/server/src/session/repository.ts
+++ b/packages/server/src/session/repository.ts
@@ -1,0 +1,46 @@
+import { join } from "node:path";
+
+import type { SessionRecord } from "@vibest/contract";
+import { Context, Effect, Layer } from "effect";
+
+import { Paths } from "../config/paths";
+import type { StoreReadError, StoreWriteError } from "../errors";
+import { readJson, readJsonDir, removeFile, writeJsonAtomic } from "../infra/json-store";
+
+/**
+ * Data access for the session record tree at
+ * `$VIBEST_HOME/storage/sessions/<projectId>/<sessionId>.json` — one file per
+ * session, no business rules. This is vibest's authoritative session list and
+ * doubles as the internal-id → backend-id map (via `harnessSessionId`).
+ */
+export class SessionRepository extends Context.Service<
+  SessionRepository,
+  {
+    readonly list: (
+      projectId: string,
+    ) => Effect.Effect<ReadonlyArray<SessionRecord>, StoreReadError>;
+    readonly get: (
+      projectId: string,
+      sessionId: string,
+    ) => Effect.Effect<SessionRecord | undefined, StoreReadError>;
+    readonly save: (record: SessionRecord) => Effect.Effect<void, StoreWriteError>;
+    readonly remove: (projectId: string, sessionId: string) => Effect.Effect<void, StoreWriteError>;
+  }
+>()("SessionRepository") {}
+
+export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths> = Layer.effect(
+  SessionRepository,
+  Effect.gen(function* () {
+    const paths = yield* Paths;
+    const fileFor = (projectId: string, sessionId: string) =>
+      join(paths.sessionsDir, projectId, `${sessionId}.json`);
+
+    return {
+      list: (projectId) => readJsonDir<SessionRecord>(join(paths.sessionsDir, projectId)),
+      get: (projectId, sessionId) =>
+        readJson<SessionRecord | undefined>(fileFor(projectId, sessionId), undefined),
+      save: (record) => writeJsonAtomic(fileFor(record.projectId, record.sessionId), record),
+      remove: (projectId, sessionId) => removeFile(fileFor(projectId, sessionId)),
+    };
+  }),
+);

--- a/packages/server/src/session/repository.ts
+++ b/packages/server/src/session/repository.ts
@@ -1,5 +1,3 @@
-import { join } from "node:path";
-
 import type { SessionRecord } from "@vibest/contract";
 import { Context, Effect, Layer } from "effect";
 
@@ -32,15 +30,17 @@ export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths
   SessionRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
-    const fileFor = (projectId: string, sessionId: string) =>
-      join(paths.sessionsDir, projectId, `${sessionId}.json`);
 
     return {
-      list: (projectId) => readJsonDir<SessionRecord>(join(paths.sessionsDir, projectId)),
+      list: (projectId) => readJsonDir<SessionRecord>(paths.sessionStoreDir(projectId)),
       get: (projectId, sessionId) =>
-        readJson<SessionRecord | undefined>(fileFor(projectId, sessionId), undefined),
-      save: (record) => writeJsonAtomic(fileFor(record.projectId, record.sessionId), record),
-      remove: (projectId, sessionId) => removeFile(fileFor(projectId, sessionId)),
+        readJson<SessionRecord | undefined>(
+          paths.sessionStoreFile(projectId, sessionId),
+          undefined,
+        ),
+      save: (record) =>
+        writeJsonAtomic(paths.sessionStoreFile(record.projectId, record.sessionId), record),
+      remove: (projectId, sessionId) => removeFile(paths.sessionStoreFile(projectId, sessionId)),
     };
   }),
 );

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -61,13 +61,8 @@ export interface RuntimeConfig {
   readonly mcp?: ReadonlyArray<McpServerConfig>;
 }
 
-/** Session-related placeholder shapes (fields not fully designed yet). */
-export interface SessionSummary {
-  readonly id: string;
-  readonly harnessAgentId: HarnessAgentId;
-  readonly name?: string;
-  readonly archived: boolean;
-}
+/** The persisted session shape lives in @vibest/contract (`SessionRecord`). */
+export type { SessionRecord, SessionSummary } from "@vibest/contract";
 
 /** A session event pushed over the event stream (payload shape is a placeholder). */
 export interface SessionEvent {

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -14,10 +14,13 @@ import {
 import { Effect, Layer, ManagedRuntime } from "effect";
 import { describe, expect, it } from "vitest";
 
+import { layerPaths } from "../src/config/paths";
 import { EventBusLayer } from "../src/events";
+import { ProjectModuleLayer } from "../src/project";
 import type { RpcContext } from "../src/rpc/context";
 import { router } from "../src/rpc/router";
 import { Codex } from "../src/rpc/runtime";
+import { SessionRepositoryLayer } from "../src/session";
 
 const FAKE = `#!/usr/bin/env node
 const readline = require("node:readline");
@@ -63,18 +66,32 @@ describe("session router", () => {
       Layer.provide(registryLayer),
       Layer.provide(EventBusLayer),
     );
-    const runtime = ManagedRuntime.make(Layer.merge(EventBusLayer, sessionLayer));
+    // create now persists a session record (and resume can recover the backend
+    // id from it), so the router needs ProjectService + SessionRepository too.
+    const pathsLayer = layerPaths(mkdtempSync(join(tmpdir(), "vibest-home-")));
+    const runtime = ManagedRuntime.make(
+      Layer.mergeAll(
+        EventBusLayer,
+        sessionLayer,
+        ProjectModuleLayer.pipe(Layer.provide(pathsLayer)),
+        SessionRepositoryLayer.pipe(Layer.provide(pathsLayer)),
+      ),
+    );
     try {
       const context: RpcContext = {
         "effect/context": runtime.runSync(runtime.contextEffect),
       };
       const client = createRouterClient(router, { context });
 
-      const { sessionId } = await client.session.create({
+      const { sessionId, harnessSessionId } = await client.session.create({
         harnessAgentId: "codex",
         workspacePath: "/tmp",
       });
-      expect(sessionId).toBe("th_1");
+      // sessionId is now a vibest-internal id; the backend threadId surfaces as
+      // harnessSessionId.
+      expect(harnessSessionId).toBe("th_1");
+      expect(sessionId).toBeTruthy();
+      expect(sessionId).not.toBe("th_1");
 
       const events = await client.session.events({ sessionId });
       const receipt = await client.session.prompt({


### PR DESCRIPTION
## 背景

此前 session 仅存在于内存中,进程重启即丢失;只有 project 与 config 会落盘。本 PR 让 session 元数据落盘,使会话在重启后仍可列出与 resume。

## 设计要点

- **内部 id 与后端 id 真解耦**:引入 vibest 自己的 `sessionId`(uuid v7),与 harness 后端的 `harnessSessionId` 分离。寻址一律用内部 id,`harnessSessionId` 仅作为字段存储供 resume 透传。
- **每 session 一文件分片**:落盘布局 `storage/sessions/<projectId>/<sessionId>.json`,原子写(临时文件 + rename)。
- **只存后端没有的**:记录 `sessionId / harnessSessionId / harnessAgentId / projectId / cwd / archived / createdAt`。title / updatedAt 仍由后端(claude-code、codex 均自管 title)在查询时实时提供。
- **查询以我们的落盘为准**:orphan(后端有、我们没存)不展示;merge 后端实时 display(title/updatedAt);当后端 transcript 被删除时派生 `harnessMissing` 标识(不落盘)。

## 改动

- **contract**:新增 `SessionRecord` / `SessionSummary` schema 与 `session.list` 路由;`create` / `resume` 结果透传 `harnessSessionId`。
- **harness**:session-service 引入内部 uuid session id;adapter 新增 `getSessionInfo` 能力(claude-code 读取 SDK session info;codex / pi 暂返回 `unsupported`)。
- **server**:新增 `SessionRepository`(原子每-session JSON 文件);`list` 路由合并落盘记录与后端实时 title/updatedAt,并在 transcript 丢失时派生 `harnessMissing`;`create` 按所属 project 落盘,`resume` 在缺少 harnessSessionId 时反查记录补全。

## 测试

- `@vibest/harness`、`@vibest/server`、`@vibest/contract` 的 typecheck 与 test 全部通过(harness 149 passed)。
- 补齐了各 mock adapter 的 `getSessionInfo`;`rpc-session` 断言改为校验内部 sessionId 与 harnessSessionId 解耦。

## 后续(不在本 PR)

- 前端阶段 4:create 传 `projectId` + 消费 `list`(待产品设计)。
- codex `getSessionInfo` 的真实实现(thread list/read)。
