### PR TITLE
feat(cli): build @vibest/cli on effect/unstable/cli

### DIFF
--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -21,9 +21,11 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.207",
+    "@effect/platform-node": "catalog:",
     "@orpc/contract": "2.0.0-beta.16",
     "@orpc/server": "^2.0.0-beta.16",
     "ai": "^7.0.22",
+    "effect": "catalog:",
     "sirv": "^3.0.2",
     "uuid": "^14.0.1",
     "ws": "^8.21.0",

--- a/packages/vibest/src/node/cli.ts
+++ b/packages/vibest/src/node/cli.ts
@@ -1,66 +1,23 @@
 #!/usr/bin/env node
 
-import { formatReadyLine } from "./handshake";
-import { listenServer } from "./listen";
-import { createServer } from "./server";
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect } from "effect";
+import { Command } from "effect/unstable/cli";
 
-const DEFAULT_PORT = 4000;
+import pkg from "../../package.json" with { type: "json" };
+import { runServe, serve, serveFlags } from "./commands/serve";
 
-/**
- * Read the token, then scrub it. The agent spawns a shell for every tool call
- * and children inherit this environment — an agent-run command must not be
- * able to read the credential that guards the agent.
- */
-function takeAuthToken(): string | undefined {
-  const token = process.env.VIBEST_AUTH_TOKEN;
-  delete process.env.VIBEST_AUTH_TOKEN;
-  return token;
-}
+// The root command runs `serve` when invoked bare, so `node cli.mjs` (how the
+// desktop supervisor spawns it, args-free, config via env) starts the server.
+// Subcommands hang off `withSubcommands` — add to the array to grow the CLI.
+const vibest = Command.make("vibest", serveFlags, runServe).pipe(
+  Command.withDescription("Vibest local server"),
+  Command.withSubcommands([serve]),
+);
 
-function readCorsOrigins(): string[] {
-  return (process.env.VIBEST_CORS_ORIGINS ?? "")
-    .split(",")
-    .map((origin) => origin.trim())
-    .filter((origin) => origin.length > 0);
-}
-
-function readPort(): number {
-  const raw = process.env.VIBEST_PORT;
-  if (raw === undefined) return process.env.NODE_ENV === "development" ? 0 : DEFAULT_PORT;
-  const port = Number.parseInt(raw, 10);
-  return Number.isInteger(port) && port >= 0 ? port : DEFAULT_PORT;
-}
-
-async function main() {
-  const authToken = takeAuthToken();
-  const server = await createServer({ authToken, corsOrigins: readCorsOrigins() });
-  let port: number;
-  try {
-    port = await listenServer(server, readPort());
-  } catch (error) {
-    await server.dispose();
-    throw error;
-  }
-
-  // Machine-readable first, for the desktop supervisor; human-readable second.
-  console.log(formatReadyLine({ port }));
-  console.log(`vibest listening on http://127.0.0.1:${port}`);
-
-  let shuttingDown: Promise<void> | undefined;
-  const shutdown = () =>
-    (shuttingDown ??= server.dispose().catch((error) => {
-      console.error(error);
-      process.exitCode = 1;
-    }));
-  process.once("SIGINT", () => {
-    void shutdown();
-  });
-  process.once("SIGTERM", () => {
-    void shutdown();
-  });
-}
-
-void main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+Command.run(vibest, { version: pkg.version }).pipe(
+  Effect.provide(NodeServices.layer),
+  Effect.scoped,
+  NodeRuntime.runMain,
+);

--- a/packages/vibest/src/node/commands/serve.test.ts
+++ b/packages/vibest/src/node/commands/serve.test.ts
@@ -1,0 +1,55 @@
+import { Option } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveServeConfig } from "./serve";
+
+const ENV_KEYS = ["VIBEST_PORT", "VIBEST_CORS_ORIGINS", "NODE_ENV"] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = saved[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("resolveServeConfig", () => {
+  it("prefers the flag over env and default for the port", () => {
+    process.env.VIBEST_PORT = "5000";
+    expect(resolveServeConfig({ port: Option.some(3000), corsOrigin: [] }).port).toBe(3000);
+  });
+
+  it("falls back to VIBEST_PORT when no flag is given", () => {
+    process.env.VIBEST_PORT = "5000";
+    expect(resolveServeConfig({ port: Option.none(), corsOrigin: [] }).port).toBe(5000);
+  });
+
+  it("defaults to 4000 in production and 0 in development", () => {
+    expect(resolveServeConfig({ port: Option.none(), corsOrigin: [] }).port).toBe(4000);
+    process.env.NODE_ENV = "development";
+    expect(resolveServeConfig({ port: Option.none(), corsOrigin: [] }).port).toBe(0);
+  });
+
+  it("prefers repeated --cors-origin flags over VIBEST_CORS_ORIGINS", () => {
+    process.env.VIBEST_CORS_ORIGINS = "https://env.example";
+    expect(
+      resolveServeConfig({ port: Option.none(), corsOrigin: ["https://a.test", "https://b.test"] })
+        .corsOrigins,
+    ).toEqual(["https://a.test", "https://b.test"]);
+  });
+
+  it("falls back to the comma-separated env list when no flag is given", () => {
+    process.env.VIBEST_CORS_ORIGINS = " https://a.test , https://b.test ,";
+    expect(resolveServeConfig({ port: Option.none(), corsOrigin: [] }).corsOrigins).toEqual([
+      "https://a.test",
+      "https://b.test",
+    ]);
+  });
+});

--- a/packages/vibest/src/node/commands/serve.ts
+++ b/packages/vibest/src/node/commands/serve.ts
@@ -1,0 +1,95 @@
+import { Effect, Option } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+
+import { formatReadyLine } from "../handshake";
+import { listenServer } from "../listen";
+import { createServer } from "../server";
+
+const DEFAULT_PORT = 4000;
+
+/**
+ * Read the token, then scrub it. The agent spawns a shell for every tool call
+ * and children inherit this environment — an agent-run command must not be
+ * able to read the credential that guards the agent. Kept env-only (never a
+ * flag) so it stays out of the process list.
+ */
+function takeAuthToken(): string | undefined {
+  const token = process.env.VIBEST_AUTH_TOKEN;
+  delete process.env.VIBEST_AUTH_TOKEN;
+  return token;
+}
+
+function corsOriginsFromEnv(): string[] {
+  return (process.env.VIBEST_CORS_ORIGINS ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+}
+
+function portFromEnv(): number {
+  const raw = process.env.VIBEST_PORT;
+  if (raw === undefined) return process.env.NODE_ENV === "development" ? 0 : DEFAULT_PORT;
+  const port = Number.parseInt(raw, 10);
+  return Number.isInteger(port) && port >= 0 ? port : DEFAULT_PORT;
+}
+
+export const serveFlags = {
+  port: Flag.integer("port").pipe(
+    Flag.withDescription("Port to listen on (overrides VIBEST_PORT)"),
+    Flag.optional,
+  ),
+  corsOrigin: Flag.string("cors-origin").pipe(
+    Flag.withDescription("Origin allowed to make cross-origin requests; repeatable"),
+    Flag.atLeast(0),
+  ),
+};
+
+type ServeInput = {
+  readonly port: Option.Option<number>;
+  readonly corsOrigin: ReadonlyArray<string>;
+};
+
+/**
+ * Resolve the effective port and CORS origins from parsed flags, falling back
+ * to `VIBEST_*` env and finally the defaults — precedence flag > env > default.
+ * Pure so the precedence can be tested without booting a server.
+ */
+export function resolveServeConfig(input: ServeInput): {
+  readonly port: number;
+  readonly corsOrigins: readonly string[];
+} {
+  return {
+    port: Option.getOrElse(input.port, portFromEnv),
+    corsOrigins: input.corsOrigin.length > 0 ? input.corsOrigin : corsOriginsFromEnv(),
+  };
+}
+
+/**
+ * Boot the HTTP server and keep the process alive until interrupted.
+ * The auth token is env-only. The server is acquired in the ambient scope so
+ * `NodeRuntime.runMain`'s SIGINT/SIGTERM interrupt tears it down through the
+ * release finalizer.
+ */
+export const runServe = (input: ServeInput) =>
+  Effect.gen(function* () {
+    const authToken = takeAuthToken();
+    const { port: requestedPort, corsOrigins } = resolveServeConfig(input);
+
+    const server = yield* Effect.acquireRelease(
+      Effect.promise(() => createServer({ authToken, corsOrigins })),
+      (managed) => Effect.promise(() => managed.dispose()),
+    );
+
+    const port = yield* Effect.tryPromise(() => listenServer(server, requestedPort));
+
+    // Machine-readable first, for the desktop supervisor; human-readable second.
+    // Both go to stdout — Effect's logger writes to stderr, so it never mixes in.
+    console.log(formatReadyLine({ port }));
+    console.log(`vibest listening on http://127.0.0.1:${port}`);
+
+    return yield* Effect.never;
+  });
+
+export const serve = Command.make("serve", serveFlags, runServe).pipe(
+  Command.withDescription("Start the vibest local server"),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,6 +561,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.3.207
         version: 0.3.207(@anthropic-ai/sdk@0.111.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1)
       '@orpc/contract':
         specifier: 2.0.0-beta.16
         version: 2.0.0-beta.16(@opentelemetry/api@1.9.1)
@@ -570,6 +573,9 @@ importers:
       ai:
         specifier: ^7.0.22
         version: 7.0.22(zod@4.4.3)
+      effect:
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97
       sirv:
         specifier: ^3.0.2
         version: 3.0.2
@@ -4934,8 +4940,8 @@ packages:
   deslop-js@0.7.6:
     resolution: {integrity: sha512-3RwCevYF5Nux7rdixzyauk4EANTJmkkJbIqkAwVmzkR3HJ4HnMQxvuLNgRX33j5gF7ftcdv7Iqc2JdJCn8Abvw==}
 
-  deslop-js@0.7.8:
-    resolution: {integrity: sha512-QMmb3Z/ARvYZmZneudb8cnY/4mVvZTdhUyA9TC2skwOcm7KvY9zyOdn0TApQc4rL0VM2TffFkmo3ky/lJZX7qw==}
+  deslop-js@0.8.1:
+    resolution: {integrity: sha512-a8wpwOPo6HsYyRndn17C88mNzeQD6t17yhZ8qpyFWTxj5jQeWtXDj+zJfnuT8++5A4LaNeNAnKs1edVWuadNdQ==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -6462,8 +6468,8 @@ packages:
     resolution: {integrity: sha512-oE01pROKCbxZ7mfHWXEZ27lw12ZWbWUe1p6OtgtRBtHWyNCqXi5MGYVsG7u3zlqG0i6k1UEYVvHrQvle2fJ1HQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
-  oxlint-plugin-react-doctor@0.7.8:
-    resolution: {integrity: sha512-3f9/jFLIC/KRLPYqxiXSk20cq47luGy9Oz5Ru7nK7w0EI9B9zuMvAU92bK9jFiwFE7Lc9PA8ER6Y+naYaGFQGw==}
+  oxlint-plugin-react-doctor@0.8.1:
+    resolution: {integrity: sha512-ETjgoKrY0EYpK51BsbvgpWySkWaLgJ6z7yB/BfOosi+TUY4+GiDmhWfjJCeul+tpDJEFKR5MnpENjlUrmtZ5Dw==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@0.24.0:
@@ -6835,8 +6841,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
-  react-doctor@0.7.8:
-    resolution: {integrity: sha512-G3spmtZJE/gWWPRJ3rpgUWTPRDJpEmdRja7iNZ7RAXlfpEO+NWVzPTca/cPI9hLwPo2Aq5/BZggo5JDBrwGrlA==}
+  react-doctor@0.8.1:
+    resolution: {integrity: sha512-lP/MaS7dDMeVFpWBjh8qYp6NYcb/1TmsAwSixqkqOI50fea9kfh89fyn+UUAC3vb53FGIqwvDPZIjlJR6BgGAQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -12428,7 +12434,7 @@ snapshots:
       oxc-resolver: 11.23.0
       typescript: 5.9.3
 
-  deslop-js@0.7.8:
+  deslop-js@0.8.1:
     dependencies:
       '@oxc-project/types': 0.138.0
       fast-glob: 3.3.3
@@ -14336,7 +14342,7 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       oxc-parser: 0.138.0
 
-  oxlint-plugin-react-doctor@0.7.8:
+  oxlint-plugin-react-doctor@0.8.1:
     dependencies:
       '@typescript-eslint/types': 8.63.0
       eslint-scope: 9.1.2
@@ -14789,19 +14795,19 @@ snapshots:
       - oxlint-tsgolint
       - supports-color
 
-  react-doctor@0.7.8(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.7.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0):
+  react-doctor@0.8.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.7.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.7.8
+      deslop-js: 0.8.1
       eslint-plugin-react-hooks: 7.1.1(eslint@10.7.0(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0(oxlint-tsgolint@0.24.0)
-      oxlint-plugin-react-doctor: 0.7.8
+      oxlint-plugin-react-doctor: 0.8.1
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -14864,7 +14870,7 @@ snapshots:
       preact: 10.29.7
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.7.8(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.7.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0)
+      react-doctor: 0.8.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.7.0(jiti@2.7.0))(oxlint-tsgolint@0.24.0)
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.48(react@19.2.7)
     optionalDependencies:


### PR DESCRIPTION
## What

Rewrite the `@vibest/cli` entry (`packages/vibest`) on Effect v4's built-in CLI module (`effect/unstable/cli`), replacing the ad-hoc env-var `main()` with a real command tree.

> Note: the standalone `@effect/cli` package peer-depends on `effect@^3` and can't be installed alongside this repo's Effect v4, so this uses the built-in `effect/unstable/cli` (marked _unstable_ upstream).

## Behavior

- Root `vibest` runs **serve** when invoked bare — env-driven — so the desktop supervisor's args-free `node cli.mjs` spawn and the `vibest:ready {json}` stdout handshake are **unchanged**.
- Adds a `serve` subcommand plus native `--help` / `--version`, and `withSubcommands([...])` as the seam for future commands (no lazy-loading framework).
- Flags: `--port` and repeatable `--cors-origin`, precedence **flag > env > default** via the pure `resolveServeConfig` seam. The auth token stays **env-only** (never a flag — it must stay out of the process list).

## Lifecycle

The server is acquired in the ambient scope and the handler blocks on `Effect.never`, so `NodeRuntime.runMain`'s SIGINT/SIGTERM interrupt tears it down through the release finalizer. Drops the hand-rolled `process.once` signal handlers.

## Misc

- `--version` reads from `package.json`.
- `effect` + `@effect/platform-node` promoted to direct `dependencies` (already covered by tsdown `onlyBundle`).
- `server.ts` / `listen.ts` / `auth.ts` / `cors.ts` / `handshake.ts` reused unchanged.

## Verification

- ✅ typecheck + 46 tests pass (incl. new `serve.test.ts` precedence cases)
- ✅ `tsdown` build inlines `effect/unstable/cli` into `dist/cli.mjs`
- ✅ `--version` / `--help` / `serve --help` render correctly
- ✅ bare spawn emits exact `vibest:ready {"port":...}`, `/api/health` → `ok`, SIGTERM exits cleanly
- ✅ `vibest serve --port X` (with `VIBEST_PORT` set) binds X — flag wins
- ✅ oxfmt / oxlint clean