### PR TITLE
fix(desktop): e2e VIBEST_HOME isolation + survive signal-killed server children

### DIFF
--- a/apps/desktop/e2e/tests/desktop-rpc.spec.ts
+++ b/apps/desktop/e2e/tests/desktop-rpc.spec.ts
@@ -149,6 +149,9 @@ test("boots the development HTTP renderer through MessagePort", async ({}, testI
   // Own userData so its single-instance lock can't collide with a real `dev`.
   const userData = path.join(testInfo.outputPath(), "user-data");
   mkdirSync(userData, { recursive: true });
+  // Own server storage so the developer's real ~/.vibest never leaks in.
+  const vibestHome = path.join(testInfo.outputPath(), "vibest-home");
+  mkdirSync(vibestHome, { recursive: true });
 
   const app = await electron.launch({
     args: [
@@ -160,6 +163,7 @@ test("boots the development HTTP renderer through MessagePort", async ({}, testI
       NODE_ENV: "development",
       ELECTRON_RENDERER_URL: origin,
       VIBEST_E2E: "1",
+      VIBEST_HOME: vibestHome,
     },
   });
 

--- a/apps/desktop/e2e/tests/desktop-rpc.spec.ts
+++ b/apps/desktop/e2e/tests/desktop-rpc.spec.ts
@@ -3,7 +3,7 @@ import { createReadStream, existsSync, mkdirSync, readFileSync, statSync } from 
 import { createServer } from "node:http";
 import path from "node:path";
 
-import { _electron as electron } from "@playwright/test";
+import { _electron as electron, type Page } from "@playwright/test";
 
 import { expect, test } from "./fixtures";
 
@@ -65,7 +65,22 @@ async function waitForDifferentServer(parentPid: number, previousPid: number): P
   return serverPid(parentPid);
 }
 
-async function driveServerToFailed(parentPid: number): Promise<void> {
+/**
+ * The server child appears well before it reports ready, and a first spawn
+ * killed pre-ready is a boot failure by design (terminal state, no respawn).
+ * These kill tests mean "kill a running server", so wait until the renderer
+ * left the splash — that requires the ready handshake to have completed.
+ */
+async function waitForConnectedUi(window: Page): Promise<void> {
+  // The splash carries "Starting Vibest" as an aria-label, not text content,
+  // and unmounts permanently once the renderer connects.
+  await expect(window.getByRole("main", { name: "Starting Vibest" })).toBeHidden({
+    timeout: 30_000,
+  });
+}
+
+async function driveServerToFailed(window: Page, parentPid: number): Promise<void> {
+  await waitForConnectedUi(window);
   let currentPid = await waitForServer(parentPid);
   for (let failure = 0; failure < 6; failure += 1) {
     process.kill(currentPid, "SIGKILL");
@@ -183,13 +198,15 @@ test("chats through Claude Agent SDK and the fake Claude executable", async ({
   e2ePaths,
   window,
 }) => {
-  await window.getByRole("button", { name: "Start Chatting" }).click();
-  await expect(window).toHaveURL(/\/chat\/[0-9a-f-]+$/);
+  // The app lands on /draft, the new-session surface: typing the first
+  // message creates the session and navigates into it.
+  await waitForConnectedUi(window);
 
   const input = window.locator("[contenteditable='true']");
   await input.fill("Desktop SDK E2E");
   await input.press("Enter");
 
+  await expect(window).toHaveURL(/\/session\/[0-9a-f-]+/);
   await expect(window.getByText("Desktop SDK E2E", { exact: true })).toBeVisible();
   await expect(window.getByText("Desktop fake Claude reply", { exact: true })).toBeVisible();
   await expect
@@ -203,6 +220,7 @@ test("reports a server crash and recovers on the pinned connection", async ({
   electronApp,
   window,
 }) => {
+  await waitForConnectedUi(window);
   const initialPid = await waitForServer(electronApp.process().pid);
   process.kill(initialPid, "SIGKILL");
 
@@ -227,12 +245,16 @@ test("disposes the server process during Electron shutdown", async ({ electronAp
 test("offers Retry after repeated server failures", async ({ electronApp, window }) => {
   test.setTimeout(60_000);
   const parentPid = electronApp.process().pid;
-  await driveServerToFailed(parentPid);
+  await driveServerToFailed(window, parentPid);
 
   await expect(window.getByText("The local server stopped")).toBeVisible({ timeout: 10_000 });
   await window.getByRole("button", { name: "Retry" }).click();
   await expect.poll(() => findServerPid(parentPid), { timeout: 10_000 }).toBeTruthy();
   await expect(window.getByText("The local server stopped")).toBeHidden({ timeout: 10_000 });
+  // Wait for the recovery to complete, not just the respawn to appear: quitting
+  // while the replacement server is still booting can hang the app shutdown
+  // (known issue), and teardown closes the app right after this test ends.
+  await expect(window.getByText("Reconnecting…")).toBeHidden({ timeout: 15_000 });
 });
 
 test("quits through Desktop RPC from the terminal failure state", async ({
@@ -241,7 +263,7 @@ test("quits through Desktop RPC from the terminal failure state", async ({
 }) => {
   test.setTimeout(60_000);
   const parentPid = electronApp.process().pid;
-  await driveServerToFailed(parentPid);
+  await driveServerToFailed(window, parentPid);
   await expect(window.getByText("The local server stopped")).toBeVisible({ timeout: 10_000 });
 
   await window.getByRole("button", { name: "Quit" }).click();

--- a/apps/desktop/e2e/tests/fixtures.ts
+++ b/apps/desktop/e2e/tests/fixtures.ts
@@ -15,6 +15,7 @@ export const test = base.extend<{
   e2ePaths: {
     fakeClaudeLog: string;
     userData: string;
+    vibestHome: string;
   };
   electronApp: ElectronApplication;
   window: Page;
@@ -23,9 +24,15 @@ export const test = base.extend<{
   e2ePaths: async ({}, use, testInfo) => {
     const output = testInfo.outputPath();
     mkdirSync(output, { recursive: true });
+    // Per-test server storage: without this the spawned server resolves
+    // $VIBEST_HOME to the developer's real ~/.vibest, so their projects and
+    // sessions leak into the UI and test chats write into their history.
+    const vibestHome = path.join(output, "vibest-home");
+    mkdirSync(vibestHome, { recursive: true });
     await use({
       fakeClaudeLog: path.join(output, "fake-claude.jsonl"),
       userData: path.join(output, "user-data"),
+      vibestHome,
     });
   },
 
@@ -48,6 +55,7 @@ export const test = base.extend<{
         VIBEST_E2E_CLAUDE_EXECUTABLE: fakeClaudePath,
         VIBEST_E2E_CLAUDE_LOG: e2ePaths.fakeClaudeLog,
         VIBEST_E2E_CLAUDE_RESPONSE: "Desktop fake Claude reply",
+        VIBEST_HOME: e2ePaths.vibestHome,
       },
     });
 

--- a/apps/desktop/src/main/server/node-server-process.test.ts
+++ b/apps/desktop/src/main/server/node-server-process.test.ts
@@ -83,6 +83,30 @@ setInterval(() => {}, 1000);
     }
   });
 
+  it("resolves awaitExit with a null code when the server dies from a signal", async () => {
+    const entry = makeScript('process.kill(process.pid, "SIGKILL");\n');
+    const runtime = makeRuntime();
+
+    try {
+      const { exit, readyError } = await runtime.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+            const running = yield* makeNodeServerProcess(spawner)(config(entry), 0);
+            const exitValue = yield* running.awaitExit;
+            const readyFailure = yield* Effect.flip(running.ready);
+            return { exit: exitValue, readyError: readyFailure };
+          }),
+        ),
+      );
+
+      expect(exit).toEqual({ exitCode: null });
+      expect(readyError).toMatchObject({ _tag: "ServerExitedBeforeReady", exitCode: null });
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it("passes the configured proxy environment to the server process", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "vibest-server-env-"));
     const marker = path.join(dir, "proxy");

--- a/apps/desktop/src/main/server/node-server-process.ts
+++ b/apps/desktop/src/main/server/node-server-process.ts
@@ -75,24 +75,26 @@ export function makeNodeServerProcess(
       );
 
       yield* handle.exitCode.pipe(
-        Effect.map((exitCode) => Number(exitCode)),
+        Effect.map((exitCode): number | null => Number(exitCode)),
+        // A signal-terminated child has no exit code, and effect's exitCode
+        // fails on it instead of returning one. The process is equally gone
+        // either way, so fold that failure into a null-code exit — reporting
+        // it as an error would make the supervisor treat a plain kill as a
+        // spawn problem.
+        Effect.catch(() => Effect.succeed(null)),
         Effect.tap((exitCode) =>
           Deferred.fail(
             ready,
             new ServerExitedBeforeReady({
               exitCode,
-              message: `Server exited during startup with code ${exitCode}`,
+              message:
+                exitCode === null
+                  ? "Server was terminated by a signal during startup"
+                  : `Server exited during startup with code ${exitCode}`,
             }),
           ),
         ),
         Effect.flatMap((exitCode) => Deferred.succeed(exited, { exitCode })),
-        Effect.catch((cause) => {
-          const error = spawnError(`Failed while waiting for the server: ${String(cause)}`, cause);
-          return Deferred.fail(ready, error).pipe(
-            Effect.andThen(Deferred.fail(exited, error)),
-            Effect.asVoid,
-          );
-        }),
         Effect.forkScoped,
       );
 


### PR DESCRIPTION
## What

The desktop e2e fixtures never set `VIBEST_HOME`, so the server spawned by the app under test resolved storage to the developer's **real** `~/.vibest` (`packages/server/src/config/paths.ts`): their projects and sessions leaked into the UI the tests assert against, and a test that completed a chat would write into their actual history. Every test — and the standalone dev-renderer launch inside the spec — now gets its own `vibest-home` under the Playwright output dir. Env propagation is direct: in non-packaged runs the main process passes `{...process.env}` to the server child.

## What this does (and does not) fix

This makes the suite **honest, not green**. With isolated storage and no sandbox, the remaining failures fail for their real reasons:

1. **Kill/recovery cases** (`reports a server crash…`, `offers Retry…`, `quits through Desktop RPC…`) — after the test SIGKILLs the server, the supervisor logs:
   ```
   ServerSpawnError: Failed while waiting for the server:
   PlatformError: Unknown: ChildProcess.exitCode (…Electron …cli.mjs)
   ```
   Effect's `ChildProcess.exitCode` fails outright when the child dies from a **signal** (exit code is null), and after that failed attempt the supervisor never respawns; `electronApp.close()` then hangs, which is also the source of the 60s teardown timeouts. Reproduced with a minimal harness on both isolated and real `VIBEST_HOME` — home-independent, pre-existing (the bare server restarts fine when spawned directly; only the in-app supervisor path is affected). Product fix tracked separately in `node-server-process.ts`/`local-server.ts`.
2. **`chats through Claude Agent SDK…`** — still waits for a `Start Chatting` button that no longer exists anywhere in the codebase; the spec needs rewriting against the current UI (seed a project into the isolated `VIBEST_HOME`, then go through `New chat`).

Context: verification work spun out of #126.