### PR TITLE
refactor(harness): rename session workspacePath to cwd

### DIFF
--- a/packages/harness/src/types/session.ts
+++ b/packages/harness/src/types/session.ts
@@ -8,7 +8,7 @@ export type SessionSummary = {
 };
 
 export type UserInput = { text: string };
-export type CreateSessionConfig = { workspacePath: string };
+export type CreateSessionConfig = { cwd: string };
 export type AvailabilityResult = { available: boolean; reason?: string };
 
 export interface LifecycleView {

--- a/packages/harness/test/types/session.test-d.ts
+++ b/packages/harness/test/types/session.test-d.ts
@@ -8,5 +8,5 @@ test("LifecycleView exposes the active turn and a turn-id minter", () => {
 });
 
 test("CreateSessionConfig requires a workspace path", () => {
-  expectTypeOf<CreateSessionConfig["workspacePath"]>().toEqualTypeOf<string>();
+  expectTypeOf<CreateSessionConfig["cwd"]>().toEqualTypeOf<string>();
 });

--- a/packages/server/src/harness/adapter.ts
+++ b/packages/server/src/harness/adapter.ts
@@ -152,10 +152,10 @@ export interface HarnessAgentAdapter {
   >;
   /**
    * Look up live display info for a persisted session by backend id, without
-   * opening it. `workspacePath` (the session's cwd) narrows the backend search.
+   * opening it. `cwd` (the session's cwd) narrows the backend search.
    */
   readonly getSessionInfo: (
     harnessSessionId: string,
-    workspacePath?: string,
+    cwd?: string,
   ) => Effect.Effect<SessionInfoResult, AgentOperationError>;
 }

--- a/packages/server/src/harness/claude-code/adapter.ts
+++ b/packages/server/src/harness/claude-code/adapter.ts
@@ -438,21 +438,19 @@ export const makeClaudeCodeAdapter = (agent: ClaudeCodeAgent): HarnessAgentAdapt
       ),
       Effect.flatMap(({ sessionId }) => makeSession(agent, sessionId)),
     ),
-  getSessionInfo: (harnessSessionId, workspacePath) =>
-    agent.session
-      .getSessionInfo(harnessSessionId, workspacePath ? { dir: workspacePath } : undefined)
-      .pipe(
-        Effect.mapError((cause) => operationError(harnessSessionId, "get-session-info", cause)),
-        Effect.map(
-          (info): SessionInfoResult =>
-            info
-              ? {
-                  _tag: "found",
-                  // customTitle (user /rename) wins over the auto summary; both fall
-                  // back to undefined title if empty.
-                  info: { title: info.customTitle ?? info.summary, updatedAt: info.lastModified },
-                }
-              : { _tag: "missing" },
-        ),
+  getSessionInfo: (harnessSessionId, cwd) =>
+    agent.session.getSessionInfo(harnessSessionId, cwd ? { dir: cwd } : undefined).pipe(
+      Effect.mapError((cause) => operationError(harnessSessionId, "get-session-info", cause)),
+      Effect.map(
+        (info): SessionInfoResult =>
+          info
+            ? {
+                _tag: "found",
+                // customTitle (user /rename) wins over the auto summary; both fall
+                // back to undefined title if empty.
+                info: { title: info.customTitle ?? info.summary, updatedAt: info.lastModified },
+              }
+            : { _tag: "missing" },
       ),
+    ),
 });

--- a/packages/server/src/harness/codex/adapter.ts
+++ b/packages/server/src/harness/codex/adapter.ts
@@ -270,13 +270,13 @@ export const makeCodexAdapter = (agent: CodexAgent): HarnessAgentAdapter => ({
   }),
   checkAvailability: Effect.succeed({ available: true }),
   open: (input) =>
-    agent.session.create({ workspacePath: input.workspacePath }).pipe(
+    agent.session.create({ cwd: input.cwd }).pipe(
       Effect.mapError((cause) => new AgentOpenError({ harnessAgentId: "codex", cause })),
       Effect.flatMap(({ sessionId }) => makeSession(agent, sessionId)),
       Effect.tap((session) => applyInitialSessionConfig(session, input)),
     ),
   resume: (input) =>
-    agent.session.resume({ sessionId: input.sessionId, workspacePath: input.workspacePath }).pipe(
+    agent.session.resume({ sessionId: input.sessionId, cwd: input.cwd }).pipe(
       Effect.mapError((cause) =>
         cause instanceof SessionNotResumable
           ? cause

--- a/packages/server/src/harness/codex/agent.ts
+++ b/packages/server/src/harness/codex/agent.ts
@@ -116,11 +116,11 @@ export interface CodexAgentDependencies<R> {
 export interface CodexAgent {
   readonly session: {
     readonly create: (config: {
-      readonly workspacePath: string;
+      readonly cwd: string;
     }) => Effect.Effect<{ readonly sessionId: string }, CodexTransportFailure>;
     readonly resume: (config: {
       readonly sessionId: string;
-      readonly workspacePath?: string;
+      readonly cwd?: string;
     }) => Effect.Effect<{ readonly sessionId: string }, CodexTransportFailure>;
     /**
      * Reads a thread's stored metadata (title, recency) straight from the
@@ -542,7 +542,7 @@ export const makeCodexAgentWithDependencies = <R>(
             const transport = yield* holder.ensure;
             const generation = yield* getTransportGeneration(transport);
             const response = yield* transport.request<ThreadStartResponse>("thread/start", {
-              cwd: config.workspacePath,
+              cwd: config.cwd,
               approvalPolicy: "on-request",
               sandbox: "workspace-write",
             });
@@ -554,7 +554,7 @@ export const makeCodexAgentWithDependencies = <R>(
             const generation = yield* getTransportGeneration(transport);
             const response = yield* transport.request<ThreadResumeResponse>("thread/resume", {
               threadId: config.sessionId,
-              cwd: config.workspacePath,
+              cwd: config.cwd,
               approvalPolicy: "on-request",
               sandbox: "workspace-write",
             });

--- a/packages/server/src/harness/pi/adapter.ts
+++ b/packages/server/src/harness/pi/adapter.ts
@@ -225,12 +225,12 @@ export const makePiAdapter = (agent: PiAgent): HarnessAgentAdapter => ({
   capabilities: Effect.succeed({}),
   checkAvailability: Effect.succeed({ available: true }),
   open: (input) =>
-    agent.session.create({ workspacePath: input.workspacePath }).pipe(
+    agent.session.create({ cwd: input.cwd }).pipe(
       Effect.mapError((cause) => new AgentOpenError({ harnessAgentId: "pi", cause })),
       Effect.flatMap(({ sessionId }) => makeSession(agent, sessionId)),
     ),
   resume: (input) =>
-    agent.session.resume({ sessionId: input.sessionId, workspacePath: input.workspacePath }).pipe(
+    agent.session.resume({ sessionId: input.sessionId, cwd: input.cwd }).pipe(
       Effect.mapError((cause) =>
         cause instanceof SessionNotResumable
           ? cause

--- a/packages/server/src/harness/pi/agent.ts
+++ b/packages/server/src/harness/pi/agent.ts
@@ -78,18 +78,18 @@ export interface PiAgentOptions {
 export interface PiAgentDependencies<R> {
   readonly makeTransport: (config: {
     readonly sessionId: string;
-    readonly workspacePath?: string;
+    readonly cwd?: string;
   }) => Effect.Effect<PiTransport, PiTransportError, R | Scope.Scope>;
 }
 
 export interface PiAgent {
   readonly session: {
     readonly create: (config: {
-      readonly workspacePath: string;
+      readonly cwd: string;
     }) => Effect.Effect<{ readonly sessionId: string }, PiTransportFailure>;
     readonly resume: (config: {
       readonly sessionId: string;
-      readonly workspacePath?: string;
+      readonly cwd?: string;
     }) => Effect.Effect<{ readonly sessionId: string }, PiTransportFailure>;
     readonly prompt: (input: {
       readonly sessionId: string;
@@ -299,13 +299,13 @@ export const makePiAgentWithDependencies = <R>(
 
     const openSession = (
       sessionId: string,
-      workspacePath?: string,
+      cwd?: string,
     ): Effect.Effect<{ readonly sessionId: string }, PiTransportFailure> =>
       Effect.gen(function* () {
         const scope = yield* Scope.fork(ownerScope, "sequential");
         return yield* Effect.gen(function* () {
           const transport = yield* dependencies
-            .makeTransport({ sessionId, ...(workspacePath ? { workspacePath } : {}) })
+            .makeTransport({ sessionId, ...(cwd ? { cwd } : {}) })
             .pipe(Effect.provideService(Scope.Scope, scope), Effect.provideContext(buildContext));
 
           // Readiness handshake: pi's CLI front-end resolves the session (and
@@ -390,8 +390,8 @@ export const makePiAgentWithDependencies = <R>(
 
     return {
       session: {
-        create: (config) => openSession(uuid(), config.workspacePath),
-        resume: (config) => openSession(config.sessionId, config.workspacePath),
+        create: (config) => openSession(uuid(), config.cwd),
+        resume: (config) => openSession(config.sessionId, config.cwd),
         prompt: (input) =>
           Effect.gen(function* () {
             const session = yield* getSession(input.sessionId);
@@ -574,6 +574,6 @@ export const makePiAgent = (
         ...(options.executablePath ? { executablePath: options.executablePath } : {}),
         ...(options.args ? { args: options.args } : {}),
         sessionId: config.sessionId,
-        ...(config.workspacePath ? { cwd: config.workspacePath } : {}),
+        ...(config.cwd ? { cwd: config.cwd } : {}),
       }),
   });

--- a/packages/server/src/harness/session-io.ts
+++ b/packages/server/src/harness/session-io.ts
@@ -9,7 +9,7 @@ import { Schema } from "effect";
  */
 
 export const CreateSessionInputSchema = Schema.Struct({
-  workspacePath: Schema.String,
+  cwd: Schema.String,
   sessionId: Schema.optionalKey(Schema.String),
   // Session config chosen at create time, applied via the session's own
   // setModel / setPermissionMode before the first prompt (applyInitialSessionConfig).
@@ -21,14 +21,14 @@ export type CreateSessionInput = typeof CreateSessionInputSchema.Type;
 
 export const ResumeSessionInputSchema = Schema.Struct({
   sessionId: Schema.String,
-  workspacePath: Schema.optionalKey(Schema.String),
+  cwd: Schema.optionalKey(Schema.String),
 });
 export type ResumeSessionInput = typeof ResumeSessionInputSchema.Type;
 
 export const ResumeManagedSessionInputSchema = Schema.Struct({
   sessionId: Schema.String,
   harnessAgentId: HarnessAgentIdSchema,
-  workspacePath: Schema.optionalKey(Schema.String),
+  cwd: Schema.optionalKey(Schema.String),
 });
 export type ResumeManagedSessionInput = typeof ResumeManagedSessionInputSchema.Type;
 

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -190,7 +190,7 @@ export const makeHarnessAgentSessionService = (
               ? adapter.open(mode.input)
               : adapter.resume({
                   sessionId: mode.input.sessionId,
-                  workspacePath: mode.input.workspacePath,
+                  cwd: mode.input.cwd,
                 })
           ).pipe(Effect.provideService(Scope.Scope, sessionScope));
           return yield* register({ session, scope: sessionScope });

--- a/packages/server/src/session/port.ts
+++ b/packages/server/src/session/port.ts
@@ -37,7 +37,7 @@ export type HarnessRespondError =
  * only to this port, never to `@vibest/harness` directly, so the orchestration
  * (projectId resolution, id translation, metadata, runtime fan-out) can be
  * built and tested against a fake. The port speaks the agent-native session id
- * and a resolved `workspacePath` only — it never sees a projectId or a server
+ * and a resolved `cwd` only — it never sees a projectId or a server
  * sessionId. Create/resume errors are mapped to server errors here; the
  * active-instance ops pass the HarnessAgent's own errors through.
  */
@@ -47,14 +47,14 @@ export class HarnessAgentSessionPort extends Context.Service<
     /** Open a fresh native session; returns the agent-native session id. */
     readonly create: (
       harnessAgentId: HarnessAgentId,
-      workspacePath: string,
+      cwd: string,
       config?: { readonly model?: string; readonly permissionMode?: string },
     ) => Effect.Effect<string, HarnessCreateError>;
     /** Ensure a native session is active again from its stored native id. */
     readonly resume: (
       harnessAgentId: HarnessAgentId,
       harnessSessionId: string,
-      workspacePath: string,
+      cwd: string,
     ) => Effect.Effect<void, HarnessResumeError>;
     /** Close a native session; idempotent no-op if it is not active. */
     readonly close: (harnessSessionId: string) => Effect.Effect<void>;
@@ -108,10 +108,10 @@ export const HarnessAgentSessionPortLayer: Layer.Layer<
   Effect.gen(function* () {
     const harness = yield* HarnessAgentSessionService;
     return {
-      create: (harnessAgentId, workspacePath, config) =>
+      create: (harnessAgentId, cwd, config) =>
         harness
           .create(harnessAgentId, {
-            workspacePath,
+            cwd,
             ...(config?.model !== undefined ? { model: config.model } : {}),
             ...(config?.permissionMode !== undefined
               ? { permissionMode: config.permissionMode }
@@ -121,9 +121,9 @@ export const HarnessAgentSessionPortLayer: Layer.Layer<
             Effect.map((result) => result.sessionId),
             Effect.mapError(mapCreateError(harnessAgentId)),
           ),
-      resume: (harnessAgentId, harnessSessionId, workspacePath) =>
+      resume: (harnessAgentId, harnessSessionId, cwd) =>
         harness
-          .resume({ sessionId: harnessSessionId, harnessAgentId, workspacePath })
+          .resume({ sessionId: harnessSessionId, harnessAgentId, cwd })
           .pipe(Effect.mapError(mapResumeError(harnessAgentId, harnessSessionId))),
       close: (harnessSessionId) => harness.close(harnessSessionId),
       events: (harnessSessionId) =>

--- a/packages/server/test/harness/claude-code/agent.test.ts
+++ b/packages/server/test/harness/claude-code/agent.test.ts
@@ -189,7 +189,7 @@ describe("ClaudeCodeAgent", () => {
         return queryInstance;
       });
       const agent = yield* makeClaudeCodeAgent();
-      const session = yield* makeClaudeCodeAdapter(agent).open({ workspacePath: "/tmp" });
+      const session = yield* makeClaudeCodeAdapter(agent).open({ cwd: "/tmp" });
       const crashSeen = yield* Deferred.make<void>();
       yield* Stream.runForEach(session.events, (event) =>
         event.body.type === "session.crashed"
@@ -216,7 +216,7 @@ describe("ClaudeCodeAgent", () => {
       ];
       const agent = yield* makeClaudeCodeAgent();
       const session = yield* makeClaudeCodeAdapter(agent).open({
-        workspacePath: "/tmp",
+        cwd: "/tmp",
         model: "opus",
       });
       const collected = yield* Effect.forkChild(

--- a/packages/server/test/harness/codex/agent.smoke.test.ts
+++ b/packages/server/test/harness/codex/agent.smoke.test.ts
@@ -12,7 +12,7 @@ layer(NodeServices.layer)("codex live smoke", (it) => {
     () =>
       Effect.gen(function* () {
         const agent = yield* makeCodexAgent();
-        const { sessionId } = yield* agent.session.create({ workspacePath: process.cwd() });
+        const { sessionId } = yield* agent.session.create({ cwd: process.cwd() });
         const prompt = yield* agent.session.prompt({
           sessionId,
           text: "Reply with exactly: PONG",

--- a/packages/server/test/harness/codex/agent.test.ts
+++ b/packages/server/test/harness/codex/agent.test.ts
@@ -18,12 +18,12 @@ const path = require("node:path");
 const readline = require("node:readline");
 const rl = readline.createInterface({ input: process.stdin });
 const send = (f) => process.stdout.write(JSON.stringify(f) + "\\n");
-let workspacePath;
+let cwd;
 rl.on("line", (line) => {
   const msg = JSON.parse(line);
   if (msg.method === "initialize") send({ id: msg.id, result: {} });
   if (msg.method === "thread/start") {
-    workspacePath = msg.params.cwd;
+    cwd = msg.params.cwd;
     send({ id: msg.id, result: { thread: { id: "th_1" } } });
     if (msg.params.cwd === "/tmp/idle-crash") setImmediate(() => process.exit(1));
   }
@@ -34,9 +34,9 @@ rl.on("line", (line) => {
       return;
     }
     if (msg.params.input[0].text === "slow-start") {
-      fs.writeFileSync(path.join(workspacePath, "turn-start-requested"), "");
+      fs.writeFileSync(path.join(cwd, "turn-start-requested"), "");
       setTimeout(() => {
-        fs.writeFileSync(path.join(workspacePath, "turn-start-replied"), "");
+        fs.writeFileSync(path.join(cwd, "turn-start-replied"), "");
         send({ id: msg.id, result: { turn: { id: "turn_slow" } } });
         send({ method: "turn/started", params: { threadId: "th_1", turn: { id: "turn_slow" } } });
       }, 50);
@@ -78,7 +78,7 @@ rl.on("line", (line) => {
     return;
   }
   if (msg.method === "turn/interrupt") {
-    fs.writeFileSync(path.join(workspacePath, "turn-interrupted"), "");
+    fs.writeFileSync(path.join(cwd, "turn-interrupted"), "");
     send({ id: msg.id, result: null });
   }
   if (msg.method === "thread/unsubscribe") send({ id: msg.id, result: null });
@@ -155,10 +155,10 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
           }),
       });
 
-      const first = yield* agent.session.create({ workspacePath: "/tmp/first" });
+      const first = yield* agent.session.create({ cwd: "/tmp/first" });
       yield* controls[0]!.terminate;
       yield* Deferred.await(oldCrashStarted);
-      const second = yield* agent.session.create({ workspacePath: "/tmp/second" });
+      const second = yield* agent.session.create({ cwd: "/tmp/second" });
       yield* Deferred.succeed(oldCrashGate, undefined);
       yield* Effect.eventually(
         agent.session
@@ -184,7 +184,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
   it.effect("creates a thread and streams a full turn", () =>
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       NodeAssert.equal(sessionId, "th_1");
 
       const prompt = yield* agent.session.prompt({ sessionId, text: "ping" });
@@ -230,7 +230,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
   it.effect("reports a transport crash while the adapter session is idle", () =>
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const session = yield* makeCodexAdapter(agent).open({ workspacePath: "/tmp/idle-crash" });
+      const session = yield* makeCodexAdapter(agent).open({ cwd: "/tmp/idle-crash" });
       const crashSeen = yield* Deferred.make<void>();
       yield* Stream.runForEach(session.events, (event) =>
         event.body.type === "session.crashed"
@@ -264,15 +264,15 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("interrupts a turn requested while turn/start is still pending", () =>
     Effect.gen(function* () {
-      const workspacePath = mkdtempSync(join(tmpdir(), "codex-starting-interrupt-"));
+      const cwd = mkdtempSync(join(tmpdir(), "codex-starting-interrupt-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath });
+      const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* Effect.forkChild(
         agent.session.prompt({ sessionId, text: "slow-start" }),
       );
 
       yield* Effect.eventually(
-        Effect.sync(() => existsSync(join(workspacePath, "turn-start-requested"))).pipe(
+        Effect.sync(() => existsSync(join(cwd, "turn-start-requested"))).pipe(
           Effect.filterOrFail(
             (requested) => requested,
             () => new Error("turn/start was not requested"),
@@ -284,7 +284,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       yield* Effect.forEach([1, 2, 3, 4], () => Effect.yieldNow, { discard: true });
 
       NodeAssert.equal(
-        existsSync(join(workspacePath, "turn-interrupted")),
+        existsSync(join(cwd, "turn-interrupted")),
         true,
         "turn/start completed without the pending interrupt",
       );
@@ -294,15 +294,15 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("interrupts the native turn when the prompt caller cancels during turn/start", () =>
     Effect.gen(function* () {
-      const workspacePath = mkdtempSync(join(tmpdir(), "codex-starting-cancel-"));
+      const cwd = mkdtempSync(join(tmpdir(), "codex-starting-cancel-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath });
+      const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* Effect.forkChild(
         agent.session.prompt({ sessionId, text: "slow-start" }),
       );
 
       yield* Effect.eventually(
-        Effect.sync(() => existsSync(join(workspacePath, "turn-start-requested"))).pipe(
+        Effect.sync(() => existsSync(join(cwd, "turn-start-requested"))).pipe(
           Effect.filterOrFail(
             (requested) => requested,
             () => new Error("turn/start was not requested"),
@@ -311,7 +311,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
       yield* Fiber.interrupt(prompt);
       yield* Effect.eventually(
-        Effect.sync(() => existsSync(join(workspacePath, "turn-start-replied"))).pipe(
+        Effect.sync(() => existsSync(join(cwd, "turn-start-replied"))).pipe(
           Effect.filterOrFail(
             (replied) => replied,
             () => new Error("turn/start did not reply"),
@@ -321,7 +321,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       yield* Effect.forEach([1, 2, 3, 4], () => Effect.yieldNow, { discard: true });
 
       NodeAssert.equal(
-        existsSync(join(workspacePath, "turn-interrupted")),
+        existsSync(join(cwd, "turn-interrupted")),
         true,
         "cancelled prompt left the native turn running",
       );
@@ -332,7 +332,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
   it.effect("unblocks a waiting prompt when the transport crashes", () =>
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       yield* agent.session.prompt({ sessionId, text: "hold" });
       const secondDone = yield* Deferred.make<void>();
       yield* agent.session.prompt({ sessionId, text: "steer-after-crash" }).pipe(
@@ -368,7 +368,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
   it.effect("exposes prompt output through the unified adapter event stream", () =>
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const session = yield* makeCodexAdapter(agent).open({ workspacePath: "/tmp" });
+      const session = yield* makeCodexAdapter(agent).open({ cwd: "/tmp" });
       const collected = yield* Effect.forkChild(
         Stream.runCollect(
           session.events.pipe(
@@ -400,7 +400,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
   it.effect("keeps a retryable error inside the active turn", () =>
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const prompt = yield* agent.session.prompt({ sessionId, text: "retry" });
       const chunks = yield* Stream.runCollect(prompt.output);
 
@@ -413,12 +413,12 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
   it.effect("does not let an abandoned session stall the shared transport", () =>
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
 
       const prompt = yield* agent.session.prompt({ sessionId, text: "flood" });
       yield* Stream.runHead(prompt.output);
       const replacement = yield* agent.session
-        .create({ workspacePath: "/tmp" })
+        .create({ cwd: "/tmp" })
         .pipe(Effect.timeout("2 seconds"));
       NodeAssert.equal(replacement.sessionId, "th_1");
       yield* agent.session.abort(replacement.sessionId);
@@ -428,7 +428,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
   it.effect("crashes existing sessions and lazily starts a replacement transport", () =>
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const prompt = yield* agent.session.prompt({ sessionId, text: "crash" });
       const chunks = yield* Stream.runCollect(prompt.output);
       NodeAssert.deepStrictEqual(
@@ -436,7 +436,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
         ["start", "text-start", "text-delta", "error"],
       );
 
-      const replacement = yield* agent.session.create({ workspacePath: "/tmp" });
+      const replacement = yield* agent.session.create({ cwd: "/tmp" });
       const replacementPrompt = yield* agent.session.prompt({
         sessionId: replacement.sessionId,
         text: "ping",

--- a/packages/server/test/harness/pi/agent.smoke.test.ts
+++ b/packages/server/test/harness/pi/agent.smoke.test.ts
@@ -12,7 +12,7 @@ layer(NodeServices.layer)("pi live smoke", (it) => {
     () =>
       Effect.gen(function* () {
         const agent = yield* makePiAgent();
-        const { sessionId } = yield* agent.session.create({ workspacePath: process.cwd() });
+        const { sessionId } = yield* agent.session.create({ cwd: process.cwd() });
         const prompt = yield* agent.session.prompt({
           sessionId,
           text: "Reply with exactly: PONG",

--- a/packages/server/test/harness/pi/agent.test.ts
+++ b/packages/server/test/harness/pi/agent.test.ts
@@ -87,7 +87,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
   it.effect("creates a session and streams a full turn", () =>
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       NodeAssert.match(sessionId, /^[0-9a-f]{8}-[0-9a-f-]{27}$/);
 
       const prompt = yield* agent.session.prompt({ sessionId, text: "ping" });
@@ -106,7 +106,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
       const { sessionId } = yield* agent.session.resume({
         sessionId: "custom-id",
-        workspacePath: "/tmp",
+        cwd: "/tmp",
       });
       NodeAssert.equal(sessionId, "custom-id");
       yield* agent.session.abort(sessionId);
@@ -117,7 +117,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
       const error = yield* agent.session
-        .resume({ sessionId: "missing-session", workspacePath: "/tmp" })
+        .resume({ sessionId: "missing-session", cwd: "/tmp" })
         .pipe(Effect.flip);
       NodeAssert.equal(error._tag, "AgentProcessExited");
     }),
@@ -126,7 +126,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
   it.effect("streams tool executions as typed tool chunks", () =>
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const prompt = yield* agent.session.prompt({ sessionId, text: "tool" });
       const chunks = yield* Stream.runCollect(prompt.output);
       NodeAssert.deepStrictEqual(
@@ -140,7 +140,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
   it.effect("round-trips a blocking extension UI request through respondPermission", () =>
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const requestFiber = yield* Stream.runHead(agent.session.requestPermission(sessionId)).pipe(
         Effect.forkChild,
       );
@@ -191,7 +191,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
   it.effect("steers an active turn instead of starting a new one", () =>
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const first = yield* agent.session.prompt({ sessionId, text: "hold" });
       NodeAssert.equal(first.started, true);
 
@@ -208,7 +208,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
   it.effect("interrupt aborts the run and the turn still finishes", () =>
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const prompt = yield* agent.session.prompt({ sessionId, text: "hold" });
       const collected = yield* Effect.forkChild(Stream.runCollect(prompt.output));
 
@@ -222,7 +222,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
   it.effect("a failed prompt command leaves the session promptable", () =>
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ workspacePath: "/tmp" });
+      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const error = yield* agent.session.prompt({ sessionId, text: "fail" }).pipe(Effect.flip);
       NodeAssert.equal(error._tag, "PiRpcError");
 
@@ -236,8 +236,8 @@ layer(NodeServices.layer)("PiAgent", (it) => {
   it.effect("a child crash evicts only that session and surfaces an error chunk", () =>
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
-      const healthy = yield* agent.session.create({ workspacePath: "/tmp" });
-      const doomed = yield* agent.session.create({ workspacePath: "/tmp" });
+      const healthy = yield* agent.session.create({ cwd: "/tmp" });
+      const doomed = yield* agent.session.create({ cwd: "/tmp" });
 
       const prompt = yield* agent.session.prompt({ sessionId: doomed.sessionId, text: "crash" });
       const chunks = yield* Stream.runCollect(prompt.output);
@@ -272,7 +272,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
   it.effect("exposes prompt output through the unified adapter event stream", () =>
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
-      const session = yield* makePiAdapter(agent).open({ workspacePath: "/tmp" });
+      const session = yield* makePiAdapter(agent).open({ cwd: "/tmp" });
       const collected = yield* Effect.forkChild(
         Stream.runCollect(
           session.events.pipe(
@@ -311,7 +311,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
   it.effect("reports a child crash while the adapter session is idle", () =>
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
-      const session = yield* makePiAdapter(agent).open({ workspacePath: "/tmp" });
+      const session = yield* makePiAdapter(agent).open({ cwd: "/tmp" });
       const crashSeen = yield* Deferred.make<void>();
       yield* Stream.runForEach(session.events, (event) =>
         event.body.type === "session.crashed"

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -128,7 +128,7 @@ const isActive = (
 it.effect("exposes the raw per-session event stream and tears down on close", () =>
   Effect.gen(function* () {
     const fixture = yield* makeFixture;
-    const created = yield* fixture.service.create("claude-code", { workspacePath: "/tmp" });
+    const created = yield* fixture.service.create("claude-code", { cwd: "/tmp" });
     const stream = yield* fixture.service.events(created.sessionId);
     const collected = yield* Effect.forkChild(
       Stream.runCollect(stream.pipe(Stream.map((draft) => draft.body.type))),
@@ -180,7 +180,7 @@ it.effect("single-flights resume in owner scope when the first waiter cancels", 
 it.effect("waits for an in-flight close before resuming the same session id", () =>
   Effect.gen(function* () {
     const fixture = yield* makeFixture;
-    const created = yield* fixture.service.create("claude-code", { workspacePath: "/tmp" });
+    const created = yield* fixture.service.create("claude-code", { cwd: "/tmp" });
     yield* Ref.set(fixture.holdClose, true);
     const close = yield* Effect.forkChild(fixture.service.close(created.sessionId));
     yield* Effect.eventually(
@@ -245,7 +245,7 @@ it.effect("closes a session that is still being resumed", () =>
 it.effect("shares one idempotent close operation", () =>
   Effect.gen(function* () {
     const fixture = yield* makeFixture;
-    const created = yield* fixture.service.create("claude-code", { workspacePath: "/tmp" });
+    const created = yield* fixture.service.create("claude-code", { cwd: "/tmp" });
     const first = yield* Effect.forkChild(fixture.service.close(created.sessionId));
     const second = yield* Effect.forkChild(fixture.service.close(created.sessionId));
 

--- a/packages/server/test/session-service.test.ts
+++ b/packages/server/test/session-service.test.ts
@@ -16,8 +16,8 @@ import { SessionManagerLayer } from "../src/session/runtime";
 import { SessionService, SessionServiceLayer } from "../src/session/service";
 
 type PortSpy = {
-  create: Array<{ harnessAgentId: string; workspacePath: string }>;
-  resume: Array<{ harnessAgentId: string; harnessSessionId: string; workspacePath: string }>;
+  create: Array<{ harnessAgentId: string; cwd: string }>;
+  resume: Array<{ harnessAgentId: string; harnessSessionId: string; cwd: string }>;
   close: Array<string>;
 };
 
@@ -27,16 +27,16 @@ const makeFakePort = (opts: { failCreate?: HarnessCreateError } = {}) => {
   // may build an effect without running it — e.g. the `onCrash` handed to the
   // runtime — and only executions should be counted.
   const layer = Layer.succeed(HarnessAgentSessionPort, {
-    create: (harnessAgentId, workspacePath) =>
+    create: (harnessAgentId, cwd) =>
       Effect.suspend(() => {
-        spy.create.push({ harnessAgentId, workspacePath });
+        spy.create.push({ harnessAgentId, cwd });
         return opts.failCreate
           ? Effect.fail(opts.failCreate)
           : Effect.succeed(`native-${spy.create.length}`);
       }),
-    resume: (harnessAgentId, harnessSessionId, workspacePath) =>
+    resume: (harnessAgentId, harnessSessionId, cwd) =>
       Effect.sync(() => {
-        spy.resume.push({ harnessAgentId, harnessSessionId, workspacePath });
+        spy.resume.push({ harnessAgentId, harnessSessionId, cwd });
       }),
     close: (harnessSessionId) =>
       Effect.sync(() => {
@@ -104,7 +104,7 @@ describe("SessionService", () => {
     expect(result.ref.sessionId).toMatch(UUID_RE);
     // harness saw the resolved cwd, never a projectId
     expect(spy.create).toEqual([
-      { harnessAgentId: "claude-code", workspacePath: resolvePath("/tmp/vibest-app") },
+      { harnessAgentId: "claude-code", cwd: resolvePath("/tmp/vibest-app") },
     ]);
     // metadata stores the native id, keyed by the server sessionId (filename)
     expect(result.stored.harnessSessionId).toBe("native-1");
@@ -162,7 +162,7 @@ describe("SessionService", () => {
       {
         harnessAgentId: "claude-code",
         harnessSessionId: "native-1",
-        workspacePath: resolvePath("/tmp/vibest-app"),
+        cwd: resolvePath("/tmp/vibest-app"),
       },
     ]);
   });


### PR DESCRIPTION
## What

Rename the internal harness/server working-directory field `workspacePath` → `cwd`.

## Why

`workspacePath` was a purely internal, redundant alias:
- The public RPC/fs contract already standardized on `cwd` (`packages/contract/src/fs.ts`).
- The codex and pi agents already aliased `workspacePath → cwd` at their process boundaries.

Renaming unifies the vocabulary and removes the aliasing step (`cwd: config.workspacePath` collapses to `cwd: config.cwd`).

## Scope

Fully contained in `packages/harness` (root type `CreateSessionConfig`) and `packages/server` (harness layer + session port) plus their tests. `workspacePath` never appeared in `packages/contract`, `packages/client`, or the apps. The persisted session JSON stores `projectId` + `harnessSessionId` (cwd is re-derived at runtime), so **no wire contract or on-disk migration** is required.

### Deliberately not changed
- The `WorkspacePathEscape` fs error — part of a consistent `Workspace*` error family; renaming just one would make it an inconsistent outlier, and it's a distinct security concept.
- Dated design docs / decision tickets — historical artifacts; the code is the source of truth.

## Verification
- `turbo run typecheck --filter=@vibest/server --filter=@vibest/harness` ✅
- `turbo run test --filter=@vibest/server --filter=@vibest/harness` ✅ (131 passed / 2 skipped smoke)
- `pnpm lint && pnpm format` ✅