### PR TITLE
feat(session): persist sessionId, source title/history from harness, flatten list

### DIFF
--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -483,9 +483,8 @@ export type SessionSummary = {
   readonly status?: SessionStatus;
 };
 
-export type ListSessionsOutput = {
-  readonly sessions: ReadonlyArray<SessionSummary>;
-};
+/** `session.list` returns the summaries directly — one shape, no wrapper. */
+export type ListSessionsOutput = ReadonlyArray<SessionSummary>;
 
 export const RenameSessionInputSchema = Schema.Struct({
   ref: SessionRefSchema,

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -117,7 +117,7 @@ export type HarnessAgentSessionServiceShape = {
   readonly getSessionInfo: (
     harnessAgentId: HarnessAgentId,
     harnessSessionId: string,
-    workspacePath?: string,
+    cwd?: string,
   ) => Effect.Effect<SessionInfoResult, HarnessAgentNotFound | AgentOperationError>;
   /**
    * The raw per-session event stream, drained by the server SessionRuntime. The
@@ -371,12 +371,10 @@ export const makeHarnessAgentSessionService = (
         ),
       getCapabilities: (sessionId) =>
         getManaged(sessionId).pipe(Effect.flatMap((managed) => managed.session.getCapabilities)),
-      getSessionInfo: (harnessAgentId, harnessSessionId, workspacePath) =>
+      getSessionInfo: (harnessAgentId, harnessSessionId, cwd) =>
         registry
           .get(harnessAgentId)
-          .pipe(
-            Effect.flatMap((adapter) => adapter.getSessionInfo(harnessSessionId, workspacePath)),
-          ),
+          .pipe(Effect.flatMap((adapter) => adapter.getSessionInfo(harnessSessionId, cwd))),
       events: (sessionId) =>
         getManaged(sessionId).pipe(Effect.map((managed) => managed.session.events)),
       close,

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -6,6 +6,7 @@ import type {
   HarnessAgentSession,
   PromptReceipt,
   SessionCapabilities,
+  SessionInfoResult,
   UserInput,
 } from "./adapter";
 import {
@@ -15,6 +16,7 @@ import {
   AgentUnavailable,
   CapabilityUnsupported,
   type CreateSessionError,
+  type HarnessAgentNotFound,
   type ResumeSessionError,
   SessionClosed,
   SessionNotFound,
@@ -107,6 +109,16 @@ export type HarnessAgentSessionServiceShape = {
     SessionCapabilities,
     SessionNotFound | CapabilityUnsupported | AgentOperationError
   >;
+  /**
+   * Look up display info (title, recency) for a persisted session by its native
+   * id, without opening it — used at list time. Never requires an active
+   * session; goes straight to the adapter via the registry.
+   */
+  readonly getSessionInfo: (
+    harnessAgentId: HarnessAgentId,
+    harnessSessionId: string,
+    workspacePath?: string,
+  ) => Effect.Effect<SessionInfoResult, HarnessAgentNotFound | AgentOperationError>;
   /**
    * The raw per-session event stream, drained by the server SessionRuntime. The
    * harness never numbers or projects it; drafts are native-`sessionId`-keyed.
@@ -359,6 +371,12 @@ export const makeHarnessAgentSessionService = (
         ),
       getCapabilities: (sessionId) =>
         getManaged(sessionId).pipe(Effect.flatMap((managed) => managed.session.getCapabilities)),
+      getSessionInfo: (harnessAgentId, harnessSessionId, workspacePath) =>
+        registry
+          .get(harnessAgentId)
+          .pipe(
+            Effect.flatMap((adapter) => adapter.getSessionInfo(harnessSessionId, workspacePath)),
+          ),
       events: (sessionId) =>
         getManaged(sessionId).pipe(Effect.map((managed) => managed.session.events)),
       close,

--- a/packages/server/src/rpc/session.ts
+++ b/packages/server/src/rpc/session.ts
@@ -71,14 +71,12 @@ export const sessionRouter = orpc.router({
   // history / index -----------------------------------------------------------
   list: orpc.list.effect(function* ({ input, errors }) {
     const sessions = yield* SessionService;
-    return {
-      sessions: yield* sessions.list(input.projectId).pipe(
-        Effect.catchTags({
-          ProjectNotFound: (e) =>
-            Effect.fail(errors.NOT_FOUND({ message: `project ${e.projectId} not found` })),
-        }),
-      ),
-    };
+    return yield* sessions.list(input.projectId).pipe(
+      Effect.catchTags({
+        ProjectNotFound: (e) =>
+          Effect.fail(errors.NOT_FOUND({ message: `project ${e.projectId} not found` })),
+      }),
+    );
   }),
   rename: orpc.rename.effect(function* ({ input, errors }) {
     const sessions = yield* SessionService;

--- a/packages/server/src/session/port.ts
+++ b/packages/server/src/session/port.ts
@@ -76,7 +76,7 @@ export class HarnessAgentSessionPort extends Context.Service<
     readonly getSessionInfo: (
       harnessAgentId: HarnessAgentId,
       harnessSessionId: string,
-      workspacePath: string,
+      cwd: string,
     ) => Effect.Effect<SessionInfoResult>;
     // Session-scoped config setters; values use the harness's outward vocabulary.
     readonly setModel: (
@@ -143,9 +143,9 @@ export const HarnessAgentSessionPortLayer: Layer.Layer<
           .pipe(Effect.map((stream) => stream.pipe(Stream.map((draft) => draft.body)))),
       prompt: (harnessSessionId, input) => harness.prompt(harnessSessionId, input),
       interrupt: (harnessSessionId) => harness.interrupt(harnessSessionId),
-      getSessionInfo: (harnessAgentId, harnessSessionId, workspacePath) =>
+      getSessionInfo: (harnessAgentId, harnessSessionId, cwd) =>
         harness
-          .getSessionInfo(harnessAgentId, harnessSessionId, workspacePath)
+          .getSessionInfo(harnessAgentId, harnessSessionId, cwd)
           .pipe(Effect.catch(() => Effect.succeed<SessionInfoResult>({ _tag: "unsupported" }))),
       setModel: (harnessSessionId, model) => harness.setModel(harnessSessionId, model),
       setPermissionMode: (harnessSessionId, permissionMode) =>

--- a/packages/server/src/session/port.ts
+++ b/packages/server/src/session/port.ts
@@ -11,6 +11,7 @@ import {
   type ResumeSessionError,
   type SessionClosed,
   type SessionEnvelopeBody,
+  type SessionInfoResult,
   type SessionNotFound as HarnessSessionNotFound,
   type TurnAlreadyRunning,
   type UserInput,
@@ -67,6 +68,16 @@ export class HarnessAgentSessionPort extends Context.Service<
       input: UserInput,
     ) => Effect.Effect<PromptReceipt, HarnessPromptError>;
     readonly interrupt: (harnessSessionId: string) => Effect.Effect<void, HarnessInterruptError>;
+    /**
+     * Best-effort display info (title, recency, existence) for a persisted
+     * session, for listings. Never fails: a missing agent or a backend error
+     * degrades to `unsupported` so one bad lookup can't sink a whole listing.
+     */
+    readonly getSessionInfo: (
+      harnessAgentId: HarnessAgentId,
+      harnessSessionId: string,
+      workspacePath: string,
+    ) => Effect.Effect<SessionInfoResult>;
     // Session-scoped config setters; values use the harness's outward vocabulary.
     readonly setModel: (
       harnessSessionId: string,
@@ -132,6 +143,10 @@ export const HarnessAgentSessionPortLayer: Layer.Layer<
           .pipe(Effect.map((stream) => stream.pipe(Stream.map((draft) => draft.body)))),
       prompt: (harnessSessionId, input) => harness.prompt(harnessSessionId, input),
       interrupt: (harnessSessionId) => harness.interrupt(harnessSessionId),
+      getSessionInfo: (harnessAgentId, harnessSessionId, workspacePath) =>
+        harness
+          .getSessionInfo(harnessAgentId, harnessSessionId, workspacePath)
+          .pipe(Effect.catch(() => Effect.succeed<SessionInfoResult>({ _tag: "unsupported" }))),
       setModel: (harnessSessionId, model) => harness.setModel(harnessSessionId, model),
       setPermissionMode: (harnessSessionId, permissionMode) =>
         harness.setPermissionMode(harnessSessionId, permissionMode),

--- a/packages/server/src/session/repository.ts
+++ b/packages/server/src/session/repository.ts
@@ -9,33 +9,28 @@ import { isEnoent, readJson, removeFile, writeJsonAtomic } from "../infra/json-s
 import type { Session } from "../types";
 
 /**
- * Data access for `storage/sessions/<projectId>/<sessionId>.json`. The server
- * `sessionId` is the filename; the file body holds {@link Session}. No
- * business rules — orchestration (id generation, projectId resolution) lives in
+ * Data access for `storage/sessions/<projectId>/<sessionId>.json`. The filename
+ * mirrors {@link Session.sessionId}, which the body also carries. No business
+ * rules — orchestration (id generation, projectId resolution) lives in
  * SessionService.
  */
 export class SessionRepository extends Context.Service<
   SessionRepository,
   {
     /** All session metadata under a project; empty if the project dir is absent. */
-    readonly list: (
-      projectId: string,
-    ) => Effect.Effect<ReadonlyArray<{ sessionId: string; metadata: Session }>, StoreReadError>;
+    readonly list: (projectId: string) => Effect.Effect<ReadonlyArray<Session>, StoreReadError>;
     readonly read: (
       projectId: string,
       sessionId: string,
     ) => Effect.Effect<Session, StoreReadError | SessionNotFound>;
     /**
      * Reverse lookup: find a session by its (globally unique) sessionId alone,
-     * scanning every project directory. Returns the owning projectId too.
+     * scanning every project directory. The record carries its own projectId.
      */
     readonly findBySessionId: (
       sessionId: string,
-    ) => Effect.Effect<
-      { projectId: string; metadata: Session },
-      StoreReadError | SessionRefNotFound
-    >;
-    readonly write: (sessionId: string, metadata: Session) => Effect.Effect<void, StoreWriteError>;
+    ) => Effect.Effect<Session, StoreReadError | SessionRefNotFound>;
+    readonly write: (metadata: Session) => Effect.Effect<void, StoreWriteError>;
     /** Idempotent: removing an absent file succeeds. */
     readonly remove: (projectId: string, sessionId: string) => Effect.Effect<void, StoreWriteError>;
   }
@@ -101,7 +96,6 @@ export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths
               ids,
               (sessionId) =>
                 read(projectId, sessionId).pipe(
-                  Effect.map((metadata) => ({ sessionId, metadata })),
                   // A file that vanished between listing and reading is skipped,
                   // not fatal to the whole listing.
                   Effect.catchTag("SessionNotFound", () => Effect.succeed(null)),
@@ -121,7 +115,6 @@ export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths
               projectIds,
               (projectId) =>
                 read(projectId, sessionId).pipe(
-                  Effect.map((metadata) => ({ projectId, metadata })),
                   Effect.catchTag("SessionNotFound", () => Effect.succeed(null)),
                 ),
               { concurrency: "unbounded" },
@@ -133,8 +126,8 @@ export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths
           ),
         ),
 
-      write: (sessionId, metadata) =>
-        writeJsonAtomic(sessionFile(metadata.projectId, sessionId), metadata),
+      write: (metadata) =>
+        writeJsonAtomic(sessionFile(metadata.projectId, metadata.sessionId), metadata),
 
       remove: (projectId, sessionId) => removeFile(sessionFile(projectId, sessionId)),
     };

--- a/packages/server/src/session/service.ts
+++ b/packages/server/src/session/service.ts
@@ -202,13 +202,14 @@ export const SessionServiceLayer: Layer.Layer<
                 const sessionId = randomUUID();
                 const metadata: Session = {
                   version: 1,
+                  sessionId,
                   projectId,
                   harnessAgentId,
                   harnessSessionId,
                   createdAt: new Date().toISOString(),
                 };
                 const ref: SessionRef = { projectId, harnessAgentId, sessionId };
-                return repo.write(sessionId, metadata).pipe(
+                return repo.write(metadata).pipe(
                   // A failed metadata write must not leak the native session.
                   Effect.tapError(() => port.close(harnessSessionId)),
                   Effect.andThen(startRuntime(ref, harnessSessionId)),
@@ -266,31 +267,53 @@ export const SessionServiceLayer: Layer.Layer<
 
       list: (projectId) =>
         projects.findById(projectId).pipe(
-          Effect.flatMap(() => repo.list(projectId)),
-          Effect.flatMap((entries) =>
-            Effect.forEach(entries, ({ sessionId, metadata }) => {
-              const ref: SessionRef = {
-                projectId: metadata.projectId,
-                harnessAgentId: metadata.harnessAgentId,
-                sessionId,
-              };
-              const base: SessionSummary = {
-                projectId: metadata.projectId,
-                harnessAgentId: metadata.harnessAgentId,
-                sessionId,
-                createdAt: metadata.createdAt,
-                // getMessages fails UNSUPPORTED until native history reads land
-                // (tickets 10/11); advertising history we cannot serve would
-                // make clients skip their "transcript missing" handling.
-                historyAvailable: false,
-              };
-              // Merge the live phase from the runtime; a session with no runtime
-              // simply carries no status.
-              return manager.status(ref).pipe(
-                Effect.map((status): SessionSummary => ({ ...base, status })),
-                Effect.catchTag("SessionNotActive", () => Effect.succeed(base)),
-              );
-            }),
+          Effect.flatMap((project) =>
+            repo.list(projectId).pipe(
+              Effect.flatMap((sessions) =>
+                Effect.forEach(
+                  sessions,
+                  (metadata) =>
+                    Effect.gen(function* () {
+                      const ref: SessionRef = {
+                        projectId: metadata.projectId,
+                        harnessAgentId: metadata.harnessAgentId,
+                        sessionId: metadata.sessionId,
+                      };
+                      // Display data (title, recency, existence) from the
+                      // harness's own session index; best-effort, never fatal.
+                      const info = yield* port.getSessionInfo(
+                        metadata.harnessAgentId,
+                        metadata.harnessSessionId,
+                        project.path,
+                      );
+                      // Live phase from the runtime; null when no runtime is up.
+                      const status = yield* manager.status(ref).pipe(
+                        Effect.map((s): SessionStatus | null => s),
+                        Effect.catchTag("SessionNotActive", () => Effect.succeed(null)),
+                      );
+                      const found = info._tag === "found";
+                      return {
+                        projectId: metadata.projectId,
+                        harnessAgentId: metadata.harnessAgentId,
+                        sessionId: metadata.sessionId,
+                        createdAt: metadata.createdAt,
+                        // Existence in the harness's session index is the truth
+                        // for whether history can be served: a session it no
+                        // longer knows (`missing`) has none.
+                        historyAvailable: found,
+                        ...(found && info.info.title !== undefined
+                          ? { title: info.info.title }
+                          : {}),
+                        ...(found && info.info.updatedAt !== undefined
+                          ? { updatedAt: new Date(info.info.updatedAt).toISOString() }
+                          : {}),
+                        ...(status !== null ? { status } : {}),
+                      } satisfies SessionSummary;
+                    }),
+                  { concurrency: "unbounded" },
+                ),
+              ),
+            ),
           ),
         ),
 
@@ -327,10 +350,10 @@ export const SessionServiceLayer: Layer.Layer<
       resolveRef: (sessionId) =>
         repo.findBySessionId(sessionId).pipe(
           Effect.map(
-            ({ projectId, metadata }): SessionRef => ({
-              projectId,
+            (metadata): SessionRef => ({
+              projectId: metadata.projectId,
               harnessAgentId: metadata.harnessAgentId,
-              sessionId,
+              sessionId: metadata.sessionId,
             }),
           ),
         ),

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -63,31 +63,16 @@ export interface RuntimeConfig {
 
 /**
  * Server-owned recovery record for one session, persisted at
- * `storage/sessions/<projectId>/<sessionId>.json`. The server `sessionId` is
- * the filename, not a field; `harnessSessionId` is the agent-native id
- * (claude session uuid / codex thread id) the server translates to when
- * calling the harness.
+ * `storage/sessions/<projectId>/<sessionId>.json`. The filename mirrors
+ * `sessionId`, which is also stored in the body so a loaded record is
+ * self-contained; `harnessSessionId` is the agent-native id (claude session
+ * uuid / codex thread id) the server translates to when calling the harness.
  */
 export interface Session {
   readonly version: 1;
+  readonly sessionId: string;
   readonly projectId: string;
   readonly harnessAgentId: HarnessAgentId;
   readonly harnessSessionId: string;
   readonly createdAt: string;
-}
-
-/** Session-related placeholder shapes (fields not fully designed yet). */
-export interface SessionSummary {
-  readonly id: string;
-  readonly harnessAgentId: HarnessAgentId;
-  readonly name?: string;
-  readonly archived: boolean;
-}
-
-/** A session event pushed over the event stream (payload shape is a placeholder). */
-export interface SessionEvent {
-  readonly sessionId: string;
-  readonly harnessAgentId: HarnessAgentId;
-  readonly type: string;
-  readonly payload: unknown;
 }

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -35,6 +35,7 @@ rl.on("line", (line) => {
   const msg = JSON.parse(line);
   if (msg.method === "initialize") send({ id: msg.id, result: {} });
   if (msg.method === "thread/start") send({ id: msg.id, result: { thread: { id: "th_1" } } });
+  if (msg.method === "thread/read") send({ id: msg.id, result: { thread: { id: "th_1", name: "Fake thread", preview: "hi", updatedAt: 1700000000 } } });
   if (msg.method === "turn/start") {
     send({ id: msg.id, result: { turn: { id: "turn_1" } } });
     send({ method: "turn/started", params: { threadId: "th_1", turn: { id: "turn_1" } } });
@@ -148,20 +149,20 @@ describe("session router", () => {
 
       // Active session: list carries the live phase from the running runtime.
       const active = await client.session.list({ projectId: project.id });
-      expect(active.sessions).toHaveLength(1);
-      expect(active.sessions[0]?.sessionId).toBe(ref.sessionId);
-      expect(active.sessions[0]?.status?.phase).toBeDefined();
+      expect(active).toHaveLength(1);
+      expect(active[0]?.sessionId).toBe(ref.sessionId);
+      expect(active[0]?.status?.phase).toBeDefined();
 
       // Closed but not deleted: metadata stays, the runtime is gone → no status.
       await client.session.close({ ref });
       const idle = await client.session.list({ projectId: project.id });
-      expect(idle.sessions).toHaveLength(1);
-      expect(idle.sessions[0]?.status).toBeUndefined();
+      expect(idle).toHaveLength(1);
+      expect(idle[0]?.status).toBeUndefined();
 
       // Delete: metadata removed → the session leaves the listing entirely.
       await client.session.delete({ ref });
       const empty = await client.session.list({ projectId: project.id });
-      expect(empty.sessions).toHaveLength(0);
+      expect(empty).toHaveLength(0);
     } finally {
       await dispose();
     }

--- a/packages/server/test/session-repository.test.ts
+++ b/packages/server/test/session-repository.test.ts
@@ -11,8 +11,9 @@ import type { Session } from "../src/types";
 
 const makeLayer = (home: string) => SessionRepositoryLayer.pipe(Layer.provide(layerPaths(home)));
 
-const meta = (projectId: string, harnessSessionId: string): Session => ({
+const meta = (sessionId: string, projectId: string, harnessSessionId: string): Session => ({
   version: 1,
+  sessionId,
   projectId,
   harnessAgentId: "claude-code",
   harnessSessionId,
@@ -35,39 +36,40 @@ describe("SessionRepository", () => {
     const read = await run(
       Effect.gen(function* () {
         const repo = yield* SessionRepository;
-        yield* repo.write("sess-1", meta("proj-a", "claude-uuid-1"));
+        yield* repo.write(meta("sess-1", "proj-a", "claude-uuid-1"));
         return yield* repo.read("proj-a", "sess-1");
       }),
     );
+    expect(read.sessionId).toBe("sess-1");
     expect(read.harnessSessionId).toBe("claude-uuid-1");
     expect(read.version).toBe(1);
   });
 
-  it("persists at storage/sessions/<projectId>/<sessionId>.json, sessionId only in filename", async () => {
+  it("persists at storage/sessions/<projectId>/<sessionId>.json, sessionId in the body too", async () => {
     await run(
       Effect.gen(function* () {
         const repo = yield* SessionRepository;
-        yield* repo.write("sess-1", meta("proj-a", "claude-uuid-1"));
+        yield* repo.write(meta("sess-1", "proj-a", "claude-uuid-1"));
       }),
     );
     const raw = JSON.parse(
       await readFile(join(home, "storage", "sessions", "proj-a", "sess-1.json"), "utf8"),
     );
-    expect(raw).not.toHaveProperty("sessionId");
+    expect(raw.sessionId).toBe("sess-1");
     expect(raw.projectId).toBe("proj-a");
   });
 
-  it("lists all sessions of a project, keyed by filename sessionId", async () => {
+  it("lists all sessions of a project", async () => {
     const listed = await run(
       Effect.gen(function* () {
         const repo = yield* SessionRepository;
-        yield* repo.write("sess-1", meta("proj-a", "u1"));
-        yield* repo.write("sess-2", meta("proj-a", "u2"));
-        yield* repo.write("sess-3", meta("proj-b", "u3"));
+        yield* repo.write(meta("sess-1", "proj-a", "u1"));
+        yield* repo.write(meta("sess-2", "proj-a", "u2"));
+        yield* repo.write(meta("sess-3", "proj-b", "u3"));
         return yield* repo.list("proj-a");
       }),
     );
-    expect(listed.map((entry) => entry.sessionId).toSorted()).toEqual(["sess-1", "sess-2"]);
+    expect(listed.map((session) => session.sessionId).toSorted()).toEqual(["sess-1", "sess-2"]);
   });
 
   it("list returns empty for a project with no session dir", async () => {
@@ -96,7 +98,7 @@ describe("SessionRepository", () => {
     const listedAfter = await run(
       Effect.gen(function* () {
         const repo = yield* SessionRepository;
-        yield* repo.write("sess-1", meta("proj-a", "u1"));
+        yield* repo.write(meta("sess-1", "proj-a", "u1"));
         yield* repo.remove("proj-a", "sess-1");
         yield* repo.remove("proj-a", "sess-1"); // idempotent: second remove is a no-op
         return yield* repo.list("proj-a");
@@ -109,13 +111,14 @@ describe("SessionRepository", () => {
     const hit = await run(
       Effect.gen(function* () {
         const repo = yield* SessionRepository;
-        yield* repo.write("sess-1", meta("proj-a", "u1"));
-        yield* repo.write("sess-2", meta("proj-b", "u2"));
+        yield* repo.write(meta("sess-1", "proj-a", "u1"));
+        yield* repo.write(meta("sess-2", "proj-b", "u2"));
         return yield* repo.findBySessionId("sess-2");
       }),
     );
     expect(hit.projectId).toBe("proj-b");
-    expect(hit.metadata.harnessSessionId).toBe("u2");
+    expect(hit.sessionId).toBe("sess-2");
+    expect(hit.harnessSessionId).toBe("u2");
   });
 
   it("findBySessionId fails with SessionRefNotFound for an unknown session", async () => {
@@ -123,7 +126,7 @@ describe("SessionRepository", () => {
       Effect.flip(
         Effect.gen(function* () {
           const repo = yield* SessionRepository;
-          yield* repo.write("sess-1", meta("proj-a", "u1"));
+          yield* repo.write(meta("sess-1", "proj-a", "u1"));
           return yield* repo.findBySessionId("ghost");
         }),
       ),

--- a/packages/server/test/session-service.test.ts
+++ b/packages/server/test/session-service.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { layerPaths } from "../src/config/paths";
 import { AgentUnavailable } from "../src/errors";
 import { EventBusLayer } from "../src/events";
+import type { SessionInfoResult } from "../src/harness";
 import { ProjectRepositoryLayer } from "../src/project/repository";
 import { ProjectService, ProjectServiceLayer } from "../src/project/service";
 import { type HarnessCreateError, HarnessAgentSessionPort } from "../src/session/port";
@@ -21,7 +22,9 @@ type PortSpy = {
   close: Array<string>;
 };
 
-const makeFakePort = (opts: { failCreate?: HarnessCreateError } = {}) => {
+const makeFakePort = (
+  opts: { failCreate?: HarnessCreateError; sessionInfo?: SessionInfoResult } = {},
+) => {
   const spy: PortSpy = { create: [], resume: [], close: [] };
   // Spy side effects live inside the effects (not at construction): callers
   // may build an effect without running it — e.g. the `onCrash` handed to the
@@ -45,6 +48,8 @@ const makeFakePort = (opts: { failCreate?: HarnessCreateError } = {}) => {
     // A started session drains an empty native stream — enough to exercise the
     // create/resume → runtime-start path without any active-instance ops.
     events: () => Effect.succeed(Stream.empty),
+    getSessionInfo: () =>
+      Effect.succeed<SessionInfoResult>(opts.sessionInfo ?? { _tag: "unsupported" }),
     prompt: () => Effect.die("prompt not exercised"),
     interrupt: () => Effect.die("interrupt not exercised"),
     setModel: () => Effect.die("setModel not exercised"),
@@ -252,8 +257,46 @@ describe("SessionService", () => {
     expect(result.listed.map((s) => s.sessionId).toSorted()).toEqual(
       [result.a.sessionId, result.b.sessionId].toSorted(),
     );
-    // getMessages is not implemented yet, so listings must not advertise history.
+    // The default fake reports `unsupported`, so history is not advertised.
     expect(result.listed.every((s) => !s.historyAvailable)).toBe(true);
+  });
+
+  it("list reflects the harness's title, recency, and history availability", async () => {
+    const { layer } = makeFakePort({
+      sessionInfo: { _tag: "found", info: { title: "My chat", updatedAt: 1_700_000_000_000 } },
+    });
+    const listed = await run(
+      layer,
+      Effect.gen(function* () {
+        const projects = yield* ProjectService;
+        const sessions = yield* SessionService;
+        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
+        yield* sessions.create(project.id, "claude-code");
+        return yield* sessions.list(project.id);
+      }),
+    );
+    expect(listed).toHaveLength(1);
+    // A session the harness still knows carries history + its display fields.
+    expect(listed[0]?.historyAvailable).toBe(true);
+    expect(listed[0]?.title).toBe("My chat");
+    expect(listed[0]?.updatedAt).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+
+  it("list marks a session the harness no longer knows as history-unavailable", async () => {
+    const { layer } = makeFakePort({ sessionInfo: { _tag: "missing" } });
+    const listed = await run(
+      layer,
+      Effect.gen(function* () {
+        const projects = yield* ProjectService;
+        const sessions = yield* SessionService;
+        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
+        yield* sessions.create(project.id, "claude-code");
+        return yield* sessions.list(project.id);
+      }),
+    );
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.historyAvailable).toBe(false);
+    expect(listed[0]?.title).toBeUndefined();
   });
 
   it("list fails with ProjectNotFound for an unknown project", async () => {


### PR DESCRIPTION
## 概要

补齐 session 持久化与列举的四个正确性问题(承接落盘布局设计,PR #118/#119 之后)。

## 变更

- **落盘 `Session` body 现在自带 `sessionId` 字段** —— 不再只靠文件名,记录 self-contained。`repo.write` 收敛为单参,`list`/`findBySessionId` 直接返回 `Session`(去掉 `{sessionId, metadata}` 元组)。
- **title / updatedAt / historyAvailable 改为向 harness 实时取** —— title 是 harness 原生能力,vibest 不落盘。`SessionService.list` 新增 `getSessionInfo` seam(`port → HarnessAgentSessionService → adapter`,claude/codex/pi 三家 adapter 本就实现),按 session 取 `SessionInfoResult`:
  - `found` → `historyAvailable = true`,并填 `title` / `updatedAt`
  - `missing` → `historyAvailable = false`(harness 已不认识该 session,history not available)
  - `unsupported` → 同 missing,不广告 history
  - 取信息为 best-effort:失败经 `Effect.catch` 兜底成 `unsupported`,不阻断 list。
- **`session.list` 输出去掉 `{ sessions }` 包装** —— `ListSessionsOutput = ReadonlyArray<SessionSummary>`,一个数据结构直出;server types 里死掉的 `SessionSummary` / `SessionEvent` placeholder 一并删除。

## 测试

- server 全量测试通过(133 passed / 2 skipped)。
- 新增两条 list 用例:harness 仍认识时带 title/recency/history;harness 不再认识时标 history-unavailable。
- typecheck(server + contract)0 error,oxlint clean。

> 备注:前端 `app-sidebar.tsx` 仍是 mock,未接 `session.list` —— 不在本 PR 范围。
