### PR TITLE
fix(app): scroll the transcript, not the whole card

### DIFF
--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -42,7 +42,10 @@ function RootLayout() {
 
   return (
     // -webkit-app-region drags the desktop window (no-op in the browser).
-    <SidebarProvider className="[-webkit-app-region:drag]">
+    // h-svh pins the shell to the viewport: the provider's own min-h-svh leaves
+    // the height auto, so a long transcript would stretch the whole card and
+    // scroll the document instead of the message list.
+    <SidebarProvider className="h-svh overflow-hidden [-webkit-app-region:drag]">
       <AppSidebar onNewChat={handleNewChat} />
       <CardPanel isFetching={isFetching} />
       {/*


### PR DESCRIPTION
## Problem

When a chat session's message list grew past the viewport, the **entire card scrolled** — header and chat input included — instead of just the message area.

## Root cause

Not `CardPanel` itself; the height chain was broken at the top. `SidebarProvider`'s wrapper (`packages/ui/src/components/sidebar.tsx`) only carries `min-h-svh`, so its height stays `auto`:

- `SidebarInset` stretches to the wrapper's height (`max(100svh, content)`), so its `min-h-0 overflow-hidden` never binds.
- `Conversation`'s `flex-1` has no definite parent height to resolve against and falls back to content height.
- `use-stick-to-bottom`'s real scroller is the inner `height: 100%` div — `100%` of `auto` is `auto`.

Net effect: the document scrolls, not the message list.

## Fix

Add `h-svh overflow-hidden` to the `SidebarProvider` in `__root.tsx`, pinning the shell to the viewport. `packages/ui` is left untouched (it is registry-synced).

## Verification

Ran `vibest serve`, opened a real session, injected a 3000px block into the transcript:

| | document scrollHeight / clientHeight | transcript scrollHeight / clientHeight |
|---|---|---|
| after fix | 793 / 793 (no scroll) | 3224 / 632 (scrolls) |
| `h-svh` removed to reproduce | 3385 / 793 (page scrolls) | 3224 / 3224 (no scroll) |

Screenshot confirmed the header and composer stay fixed while the middle scrolls. `pnpm run lint` and `pnpm --filter @vibest/app typecheck` pass.