### PR TITLE
refactor(server): move disk, path, and randomness onto Effect's platform services

### DIFF
--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -48,28 +48,30 @@ fail, is it non-deterministic — **not** _"did it come from a `node:` module?"_
 | `join` / `dirname` / `relative` / `isAbsolute` / `sep` — pure string math |                       | `node:path`                      |
 | `homedir()`                                                               |                       | `node:os` (no Effect equivalent) |
 
-`effect/Path` is therefore reached for only when an Effect already has it in
-scope for other reasons; taking `Path.Path` as a _parameter_ to do string work,
-or turning a pure function into an `Effect` to reach it, is the thing this rule
-forbids. Reference points: opencode uses `Path.Path` in 2 files across its core
-and server, and `Crypto.Crypto` in none.
+`effect/Path` is therefore reached for only when a library asks for it. Taking
+`Path.Path` as a _parameter_ to do string work, or turning a pure function into
+an `Effect` to reach it, is the thing this rule forbids. `packages/server` has
+exactly one `Path.Path`, in `http/ui.ts`, and it is not ours —
+`HttpStaticServer.make` requires it. (Reference point: opencode, also on Effect
+4.x beta, uses `Path.Path` in 2 files across its core and server and
+`Crypto.Crypto` in none.)
 
 - **The dependency rides the `R` channel.** A function that touches disk is
-  `Effect<A, E, FileSystem.FileSystem | Path.Path>`. Don't seal a layer inside
+  `Effect<A, E, FileSystem.FileSystem>`. Don't seal a layer inside
   the module and don't promote the need into a new service — the requirement
   bubbles to a composition root (`rpc/runtime.ts`, `apps/desktop`'s
   `desktop-runtime.ts`, the CLI), which is the only place `NodeFileSystem.layer`
   / `NodePath.layer` / `NodeCrypto.layer` appear.
 - **A service shape stays `R`-free.** Bind the platform once while building the
-  Layer — `const platform = yield* Effect.context<FileSystem | Path>()` — and
+  Layer — `const platform = yield* Effect.context<FileSystem | Crypto>()` — and
   `Effect.provide(platform)` each method. `infra/json-store.ts` plus the four
   repositories are the pattern to copy.
 - **Platform failures get mapped at the seam,** not propagated raw: the store's
   `StoreReadError` / `StoreWriteError` wrap them, and "file isn't there" is
   `error.reason._tag === "NotFound"` (`isNotFound`), never an errno string.
-- **Two gaps to route around.** `FileSystem.access` has no `X_OK` — test
+- **One gap to route around.** `FileSystem.access` has no `X_OK` — test
   executability with `stat` + `(info.mode & 0o111) !== 0`, as both executable
-  resolvers do. `Path` has no `delimiter` — derive it from the platform locally.
+  resolvers do.
 - **Tests:** real-fs + `mkdtemp` for behaviour, `FileSystem.makeNoop` (see
   `packages/server/test/fake-file-system.ts`) for failures a real disk won't
   produce on demand.
@@ -95,5 +97,5 @@ already written" is not a reason to add to the list:
 
 `node:path` is not on this list because it never needed an exemption — see
 "Where the boundary is" above. Path math is pure, so it stays `node:path`
-everywhere; the migration overshot on this one and `packages/server` still
-carries ~60 `Path.Path` references that predate the rule.
+everywhere, and thirteen files in `packages/server/src` import it for exactly
+that.

--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -74,12 +74,13 @@ exactly one `Path.Path`, in `http/ui.ts`, and it is not ours —
   resolvers do.
 - **Tests:** real-fs + `mkdtemp` for behaviour, `FileSystem.makeNoop` (see
   `packages/server/test/fake-file-system.ts`) for failures a real disk won't
-  produce on demand. Providing the platform has two spellings and no third:
-  `@effect/vitest`'s `layer(...)` + `it.effect` when the whole file is effects
-  (`test/harness/child-process.test.ts`), and `runNode` from
-  `packages/server/test/platform.ts` when the bodies are Promise-shaped around
-  `beforeEach`/`afterEach`. Don't re-declare a local `Effect.provide(NodeServices.layer)`
-  wrapper per file.
+  produce on demand. A test that needs the real Node platform gets it from
+  `@effect/vitest`'s `layer(...)` and writes `it.effect` bodies — never a local
+  `run = (effect) => Effect.runPromise(effect.pipe(Effect.provide(...)))`
+  wrapper, which re-runs the layer per test and turns every assertion into an
+  `await`. `layer(...)` builds it once for the block and scopes each test, so
+  `fs.makeTempDirectoryScoped` and `Effect.addFinalizer` replace
+  `beforeEach`/`afterEach` (`test/daemon/launcher.test.ts`).
 - **The HTTP seam is `NodeHttpServer.makeHandler`,** not `HttpServer.serve`:
   `serve` registers its own `upgrade` listener, and that event belongs to oRPC
   and Vite's HMR socket. `makeHandler` yields a plain node `request` listener,

--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -22,3 +22,48 @@ These differ from what the library names suggest.
   `./src/*.ts` directly and only `server` and `vibest` build. `lib` is `es2022`,
   so `toSorted`/`toSpliced` don't typecheck — write `Array.from(list).sort()`.
   `noUncheckedIndexedAccess` is on, so indexed access yields `T | undefined`.
+
+## Side effects go through Effect's platform services
+
+New disk, path, randomness, and child-process code uses `effect/FileSystem`,
+`effect/Path`, `effect/Crypto`, and `effect/unstable/process`'s
+`ChildProcessSpawner` — not `node:fs` / `node:path` / `node:crypto` /
+`node:child_process`. `packages/server` was migrated wholesale in
+`docs/2026-07-27-effect-platform-migration.md`; matching the surrounding style
+means matching this.
+
+- **The dependency rides the `R` channel.** A function that touches disk is
+  `Effect<A, E, FileSystem.FileSystem | Path.Path>`. Don't seal a layer inside
+  the module and don't promote the need into a new service — the requirement
+  bubbles to a composition root (`rpc/runtime.ts`, `apps/desktop`'s
+  `desktop-runtime.ts`, the CLI), which is the only place `NodeFileSystem.layer`
+  / `NodePath.layer` / `NodeCrypto.layer` appear.
+- **A service shape stays `R`-free.** Bind the platform once while building the
+  Layer — `const platform = yield* Effect.context<FileSystem | Path>()` — and
+  `Effect.provide(platform)` each method. `infra/json-store.ts` plus the four
+  repositories are the pattern to copy.
+- **Platform failures get mapped at the seam,** not propagated raw: the store's
+  `StoreReadError` / `StoreWriteError` wrap them, and "file isn't there" is
+  `error.reason._tag === "NotFound"` (`isNotFound`), never an errno string.
+- **Two gaps to route around.** `FileSystem.access` has no `X_OK` — test
+  executability with `stat` + `(info.mode & 0o111) !== 0`, as both executable
+  resolvers do. `Path` has no `delimiter` — derive it from the platform locally.
+- **Tests:** real-fs + `mkdtemp` for behaviour, `FileSystem.makeNoop` (see
+  `packages/server/test/fake-file-system.ts`) for failures a real disk won't
+  produce on demand.
+
+Exempt, deliberately — these are boundaries Effect doesn't model, and "it's
+already written" is not a reason to add to the list:
+
+| Location                                                                  | Why                                                                                                  |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `daemon/launcher.ts`'s `spawnDetached`                                    | detached + unref + stdio to a log fd is the opposite of `ChildProcessSpawner`'s supervised semantics |
+| `http/server.ts` as a whole                                               | node:http, ws, the oRPC WS handler, and Vite HMR share one server and its upgrade event              |
+| Call sites inside an exempt file                                          | e.g. `http/auth.ts`'s ticket `randomUUID`, called synchronously from Promise-shaped `http/server.ts` |
+| `apps/desktop/src/main`'s Electron-bound files                            | `app-protocol`, `main-window`, `desktop-config`, `lib/utils` are tied to the Electron lifecycle      |
+| `packages/services`' terminal-manager                                     | node-pty has no Effect equivalent (and the package is dormant)                                       |
+| `node:os.homedir` (`config/paths.ts`, `rpc/fs.ts`)                        | Effect has no OS/home-directory service                                                              |
+| `node:module.createRequire` (`harness/claude-code/executable.ts`)         | no Effect equivalent                                                                                 |
+| `daemon/port.ts`, and the `process.kill` signals in `liveness`/`launcher` | Effect has no port-probe or process-signal service                                                   |
+
+Exempt files keep `node:path` too; migrated ones switch to the `Path` service.

--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -51,6 +51,11 @@ means matching this.
 - **Tests:** real-fs + `mkdtemp` for behaviour, `FileSystem.makeNoop` (see
   `packages/server/test/fake-file-system.ts`) for failures a real disk won't
   produce on demand.
+- **The HTTP seam is `NodeHttpServer.makeHandler`,** not `HttpServer.serve`:
+  `serve` registers its own `upgrade` listener, and that event belongs to oRPC
+  and Vite's HMR socket. `makeHandler` yields a plain node `request` listener,
+  so `http/app.ts` is an ordinary Effect while `http/server.ts` keeps the raw
+  upgrade block.
 
 Exempt, deliberately — these are boundaries Effect doesn't model, and "it's
 already written" is not a reason to add to the list:
@@ -58,7 +63,7 @@ already written" is not a reason to add to the list:
 | Location                                                                  | Why                                                                                                  |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `daemon/launcher.ts`'s `spawnDetached`                                    | detached + unref + stdio to a log fd is the opposite of `ChildProcessSpawner`'s supervised semantics |
-| `http/server.ts` as a whole                                               | node:http, ws, the oRPC WS handler, and Vite HMR share one server and its upgrade event              |
+| `http/server.ts`'s `upgrade` path                                         | oRPC and Vite HMR share that event; Effect's own websocket handler would fight them for the listener |
 | Call sites inside an exempt file                                          | e.g. `http/auth.ts`'s ticket `randomUUID`, called synchronously from Promise-shaped `http/server.ts` |
 | `apps/desktop/src/main`'s Electron-bound files                            | `app-protocol`, `main-window`, `desktop-config`, `lib/utils` are tied to the Electron lifecycle      |
 | `packages/services`' terminal-manager                                     | node-pty has no Effect equivalent (and the package is dormant)                                       |

--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -77,10 +77,19 @@ exactly one `Path.Path`, in `http/ui.ts`, and it is not ours —
   produce on demand. A test that needs the real Node platform gets it from
   `@effect/vitest`'s `layer(...)` and writes `it.effect` bodies — never a local
   `run = (effect) => Effect.runPromise(effect.pipe(Effect.provide(...)))`
-  wrapper, which re-runs the layer per test and turns every assertion into an
-  `await`. `layer(...)` builds it once for the block and scopes each test, so
+  wrapper. That wrapper rebuilds its layer on every call, so two `run`s in one
+  test silently get two service instances; it also forces every assertion out
+  of the effect and into an `await`.
+- **Per-test isolation is `Layer.build` inside the body,** not a second
+  `layer(...)`: `layer(...)` memoizes per block, so anything stateful (a temp
+  `$VIBEST_HOME`, an EventBus) would leak between tests. Put the platform in
+  `layer(NodePlatformLayer)`, then build the service graph per test —
+  `Context.get(yield* Layer.build(...), Tag)`. `it.effect` bodies are scoped, so
   `fs.makeTempDirectoryScoped` and `Effect.addFinalizer` replace
-  `beforeEach`/`afterEach` (`test/daemon/launcher.test.ts`).
+  `beforeEach`/`afterEach` and fire on the failure path too
+  (`test/session-service.test.ts`, `test/daemon/launcher.test.ts`).
+  `layer(..., { excludeTestServices: true })` when the code under test polls a
+  real clock — the default `TestClock` never advances a retry schedule.
 - **The HTTP seam is `NodeHttpServer.makeHandler`,** not `HttpServer.serve`:
   `serve` registers its own `upgrade` listener, and that event belongs to oRPC
   and Vite's HMR socket. `makeHandler` yields a plain node `request` listener,

--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -74,7 +74,12 @@ exactly one `Path.Path`, in `http/ui.ts`, and it is not ours —
   resolvers do.
 - **Tests:** real-fs + `mkdtemp` for behaviour, `FileSystem.makeNoop` (see
   `packages/server/test/fake-file-system.ts`) for failures a real disk won't
-  produce on demand.
+  produce on demand. Providing the platform has two spellings and no third:
+  `@effect/vitest`'s `layer(...)` + `it.effect` when the whole file is effects
+  (`test/harness/child-process.test.ts`), and `runNode` from
+  `packages/server/test/platform.ts` when the bodies are Promise-shaped around
+  `beforeEach`/`afterEach`. Don't re-declare a local `Effect.provide(NodeServices.layer)`
+  wrapper per file.
 - **The HTTP seam is `NodeHttpServer.makeHandler`,** not `HttpServer.serve`:
   `serve` registers its own `upgrade` listener, and that event belongs to oRPC
   and Vite's HMR socket. `makeHandler` yields a plain node `request` listener,

--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -25,12 +25,34 @@ These differ from what the library names suggest.
 
 ## Side effects go through Effect's platform services
 
-New disk, path, randomness, and child-process code uses `effect/FileSystem`,
-`effect/Path`, `effect/Crypto`, and `effect/unstable/process`'s
-`ChildProcessSpawner` — not `node:fs` / `node:path` / `node:crypto` /
-`node:child_process`. `packages/server` was migrated wholesale in
-`docs/2026-07-27-effect-platform-migration.md`; matching the surrounding style
-means matching this.
+New disk, randomness, and child-process code uses `effect/FileSystem`,
+`effect/Crypto`, and `effect/unstable/process`'s `ChildProcessSpawner` — not
+`node:fs` / `node:crypto` / `node:child_process`. `packages/server` was migrated
+wholesale in `docs/2026-07-27-effect-platform-migration.md`; matching the
+surrounding style means matching this.
+
+## Where the boundary is
+
+**Don't return `Effect` from a helper unless it actually performs effectful
+work. Synchronous parsing, validation, path math, and option building stay
+synchronous.** (Same rule opencode states in its `AGENTS.md`.)
+
+The test is _"is this an effect?"_ — does it touch the outside world, can it
+fail, is it non-deterministic — **not** _"did it come from a `node:` module?"_
+
+|                                                                           | goes through Effect   | stays plain `node:`              |
+| ------------------------------------------------------------------------- | --------------------- | -------------------------------- |
+| read/write, `stat`, `mkdir`, `rename`                                     | `FileSystem`          |                                  |
+| ids and tokens (non-deterministic, must be fakeable)                      | `Crypto`              |                                  |
+| spawning children                                                         | `ChildProcessSpawner` |                                  |
+| `join` / `dirname` / `relative` / `isAbsolute` / `sep` — pure string math |                       | `node:path`                      |
+| `homedir()`                                                               |                       | `node:os` (no Effect equivalent) |
+
+`effect/Path` is therefore reached for only when an Effect already has it in
+scope for other reasons; taking `Path.Path` as a _parameter_ to do string work,
+or turning a pure function into an `Effect` to reach it, is the thing this rule
+forbids. Reference points: opencode uses `Path.Path` in 2 files across its core
+and server, and `Crypto.Crypto` in none.
 
 - **The dependency rides the `R` channel.** A function that touches disk is
   `Effect<A, E, FileSystem.FileSystem | Path.Path>`. Don't seal a layer inside
@@ -71,4 +93,7 @@ already written" is not a reason to add to the list:
 | `node:module.createRequire` (`harness/claude-code/executable.ts`)         | no Effect equivalent                                                                                 |
 | `daemon/port.ts`, and the `process.kill` signals in `liveness`/`launcher` | Effect has no port-probe or process-signal service                                                   |
 
-Exempt files keep `node:path` too; migrated ones switch to the `Path` service.
+`node:path` is not on this list because it never needed an exemption — see
+"Where the boundary is" above. Path math is pure, so it stays `node:path`
+everywhere; the migration overshot on this one and `packages/server` still
+carries ~60 `Path.Path` references that predate the rule.

--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -91,8 +91,8 @@ exactly one `Path.Path`, in `http/ui.ts`, and it is not ours —
   `layer(..., { excludeTestServices: true })` when the code under test polls a
   real clock — the default `TestClock` never advances a retry schedule.
 - **The HTTP seam is `NodeHttpServer.makeHandler`,** not `HttpServer.serve`:
-  `serve` registers its own `upgrade` listener, and that event belongs to oRPC
-  and Vite's HMR socket. `makeHandler` yields a plain node `request` listener,
+  `serve` registers its own `upgrade` listener, and that event belongs to oRPC.
+  `makeHandler` yields a plain node `request` listener,
   so `http/app.ts` is an ordinary Effect while `http/server.ts` keeps the raw
   upgrade block.
 
@@ -102,7 +102,7 @@ already written" is not a reason to add to the list:
 | Location                                                                  | Why                                                                                                  |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `daemon/launcher.ts`'s `spawnDetached`                                    | detached + unref + stdio to a log fd is the opposite of `ChildProcessSpawner`'s supervised semantics |
-| `http/server.ts`'s `upgrade` path                                         | oRPC and Vite HMR share that event; Effect's own websocket handler would fight them for the listener |
+| `http/server.ts`'s `upgrade` path                                         | oRPC owns that event; Effect's own websocket handler would fight it for the listener                 |
 | Call sites inside an exempt file                                          | e.g. `http/auth.ts`'s ticket `randomUUID`, called synchronously from Promise-shaped `http/server.ts` |
 | `apps/desktop/src/main`'s Electron-bound files                            | `app-protocol`, `main-window`, `desktop-config`, `lib/utils` are tied to the Electron lifecycle      |
 | `packages/services`' terminal-manager                                     | node-pty has no Effect equivalent (and the package is dormant)                                       |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,7 @@
     "react-error-boundary": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@electron-toolkit/tsconfig": "^2.0.0",
     "@orpc/tanstack-query": "catalog:orpc",
     "@playwright/test": "^1.61.1",

--- a/apps/desktop/src/main/desktop-runtime.ts
+++ b/apps/desktop/src/main/desktop-runtime.ts
@@ -1,4 +1,5 @@
 import * as NodeChildProcessSpawner from "@effect/platform-node/NodeChildProcessSpawner";
+import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { electronApp, is, optimizer } from "@electron-toolkit/utils";
@@ -14,7 +15,9 @@ import { LocalServerLive } from "./server/local-server-live";
 import { formatStartupFailure } from "./startup-failure";
 
 function makeRuntime(devUrl: string | undefined) {
-  const nodeBase = Layer.merge(NodeFileSystem.layer, NodePath.layer);
+  // The Node platform services: the daemon launcher's file state and token
+  // minting bubble these up their R channel, and this is where they land.
+  const nodeBase = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer, NodeCrypto.layer);
   const ChildProcessSpawnerLive = NodeChildProcessSpawner.layer.pipe(Layer.provide(nodeBase));
   const DesktopConfigLive = makeDesktopConfigLive({
     isPackaged: app.isPackaged,
@@ -29,6 +32,7 @@ function makeRuntime(devUrl: string | undefined) {
       Layer.provide(LocalServerLive),
       Layer.provide(DesktopConfigLive),
       Layer.provide(ChildProcessSpawnerLive),
+      Layer.provide(nodeBase),
     ),
   );
 }

--- a/apps/desktop/src/main/server/daemon-server-process.test.ts
+++ b/apps/desktop/src/main/server/daemon-server-process.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { readRecord, stopDaemon } from "@vibest/server/daemon";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -21,6 +22,11 @@ const server = http.createServer((req, res) => {
 server.listen(Number(process.env.VIBEST_PORT ?? 0), "127.0.0.1");
 `;
 
+// The launcher's file state runs on the platform services; the real ones here,
+// exactly as the desktop runtime provides them.
+const run = <A, E>(effect: Effect.Effect<A, E, NodeServices.NodeServices>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)));
+
 describe("DaemonServerProcess", () => {
   let home: string;
   let entry: string;
@@ -31,7 +37,7 @@ describe("DaemonServerProcess", () => {
     fs.writeFileSync(entry, FAKE_SERVER);
   });
   afterEach(async () => {
-    await Effect.runPromise(stopDaemon(home));
+    await run(stopDaemon(home));
     fs.rmSync(home, { recursive: true, force: true });
   });
 
@@ -41,18 +47,17 @@ describe("DaemonServerProcess", () => {
   });
 
   it("spawns the shared daemon and reports its endpoint, then attaches on respawn", async () => {
-    const spawn = makeDaemonServerProcess({ pollIntervalMs: 100 });
-
-    const endpoint = await Effect.runPromise(
+    const endpoint = await run(
       Effect.scoped(
         Effect.gen(function* () {
+          const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 100 });
           const running = yield* spawn(config(), 0);
           return yield* running.ready;
         }),
       ),
     );
 
-    const record = readRecord(home);
+    const record = await run(readRecord(home));
     expect(record).toBeDefined();
     // The endpoint carries the daemon's own minted token, read from the record.
     expect(endpoint).toEqual({
@@ -60,24 +65,24 @@ describe("DaemonServerProcess", () => {
       token: record!.token,
     });
 
-    const again = await Effect.runPromise(
+    const again = await run(
       Effect.scoped(
         Effect.gen(function* () {
+          const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 100 });
           const running = yield* spawn(config(), endpoint.port);
           return yield* running.ready;
         }),
       ),
     );
     expect(again).toEqual(endpoint);
-    expect(readRecord(home)?.pid).toBe(record!.pid);
+    expect((await run(readRecord(home)))?.pid).toBe(record!.pid);
   });
 
   it("resolves awaitExit when the daemon dies", async () => {
-    const spawn = makeDaemonServerProcess({ pollIntervalMs: 50 });
-
-    const exit = await Effect.runPromise(
+    const exit = await run(
       Effect.scoped(
         Effect.gen(function* () {
+          const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 50 });
           const running = yield* spawn(config(), 0);
           yield* running.ready;
           yield* stopDaemon(home);

--- a/apps/desktop/src/main/server/daemon-server-process.test.ts
+++ b/apps/desktop/src/main/server/daemon-server-process.test.ts
@@ -1,11 +1,10 @@
-import fs from "node:fs";
-import os from "node:os";
+import assert from "node:assert/strict";
 import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import { layer } from "@effect/vitest";
 import { readRecord, stopDaemon } from "@vibest/server/daemon";
-import { Effect } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Effect, FileSystem } from "effect";
 
 import { makeDaemonServerProcess } from "./daemon-server-process";
 import type { ServerProcessConfig } from "./local-server";
@@ -23,74 +22,78 @@ server.listen(Number(process.env.VIBEST_PORT ?? 0), "127.0.0.1");
 `;
 
 // The launcher's file state runs on the platform services; the real ones here,
-// exactly as the desktop runtime provides them.
-const run = <A, E>(effect: Effect.Effect<A, E, NodeServices.NodeServices>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)));
-
-describe("DaemonServerProcess", () => {
-  let home: string;
-  let entry: string;
-
-  beforeEach(() => {
-    home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-daemon-desktop-"));
-    entry = path.join(home, "fake-server.mjs");
-    fs.writeFileSync(entry, FAKE_SERVER);
-  });
-  afterEach(async () => {
-    await run(stopDaemon(home));
-    fs.rmSync(home, { recursive: true, force: true });
-  });
-
-  const config = (): ServerProcessConfig => ({
-    entry,
-    environment: { ...process.env, VIBEST_HOME: home },
-  });
-
-  it("spawns the shared daemon and reports its endpoint, then attaches on respawn", async () => {
-    const endpoint = await run(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 100 });
-          const running = yield* spawn(config(), 0);
-          return yield* running.ready;
-        }),
-      ),
-    );
-
-    const record = await run(readRecord(home));
-    expect(record).toBeDefined();
-    // The endpoint carries the daemon's own minted token, read from the record.
-    expect(endpoint).toEqual({
-      port: Number(new URL(record!.address).port),
-      token: record!.token,
+// exactly as the desktop runtime provides them. `excludeTestServices` because
+// readiness and liveness poll on a real clock, which the default TestClock
+// never advances.
+layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
+  "DaemonServerProcess",
+  (it) => {
+    /**
+     * A temp `$VIBEST_HOME` holding the fake server's entry point. Finalizers
+     * run LIFO, so the daemon is stopped before the directory holding its
+     * record goes away — on the failure path too.
+     */
+    const workspace = Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-daemon-desktop-" });
+      const entry = path.join(home, "fake-server.mjs");
+      yield* fs.writeFileString(entry, FAKE_SERVER);
+      yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(home)));
+      const config: ServerProcessConfig = {
+        entry,
+        environment: { ...process.env, VIBEST_HOME: home },
+      };
+      return { home, config };
     });
 
-    const again = await run(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 100 });
-          const running = yield* spawn(config(), endpoint.port);
-          return yield* running.ready;
-        }),
-      ),
-    );
-    expect(again).toEqual(endpoint);
-    expect((await run(readRecord(home)))?.pid).toBe(record!.pid);
-  });
+    it.effect("spawns the shared daemon and reports its endpoint, then attaches on respawn", () =>
+      Effect.gen(function* () {
+        const { home, config } = yield* workspace;
 
-  it("resolves awaitExit when the daemon dies", async () => {
-    const exit = await run(
-      Effect.scoped(
-        Effect.gen(function* () {
-          const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 50 });
-          const running = yield* spawn(config(), 0);
-          yield* running.ready;
-          yield* stopDaemon(home);
-          return yield* running.awaitExit;
-        }),
-      ),
+        const endpoint = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 100 });
+            const running = yield* spawn(config, 0);
+            return yield* running.ready;
+          }),
+        );
+
+        const record = yield* readRecord(home);
+        assert.ok(record);
+        // The endpoint carries the daemon's own minted token, read from the record.
+        assert.deepEqual(endpoint, {
+          port: Number(new URL(record.address).port),
+          token: record.token,
+        });
+
+        const again = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 100 });
+            const running = yield* spawn(config, endpoint.port);
+            return yield* running.ready;
+          }),
+        );
+        assert.deepEqual(again, endpoint);
+        assert.equal((yield* readRecord(home))?.pid, record.pid);
+      }),
     );
 
-    expect(exit).toEqual({ exitCode: null });
-  });
-});
+    it.effect("resolves awaitExit when the daemon dies", () =>
+      Effect.gen(function* () {
+        const { home, config } = yield* workspace;
+
+        const exit = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 50 });
+            const running = yield* spawn(config, 0);
+            yield* running.ready;
+            yield* stopDaemon(home);
+            return yield* running.awaitExit;
+          }),
+        );
+
+        assert.deepEqual(exit, { exitCode: null });
+      }),
+    );
+  },
+);

--- a/apps/desktop/src/main/server/daemon-server-process.ts
+++ b/apps/desktop/src/main/server/daemon-server-process.ts
@@ -1,5 +1,6 @@
 import {
   type DaemonHandle,
+  type DaemonPlatform,
   healthy,
   pidAlive,
   resolveOrSpawnDaemon,
@@ -32,54 +33,62 @@ export type DaemonServerProcessOptions = {
  *   tombstoned daemon and the supervisor surfaces "failed" instead. A fresh
  *   app launch (port === 0) is explicit intent and clears the tombstone.
  */
-export function makeDaemonServerProcess(options: DaemonServerProcessOptions = {}): SpawnServer {
+export function makeDaemonServerProcess(
+  options: DaemonServerProcessOptions = {},
+): Effect.Effect<SpawnServer, never, DaemonPlatform> {
   const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
 
-  return (config, port) =>
-    Effect.gen(function* () {
-      const environment = {
-        ...config.environment,
-        // The daemon runs `node <entry>` via the Electron binary.
-        ELECTRON_RUN_AS_NODE: "1",
-      };
+  return Effect.gen(function* () {
+    // The launcher's file state runs on the platform services; bind them once
+    // here so the spawner still satisfies the supervisor's `SpawnServer` shape.
+    const platform = yield* Effect.context<DaemonPlatform>();
 
-      const handle = yield* resolveOrSpawnDaemon({
-        home: resolveVibestHome(config.environment),
-        serverArgv: [process.execPath, config.entry],
-        // 0 means "no preference" on the first attempt; afterwards the
-        // supervisor pins the port it saw, which we pass as preferred.
-        port: port === 0 ? undefined : port,
-        environment,
-        autoRespawn: port !== 0,
-      }).pipe(
-        Effect.mapError(
-          (cause) =>
-            new ServerSpawnError({
-              message: `Unable to attach or spawn the vibest daemon: ${cause.message}`,
-              cause,
-            }),
-        ),
-      );
+    return (config, port) =>
+      Effect.gen(function* () {
+        const environment = {
+          ...config.environment,
+          // The daemon runs `node <entry>` via the Electron binary.
+          ELECTRON_RUN_AS_NODE: "1",
+        };
 
-      const awaitExit: Effect.Effect<ServerProcessExit, ServerSpawnError> = Effect.gen(
-        function* () {
-          let misses = 0;
-          while (true) {
-            yield* Effect.sleep(pollIntervalMs);
-            if (!pidAlive(handle.pid)) return { exitCode: null };
-            // Tolerate transient probe failures; a wedged-but-alive daemon
-            // still counts as dead after enough consecutive misses.
-            misses = (yield* healthy(handle.address)) ? 0 : misses + 1;
-            if (misses >= MAX_HEALTH_MISSES) return { exitCode: null };
-          }
-        },
-      );
+        const handle = yield* resolveOrSpawnDaemon({
+          home: resolveVibestHome(config.environment),
+          serverArgv: [process.execPath, config.entry],
+          // 0 means "no preference" on the first attempt; afterwards the
+          // supervisor pins the port it saw, which we pass as preferred.
+          port: port === 0 ? undefined : port,
+          environment,
+          autoRespawn: port !== 0,
+        }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ServerSpawnError({
+                message: `Unable to attach or spawn the vibest daemon: ${cause.message}`,
+                cause,
+              }),
+          ),
+        );
 
-      return {
-        ready: Effect.succeed(endpointOf(handle)),
-        awaitExit,
-      };
-    });
+        const awaitExit: Effect.Effect<ServerProcessExit, ServerSpawnError> = Effect.gen(
+          function* () {
+            let misses = 0;
+            while (true) {
+              yield* Effect.sleep(pollIntervalMs);
+              if (!pidAlive(handle.pid)) return { exitCode: null };
+              // Tolerate transient probe failures; a wedged-but-alive daemon
+              // still counts as dead after enough consecutive misses.
+              misses = (yield* healthy(handle.address)) ? 0 : misses + 1;
+              if (misses >= MAX_HEALTH_MISSES) return { exitCode: null };
+            }
+          },
+        );
+
+        return {
+          ready: Effect.succeed(endpointOf(handle)),
+          awaitExit,
+        };
+      }).pipe(Effect.provide(platform));
+  });
 }
 
 function endpointOf(handle: DaemonHandle): { port: number; token: string } {

--- a/apps/desktop/src/main/server/local-server-live.ts
+++ b/apps/desktop/src/main/server/local-server-live.ts
@@ -22,7 +22,7 @@ export const LocalServerLive = Layer.effect(
         entry: config.serverEntry,
         environment,
       },
-      makeDaemonServerProcess(),
+      yield* makeDaemonServerProcess(),
     );
   }),
 );

--- a/docs/2026-07-27-effect-platform-migration.md
+++ b/docs/2026-07-27-effect-platform-migration.md
@@ -1,0 +1,80 @@
+# Effect 平台服务迁移:node 原生 API → effect/FileSystem · Path · Crypto
+
+2026-07-27 定案(grilling 会话)。方针:**除了不能用 Effect 的地方,都要用**——
+副作用一律走 Effect 平台服务;豁免仅限 Effect 确实无法建模的边界,"不想动"不构成
+豁免理由。本次一个分支全量迁移,不分波次。
+
+## 豁免清单(写死,后续 agent 不得"顺手修正")
+
+| 位置                                                                                  | 理由                                                                                                                                                           |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/server/src/daemon/launcher.ts` 的 `spawnDetached`                           | detached + unref + stdio 重定向到 log fd,与 `ChildProcessSpawner` 的受监督语义(piped stdio、scope 关闭即杀)正好相反;文件注释已声明这是 Effect 无法建模的一道缝 |
+| `packages/server/src/http/server.ts` 整体                                             | node:http + ws 库 + oRPC WS handler + Vite HMR 四方共享同一 server 与 upgrade 事件;`NodeHttpServer` 替换会破坏 oRPC/Vite 集成,收益为负                         |
+| 豁免区内的调用点                                                                      | 例:`http/auth.ts` 的 `randomUUID`(ticket)被 Promise 风格的 `http/server.ts` 同步调用,调用上下文非 Effect,保留 node:crypto                                      |
+| `apps/desktop/src/main` 的 Electron API 交织处                                        | `app-protocol` / `main-window` / `desktop-config` / `lib/utils` 与 Electron 生命周期绑定                                                                       |
+| `packages/services` 的 terminal-manager                                               | node-pty 无 Effect 等价物(且该包 dormant)                                                                                                                      |
+| `node:os.homedir`(`config/paths.ts`、`rpc/fs.ts`)                                     | Effect 无 OS/home 目录服务                                                                                                                                     |
+| `node:module.createRequire`(`harness/claude-code/executable.ts` 中解析 SDK 的段落)    | 无 Effect 等价物                                                                                                                                               |
+| `daemon/port.ts`(node:net 试绑端口)、`process.kill` 信号(`liveness.ts`/`launcher.ts`) | Effect 无端口探测 / 进程信号的平台服务                                                                                                                         |
+
+## 迁移清单(全部"能用"项)
+
+1. **`infra/json-store.ts`** → `effect/FileSystem` + `effect/Path`。
+   - 依赖形态:**R 通道冒出**,签名变
+     `Effect<A, StoreReadError, FileSystem.FileSystem | Path.Path>`;不在模块内封死
+     layer,不升格为 service。
+   - 错误仍收敛为 `StoreReadError` / `StoreWriteError`;ENOENT 判断改用
+     PlatformError 的 `NotFound` reason(替代 errno 字符串)。
+   - `writeJsonAtomic` 的 tmp 文件名 `randomUUID` → `effect/Crypto`。
+   - `readJsonDir` 的顺序 for 循环顺带改 `Effect.forEach`。
+2. **`session/repository.ts`** — 两处裸 `readdir` → `fs.readDirectory`;
+   `withFileTypes` 目录过滤改用 stat(或逐目录 readDirectory 容错)。
+3. **project / provider / mcp repository** — R 通道连锁更新:Layer 的 R 从 `Paths`
+   变 `Paths | FileSystem | Path | Crypto`,在 `rpc/runtime.ts` 统一 provide
+   (NodeFileSystem / NodePath 已在,补 Crypto 的 node layer)。
+4. **node:crypto 全量**(豁免区外)→ `effect/Crypto`:launcher 的
+   `randomBytes(32)` token、`project/service` 与 `session/service` 的实体 id。
+5. **`harness/executable.ts` + `harness/claude-code/executable.ts`** →
+   Effect 化,`accessSync(X_OK)` → `fs.access`;deps 注入改为 FileSystem 注入;
+   createRequire 段保留(豁免)。
+6. **daemon `lock.ts` / `record.ts` / `tombstone.ts`** → FileSystem。
+   锁的排他创建用 `fs.open(path, { flag: "wx" })`(`OpenFlag` 已含 `"wx"`)。
+   同步变异步会移动锁竞态窗口——迁移时重新推演 launcher 的加锁/重入序列。
+7. **`daemon/launcher.ts`** — 编排已是 Effect,内部裸同步调用改 `yield*`;
+   `mkdirSync` → `fs.makeDirectory`;R 冒出 `FileSystem | Path | Crypto`。
+   调用方(CLI `cli.ts` 走 NodeServices、desktop `daemon-server-process.ts` 走
+   desktop-runtime)按需补 layer,均为机械改动。
+8. **`http/ui.ts`** — 静态资源读取 → FileSystem;Vite dev server 段不动。
+9. **`config/paths.ts`** — `join` → Path 服务,`Layer.sync` 变 `Layer.effect`;
+   `homedir` 保留。
+10. **`rpc/fs.ts`** — 残余 node:path → Path;`homedir` 保留。
+
+node:path 原则:**迁移的文件里顺带换 `effect/Path`**;豁免区文件保留 node:path。
+
+## 测试策略
+
+- 现有真实 fs + `mkdtemp` 测试全保留,断言不动;各 `makeLayer` 机械补
+  `NodeFileSystem.layer` / `NodePath.layer`(及 Crypto layer)。
+- **新增故障注入测试**:自制 fake FileSystem layer(`FileSystem.make`),验证
+  读失败 → `StoreReadError`、写失败 → `StoreWriteError`、NotFound → fallback
+  路径的错误映射层。
+- `apps/desktop/.../daemon-server-process.test.ts` 直接调用同步 `readRecord`,
+  随 record.ts Effect 化一并更新。
+
+## 规则成文
+
+`.agents/rules/stack.md` 新增一节,与迁移同 PR 提交:新写副作用代码
+(fs / 子进程)走 `effect/FileSystem`、`Path`、`Crypto`、`ChildProcessSpawner`,
+layer 在 composition root 统一 provide;附上方豁免清单及理由。
+
+## 实施顺序(同分支内分 commit)
+
+json-store + 四个 repository → crypto 全量 → executable ×2 → daemon 三件套 +
+launcher → ui / paths / rpc-fs → stack.md 规则。
+
+## 实现时需现场验证
+
+- `NodeFileSystem` 对 `open` `"wx"` flag 的实际行为(锁语义等价性)。
+- `effect/Crypto` 的 node layer 名称,以及 CLI 所用 `NodeServices.layer`
+  是否已包含 FileSystem/Path/Crypto,缺则单独补。
+- `readDirectory` 无 `withFileTypes` 时目录判定的实现取舍。

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -35,7 +35,6 @@
     "ai": "catalog:",
     "effect": "catalog:",
     "simple-git": "catalog:",
-    "sirv": "^3.0.2",
     "uuid": "catalog:",
     "ws": "catalog:",
     "zod": "catalog:"

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -33,12 +33,10 @@ const resolve = (home: string) => ({
  * (server Paths, CLI, desktop, daemon launcher) resolves through, so the
  * one-daemon-per-home invariant can never drift on a second definition.
  *
- * Deliberately a plain function, not an Effect: an env lookup and a string join
- * perform no effectful work, so per `.agents/rules/stack.md` they stay
- * synchronous. (`node:os.homedir` has no Effect equivalent either way.) Every
- * caller today is already inside an `Effect.gen` with `Path` in scope — that is
- * not the reason this is sync, and making it an Effect would cost them nothing;
- * it is sync because there is nothing here to suspend.
+ * A plain function, not an Effect: an env lookup and a string join perform no
+ * effectful work (`.agents/rules/stack.md`, "Where the boundary is"). Not
+ * because callers lack a runtime — every one of them is inside an `Effect.gen`
+ * today — but because there is nothing here to suspend.
  */
 export function resolveVibestHome(env: NodeJS.ProcessEnv = process.env): string {
   return env.VIBEST_HOME ?? path.join(os.homedir(), ".vibest");

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -1,5 +1,5 @@
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Context, Layer } from "effect";
 
@@ -23,9 +23,9 @@ export class Paths extends Context.Service<
 
 const resolve = (home: string) => ({
   home,
-  projectsFile: nodePath.join(home, "storage", "projects.json"),
-  configFile: nodePath.join(home, "config.json"),
-  sessionsDir: nodePath.join(home, "storage", "sessions"),
+  projectsFile: path.join(home, "storage", "projects.json"),
+  configFile: path.join(home, "config.json"),
+  sessionsDir: path.join(home, "storage", "sessions"),
 });
 
 /**
@@ -41,7 +41,7 @@ const resolve = (home: string) => ({
  * it is sync because there is nothing here to suspend.
  */
 export function resolveVibestHome(env: NodeJS.ProcessEnv = process.env): string {
-  return env.VIBEST_HOME ?? nodePath.join(os.homedir(), ".vibest");
+  return env.VIBEST_HOME ?? path.join(os.homedir(), ".vibest");
 }
 
 /** Point the runtime at an explicit home directory (used in tests). */

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -33,9 +33,12 @@ const resolve = (path: Path.Path, home: string) => ({
  * (server Paths, CLI, desktop, daemon launcher) resolves through, so the
  * one-daemon-per-home invariant can never drift on a second definition.
  *
- * Deliberately a plain function: it is the one thing every front door needs
- * before it has a runtime, and `node:os.homedir` has no Effect equivalent
- * anyway, so the join rides along with it.
+ * Deliberately a plain function, not an Effect: an env lookup and a string join
+ * perform no effectful work, so per `.agents/rules/stack.md` they stay
+ * synchronous. (`node:os.homedir` has no Effect equivalent either way.) Every
+ * caller today is already inside an `Effect.gen` with `Path` in scope — that is
+ * not the reason this is sync, and making it an Effect would cost them nothing;
+ * it is sync because there is nothing here to suspend.
  */
 export function resolveVibestHome(env: NodeJS.ProcessEnv = process.env): string {
   return env.VIBEST_HOME ?? nodePath.join(os.homedir(), ".vibest");

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import nodePath from "node:path";
 
-import { Context, Effect, Layer, Path } from "effect";
+import { Context, Layer } from "effect";
 
 /**
  * Resolved filesystem locations the runtime persists to. Injected as a service
@@ -21,11 +21,11 @@ export class Paths extends Context.Service<
   }
 >()("Paths") {}
 
-const resolve = (path: Path.Path, home: string) => ({
+const resolve = (home: string) => ({
   home,
-  projectsFile: path.join(home, "storage", "projects.json"),
-  configFile: path.join(home, "config.json"),
-  sessionsDir: path.join(home, "storage", "sessions"),
+  projectsFile: nodePath.join(home, "storage", "projects.json"),
+  configFile: nodePath.join(home, "config.json"),
+  sessionsDir: nodePath.join(home, "storage", "sessions"),
 });
 
 /**
@@ -45,22 +45,12 @@ export function resolveVibestHome(env: NodeJS.ProcessEnv = process.env): string 
 }
 
 /** Point the runtime at an explicit home directory (used in tests). */
-export const layerPaths = (home: string): Layer.Layer<Paths, never, Path.Path> =>
-  Layer.effect(
-    Paths,
-    Effect.gen(function* () {
-      const path = yield* Path.Path;
-      return resolve(path, home);
-    }),
-  );
+export const layerPaths = (home: string): Layer.Layer<Paths> => Layer.succeed(Paths, resolve(home));
 
 /** Default: `$VIBEST_HOME`, falling back to `~/.vibest`. */
-export const PathsLayer: Layer.Layer<Paths, never, Path.Path> = Layer.effect(
+export const PathsLayer: Layer.Layer<Paths> = Layer.sync(
   Paths,
   // Resolved when the layer is built, not when this module is imported — the
   // daemon sets `VIBEST_HOME` in the child's environment.
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    return resolve(path, resolveVibestHome());
-  }),
+  () => resolve(resolveVibestHome()),
 );

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
-import path from "node:path";
+import nodePath from "node:path";
 
-import { Context, Layer } from "effect";
+import { Context, Effect, Layer, Path } from "effect";
 
 /**
  * Resolved filesystem locations the runtime persists to. Injected as a service
@@ -21,7 +21,7 @@ export class Paths extends Context.Service<
   }
 >()("Paths") {}
 
-const resolve = (home: string) => ({
+const resolve = (path: Path.Path, home: string) => ({
   home,
   projectsFile: path.join(home, "storage", "projects.json"),
   configFile: path.join(home, "config.json"),
@@ -32,14 +32,32 @@ const resolve = (home: string) => ({
  * `$VIBEST_HOME`, falling back to `~/.vibest` — the single home every client
  * (server Paths, CLI, desktop, daemon launcher) resolves through, so the
  * one-daemon-per-home invariant can never drift on a second definition.
+ *
+ * Deliberately a plain function: it is the one thing every front door needs
+ * before it has a runtime, and `node:os.homedir` has no Effect equivalent
+ * anyway, so the join rides along with it.
  */
 export function resolveVibestHome(env: NodeJS.ProcessEnv = process.env): string {
-  return env.VIBEST_HOME ?? path.join(os.homedir(), ".vibest");
+  return env.VIBEST_HOME ?? nodePath.join(os.homedir(), ".vibest");
 }
 
 /** Point the runtime at an explicit home directory (used in tests). */
-export const layerPaths = (home: string): Layer.Layer<Paths> =>
-  Layer.sync(Paths, () => resolve(home));
+export const layerPaths = (home: string): Layer.Layer<Paths, never, Path.Path> =>
+  Layer.effect(
+    Paths,
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      return resolve(path, home);
+    }),
+  );
 
 /** Default: `$VIBEST_HOME`, falling back to `~/.vibest`. */
-export const PathsLayer: Layer.Layer<Paths> = Layer.sync(Paths, () => resolve(resolveVibestHome()));
+export const PathsLayer: Layer.Layer<Paths, never, Path.Path> = Layer.effect(
+  Paths,
+  // Resolved when the layer is built, not when this module is imported — the
+  // daemon sets `VIBEST_HOME` in the child's environment.
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    return resolve(path, resolveVibestHome());
+  }),
+);

--- a/packages/server/src/daemon/index.ts
+++ b/packages/server/src/daemon/index.ts
@@ -3,6 +3,7 @@ export { DaemonLaunchError, DaemonStoppedError } from "./errors";
 export {
   type DaemonHandle,
   type DaemonLauncherError,
+  type DaemonPlatform,
   type ResolveDaemonOptions,
   resolveOrSpawnDaemon,
   statusDaemon,

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -1,9 +1,8 @@
 import childProcess from "node:child_process";
-import crypto from "node:crypto";
 import fs from "node:fs";
-import path from "node:path";
+import nodePath from "node:path";
 
-import { Clock, Effect } from "effect";
+import { Clock, Crypto, Effect, FileSystem, Path, type PlatformError } from "effect";
 
 import { DaemonLaunchError, DaemonStoppedError } from "./errors";
 import { daemonAlive, healthy, pidAlive } from "./liveness";
@@ -57,6 +56,12 @@ export type ResolveDaemonOptions = {
 export type DaemonLauncherError = DaemonLaunchError | DaemonStoppedError;
 
 /**
+ * The platform services the launcher's file state runs on. Provided at each
+ * front door's composition root (CLI `NodeServices`, desktop runtime).
+ */
+export type DaemonPlatform = FileSystem.FileSystem | Path.Path | Crypto.Crypto;
+
+/**
  * The shared launcher (the local twin of the SSH launch script): read
  * `daemon.pid`; if a healthy daemon is there, attach; otherwise spawn the
  * foreground server detached, wait for it to answer health, and record it. Both
@@ -74,17 +79,17 @@ export type DaemonLauncherError = DaemonLaunchError | DaemonStoppedError;
  */
 export const resolveOrSpawnDaemon = (
   options: ResolveDaemonOptions,
-): Effect.Effect<DaemonHandle, DaemonLauncherError> =>
+): Effect.Effect<DaemonHandle, DaemonLauncherError, DaemonPlatform> =>
   Effect.gen(function* () {
-    const existing = readRecord(options.home);
+    const existing = yield* readRecord(options.home);
 
     if (existing && (yield* daemonAlive(existing))) {
       // A live daemon makes any tombstone stale (someone started it again).
-      clearTombstone(options.home);
+      yield* clearTombstone(options.home);
       return attach(existing, true);
     }
 
-    if (options.autoRespawn === true && hasTombstone(options.home)) {
+    if (options.autoRespawn === true && (yield* hasTombstone(options.home))) {
       return yield* Effect.fail(
         new DaemonStoppedError({
           message:
@@ -92,14 +97,14 @@ export const resolveOrSpawnDaemon = (
         }),
       );
     }
-    clearTombstone(options.home);
+    yield* clearTombstone(options.home);
 
     if (existing) {
       // Wedged (pid alive but unhealthy) daemons must die before we replace
       // them, or they leak as orphans still holding their port. A dead pid is
       // a no-op here.
       yield* killPid(existing.pid);
-      removeRecord(options.home);
+      yield* removeRecord(options.home);
     }
     return yield* spawnLocked(options);
   });
@@ -107,9 +112,13 @@ export const resolveOrSpawnDaemon = (
 /** Read the current daemon's status without starting one. */
 export const statusDaemon = (
   home: string,
-): Effect.Effect<{ readonly running: boolean; readonly record?: DaemonRecord }> =>
+): Effect.Effect<
+  { readonly running: boolean; readonly record?: DaemonRecord },
+  never,
+  FileSystem.FileSystem | Path.Path
+> =>
   Effect.gen(function* () {
-    const record = readRecord(home);
+    const record = yield* readRecord(home);
     if (record && (yield* daemonAlive(record))) return { running: true, record };
     return { running: false };
   });
@@ -120,17 +129,23 @@ export const statusDaemon = (
  * tombstone is written before the kill so a respawn racing the stop still
  * sees it. Returns whether anything was running.
  */
-export const stopDaemon = (home: string): Effect.Effect<"stopped" | "not-running"> =>
+export const stopDaemon = (
+  home: string,
+): Effect.Effect<
+  "stopped" | "not-running",
+  PlatformError.PlatformError,
+  FileSystem.FileSystem | Path.Path
+> =>
   Effect.gen(function* () {
-    const record = readRecord(home);
+    const record = yield* readRecord(home);
     if (!record || !pidAlive(record.pid)) {
-      removeRecord(home);
+      yield* removeRecord(home);
       return "not-running";
     }
 
-    writeTombstone(home);
+    yield* writeTombstone(home);
     yield* killPid(record.pid);
-    removeRecord(home);
+    yield* removeRecord(home);
     return "stopped";
   });
 
@@ -155,27 +170,41 @@ const killPid = (pid: number): Effect.Effect<void> =>
  */
 const spawnLocked = (
   options: ResolveDaemonOptions,
-): Effect.Effect<DaemonHandle, DaemonLauncherError> =>
+): Effect.Effect<DaemonHandle, DaemonLauncherError, DaemonPlatform> =>
   Effect.gen(function* () {
     const { home } = options;
-    fs.mkdirSync(home, { recursive: true });
+    const fileSystem = yield* FileSystem.FileSystem;
+    yield* fileSystem
+      .makeDirectory(home, { recursive: true })
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new DaemonLaunchError({ message: `Unable to create ${home}: ${cause.message}`, cause }),
+        ),
+      );
     const timeoutMs = options.readyTimeoutMs ?? READY_TIMEOUT_MS;
 
     for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt += 1) {
-      const acquired = yield* Effect.try({
-        try: () => tryAcquireLock(home),
-        catch: (cause) =>
-          new DaemonLaunchError({
-            message: `Unable to acquire the vibest daemon launch lock: ${String(cause)}`,
-            cause,
-          }),
-      });
+      // The exclusive create is still one atomic syscall, so making the
+      // surrounding steps async moves no decision: only the winner proceeds to
+      // spawn, and every other branch below already assumes the file state can
+      // change under it (a reclaim can lose its race, and the retry loop is
+      // what covers that).
+      const acquired = yield* tryAcquireLock(home).pipe(
+        Effect.mapError(
+          (cause) =>
+            new DaemonLaunchError({
+              message: `Unable to acquire the vibest daemon launch lock: ${cause.message}`,
+              cause,
+            }),
+        ),
+      );
 
       if (!acquired) {
-        const holder = readLockPid(home);
+        const holder = yield* readLockPid(home);
         if (holder !== undefined && !pidAlive(holder)) {
           // The locking launcher died mid-spawn; reclaim and try again.
-          releaseLock(home);
+          yield* releaseLock(home);
           continue;
         }
         // Another launcher is spawning right now: wait for its daemon, then
@@ -186,9 +215,7 @@ const spawnLocked = (
         continue;
       }
 
-      return yield* spawnDaemon(options).pipe(
-        Effect.ensuring(Effect.sync(() => releaseLock(home))),
-      );
+      return yield* spawnDaemon(options).pipe(Effect.ensuring(releaseLock(home)));
     }
     return yield* Effect.fail(
       new DaemonLaunchError({ message: "Could not acquire the vibest daemon launch lock" }),
@@ -196,13 +223,16 @@ const spawnLocked = (
   });
 
 /** Poll for a healthy record to appear (a concurrent launcher is spawning). */
-const waitForRecord = (home: string, timeoutMs: number): Effect.Effect<DaemonRecord | undefined> =>
+const waitForRecord = (
+  home: string,
+  timeoutMs: number,
+): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem | Path.Path> =>
   Effect.gen(function* () {
     const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
     while ((yield* Clock.currentTimeMillis) < deadline) {
-      const record = readRecord(home);
+      const record = yield* readRecord(home);
       if (record && (yield* daemonAlive(record))) return record;
-      if (!lockExists(home)) return undefined;
+      if (!(yield* lockExists(home))) return undefined;
       yield* Effect.sleep(HEALTH_POLL_INTERVAL_MS);
     }
     return undefined;
@@ -210,11 +240,17 @@ const waitForRecord = (home: string, timeoutMs: number): Effect.Effect<DaemonRec
 
 const spawnDaemon = (
   options: ResolveDaemonOptions,
-): Effect.Effect<DaemonHandle, DaemonLaunchError> =>
+): Effect.Effect<DaemonHandle, DaemonLaunchError, DaemonPlatform> =>
   Effect.gen(function* () {
     const { home } = options;
+    const crypto = yield* Crypto.Crypto;
     const port = yield* reservePort(options.port ?? DEFAULT_PORT);
-    const token = crypto.randomBytes(32).toString("hex");
+    const token = yield* crypto.randomBytes(32).pipe(
+      Effect.map(hex),
+      Effect.mapError(
+        (cause) => new DaemonLaunchError({ message: "Unable to generate a daemon token", cause }),
+      ),
+    );
     const address = `http://127.0.0.1:${port}`;
 
     const pid = yield* Effect.try({
@@ -231,7 +267,7 @@ const spawnDaemon = (
       signal(pid, "SIGTERM");
       return yield* Effect.fail(
         new DaemonLaunchError({
-          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${path.join(home, "daemon.log")}`,
+          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${nodePath.join(home, "daemon.log")}`,
         }),
       );
     }
@@ -242,9 +278,21 @@ const spawnDaemon = (
       token,
       startedAt: yield* Clock.currentTimeMillis,
     };
-    writeRecord(home, record);
+    yield* writeRecord(home, record).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DaemonLaunchError({
+            message: `Unable to record the vibest daemon: ${cause.message}`,
+            cause,
+          }),
+      ),
+    );
     return attach(record, false);
   });
+
+/** Hex, without reaching for Buffer — the token is a display/URL string. */
+const hex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 
 /**
  * The one seam Effect cannot model: a detached, unref'd child with stdio
@@ -255,7 +303,7 @@ const spawnDaemon = (
  */
 function spawnDetached(options: ResolveDaemonOptions, port: number, token: string): number {
   const { home } = options;
-  const logFd = fs.openSync(path.join(home, "daemon.log"), "a", 0o600);
+  const logFd = fs.openSync(nodePath.join(home, "daemon.log"), "a", 0o600);
   try {
     const [command, ...args] = options.serverArgv;
     if (command === undefined) throw new Error("serverArgv must not be empty");

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -244,6 +244,7 @@ const spawnDaemon = (
   Effect.gen(function* () {
     const { home } = options;
     const crypto = yield* Crypto.Crypto;
+    const path = yield* Path.Path;
     const port = yield* reservePort(options.port ?? DEFAULT_PORT);
     const token = yield* crypto.randomBytes(32).pipe(
       Effect.map(hex),
@@ -267,7 +268,7 @@ const spawnDaemon = (
       signal(pid, "SIGTERM");
       return yield* Effect.fail(
         new DaemonLaunchError({
-          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${nodePath.join(home, "daemon.log")}`,
+          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${path.join(home, "daemon.log")}`,
         }),
       );
     }

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -2,7 +2,7 @@ import childProcess from "node:child_process";
 import fs from "node:fs";
 import nodePath from "node:path";
 
-import { Clock, Crypto, Effect, FileSystem, Path, type PlatformError } from "effect";
+import { Clock, Crypto, Effect, FileSystem, type PlatformError } from "effect";
 
 import { DaemonLaunchError, DaemonStoppedError } from "./errors";
 import { daemonAlive, healthy, pidAlive } from "./liveness";
@@ -59,7 +59,7 @@ export type DaemonLauncherError = DaemonLaunchError | DaemonStoppedError;
  * The platform services the launcher's file state runs on. Provided at each
  * front door's composition root (CLI `NodeServices`, desktop runtime).
  */
-export type DaemonPlatform = FileSystem.FileSystem | Path.Path | Crypto.Crypto;
+export type DaemonPlatform = FileSystem.FileSystem | Crypto.Crypto;
 
 /**
  * The shared launcher (the local twin of the SSH launch script): read
@@ -115,7 +115,7 @@ export const statusDaemon = (
 ): Effect.Effect<
   { readonly running: boolean; readonly record?: DaemonRecord },
   never,
-  FileSystem.FileSystem | Path.Path
+  FileSystem.FileSystem
 > =>
   Effect.gen(function* () {
     const record = yield* readRecord(home);
@@ -131,11 +131,7 @@ export const statusDaemon = (
  */
 export const stopDaemon = (
   home: string,
-): Effect.Effect<
-  "stopped" | "not-running",
-  PlatformError.PlatformError,
-  FileSystem.FileSystem | Path.Path
-> =>
+): Effect.Effect<"stopped" | "not-running", PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const record = yield* readRecord(home);
     if (!record || !pidAlive(record.pid)) {
@@ -226,7 +222,7 @@ const spawnLocked = (
 const waitForRecord = (
   home: string,
   timeoutMs: number,
-): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
     while ((yield* Clock.currentTimeMillis) < deadline) {
@@ -244,7 +240,6 @@ const spawnDaemon = (
   Effect.gen(function* () {
     const { home } = options;
     const crypto = yield* Crypto.Crypto;
-    const path = yield* Path.Path;
     const port = yield* reservePort(options.port ?? DEFAULT_PORT);
     const token = yield* crypto.randomBytes(32).pipe(
       Effect.map(hex),
@@ -268,7 +263,7 @@ const spawnDaemon = (
       signal(pid, "SIGTERM");
       return yield* Effect.fail(
         new DaemonLaunchError({
-          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${path.join(home, "daemon.log")}`,
+          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${nodePath.join(home, "daemon.log")}`,
         }),
       );
     }

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -2,7 +2,7 @@ import childProcess from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-import { Clock, Crypto, Effect, FileSystem, type PlatformError } from "effect";
+import { Clock, Crypto, Effect, Encoding, FileSystem, type PlatformError } from "effect";
 
 import { DaemonLaunchError, DaemonStoppedError } from "./errors";
 import { daemonAlive, healthy, pidAlive } from "./liveness";
@@ -242,7 +242,7 @@ const spawnDaemon = (
     const crypto = yield* Crypto.Crypto;
     const port = yield* reservePort(options.port ?? DEFAULT_PORT);
     const token = yield* crypto.randomBytes(32).pipe(
-      Effect.map(hex),
+      Effect.map(Encoding.encodeHex),
       Effect.mapError(
         (cause) => new DaemonLaunchError({ message: "Unable to generate a daemon token", cause }),
       ),
@@ -285,10 +285,6 @@ const spawnDaemon = (
     );
     return attach(record, false);
   });
-
-/** Hex, without reaching for Buffer — the token is a display/URL string. */
-const hex = (bytes: Uint8Array): string =>
-  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 
 /**
  * The one seam Effect cannot model: a detached, unref'd child with stdio

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -1,6 +1,6 @@
 import childProcess from "node:child_process";
 import fs from "node:fs";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Clock, Crypto, Effect, FileSystem, type PlatformError } from "effect";
 
@@ -263,7 +263,7 @@ const spawnDaemon = (
       signal(pid, "SIGTERM");
       return yield* Effect.fail(
         new DaemonLaunchError({
-          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${nodePath.join(home, "daemon.log")}`,
+          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${path.join(home, "daemon.log")}`,
         }),
       );
     }
@@ -299,7 +299,7 @@ const hex = (bytes: Uint8Array): string =>
  */
 function spawnDetached(options: ResolveDaemonOptions, port: number, token: string): number {
   const { home } = options;
-  const logFd = fs.openSync(nodePath.join(home, "daemon.log"), "a", 0o600);
+  const logFd = fs.openSync(path.join(home, "daemon.log"), "a", 0o600);
   try {
     const [command, ...args] = options.serverArgv;
     if (command === undefined) throw new Error("serverArgv must not be empty");

--- a/packages/server/src/daemon/lock.ts
+++ b/packages/server/src/daemon/lock.ts
@@ -1,4 +1,4 @@
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Effect, FileSystem, type PlatformError } from "effect";
 
@@ -10,7 +10,7 @@ import { Effect, FileSystem, type PlatformError } from "effect";
  * reclaimable. This is the file-state seam; the retry/wait orchestration lives
  * in the launcher.
  */
-const lockPath = (home: string): string => nodePath.join(home, "daemon.lock");
+const lockPath = (home: string): string => path.join(home, "daemon.lock");
 
 /**
  * Create the lock atomically. True when acquired; false when someone holds it.

--- a/packages/server/src/daemon/lock.ts
+++ b/packages/server/src/daemon/lock.ts
@@ -1,5 +1,4 @@
-import fs from "node:fs";
-import path from "node:path";
+import { Effect, FileSystem, Path, type PlatformError } from "effect";
 
 /**
  * The launch lock — an exclusive-create `$VIBEST_HOME/daemon.lock` holding the
@@ -9,41 +8,61 @@ import path from "node:path";
  * reclaimable. This is the file-state seam; the retry/wait orchestration lives
  * in the launcher.
  */
-function lockPath(home: string): string {
-  return path.join(home, "daemon.lock");
-}
+const lockPath = (path: Path.Path, home: string): string => path.join(home, "daemon.lock");
 
-/** Create the lock atomically. True when acquired; false when someone holds it. */
-export function tryAcquireLock(home: string): boolean {
-  try {
-    fs.writeFileSync(lockPath(home), String(process.pid), { flag: "wx", mode: 0o600 });
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
-    throw error;
-  }
-}
+/**
+ * Create the lock atomically. True when acquired; false when someone holds it.
+ *
+ * The exclusivity is the OS's, not ours: `wx` is `O_CREAT | O_EXCL`, so exactly
+ * one racing launcher can win however the writes are scheduled. Anything other
+ * than "already there" (unwritable home, full disk) is a real launch failure
+ * and stays in the error channel.
+ */
+export const tryAcquireLock = (
+  home: string,
+): Effect.Effect<boolean, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    return yield* fs
+      .writeFileString(lockPath(path, home), String(process.pid), { flag: "wx", mode: 0o600 })
+      .pipe(
+        Effect.as(true),
+        Effect.catchIf(
+          (error) => error.reason._tag === "AlreadyExists",
+          () => Effect.succeed(false),
+        ),
+      );
+  });
 
 /** The pid recorded in the lock, or `undefined` if missing/garbage. */
-export function readLockPid(home: string): number | undefined {
-  try {
-    const pid = Number.parseInt(fs.readFileSync(lockPath(home), "utf8"), 10);
+export const readLockPid = (
+  home: string,
+): Effect.Effect<number | undefined, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const raw = yield* fs.readFileString(lockPath(path, home)).pipe(Effect.orElseSucceed(() => ""));
+    const pid = Number.parseInt(raw, 10);
     return Number.isInteger(pid) && pid > 0 ? pid : undefined;
-  } catch {
-    return undefined;
-  }
-}
+  });
 
 /** Whether the lock still exists (a concurrent launcher is still spawning). */
-export function lockExists(home: string): boolean {
-  return fs.existsSync(lockPath(home));
-}
+export const lockExists = (
+  home: string,
+): Effect.Effect<boolean, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    return yield* fs.exists(lockPath(path, home)).pipe(Effect.orElseSucceed(() => false));
+  });
 
 /** Release the lock; a missing lock (or a lost reclaim race) is not an error. */
-export function releaseLock(home: string): void {
-  try {
-    fs.rmSync(lockPath(home));
-  } catch {
-    // already gone (or lost a reclaim race — the retry loop handles it)
-  }
-}
+export const releaseLock = (
+  home: string,
+): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    yield* fs.remove(lockPath(path, home), { force: true }).pipe(Effect.ignore);
+  });

--- a/packages/server/src/daemon/lock.ts
+++ b/packages/server/src/daemon/lock.ts
@@ -1,4 +1,6 @@
-import { Effect, FileSystem, Path, type PlatformError } from "effect";
+import nodePath from "node:path";
+
+import { Effect, FileSystem, type PlatformError } from "effect";
 
 /**
  * The launch lock — an exclusive-create `$VIBEST_HOME/daemon.lock` holding the
@@ -8,7 +10,7 @@ import { Effect, FileSystem, Path, type PlatformError } from "effect";
  * reclaimable. This is the file-state seam; the retry/wait orchestration lives
  * in the launcher.
  */
-const lockPath = (path: Path.Path, home: string): string => path.join(home, "daemon.lock");
+const lockPath = (home: string): string => nodePath.join(home, "daemon.lock");
 
 /**
  * Create the lock atomically. True when acquired; false when someone holds it.
@@ -20,12 +22,11 @@ const lockPath = (path: Path.Path, home: string): string => path.join(home, "dae
  */
 export const tryAcquireLock = (
   home: string,
-): Effect.Effect<boolean, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<boolean, PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
     return yield* fs
-      .writeFileString(lockPath(path, home), String(process.pid), { flag: "wx", mode: 0o600 })
+      .writeFileString(lockPath(home), String(process.pid), { flag: "wx", mode: 0o600 })
       .pipe(
         Effect.as(true),
         Effect.catchIf(
@@ -38,31 +39,24 @@ export const tryAcquireLock = (
 /** The pid recorded in the lock, or `undefined` if missing/garbage. */
 export const readLockPid = (
   home: string,
-): Effect.Effect<number | undefined, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<number | undefined, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const raw = yield* fs.readFileString(lockPath(path, home)).pipe(Effect.orElseSucceed(() => ""));
+    const raw = yield* fs.readFileString(lockPath(home)).pipe(Effect.orElseSucceed(() => ""));
     const pid = Number.parseInt(raw, 10);
     return Number.isInteger(pid) && pid > 0 ? pid : undefined;
   });
 
 /** Whether the lock still exists (a concurrent launcher is still spawning). */
-export const lockExists = (
-  home: string,
-): Effect.Effect<boolean, never, FileSystem.FileSystem | Path.Path> =>
+export const lockExists = (home: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    return yield* fs.exists(lockPath(path, home)).pipe(Effect.orElseSucceed(() => false));
+    return yield* fs.exists(lockPath(home)).pipe(Effect.orElseSucceed(() => false));
   });
 
 /** Release the lock; a missing lock (or a lost reclaim race) is not an error. */
-export const releaseLock = (
-  home: string,
-): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+export const releaseLock = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    yield* fs.remove(lockPath(path, home), { force: true }).pipe(Effect.ignore);
+    yield* fs.remove(lockPath(home), { force: true }).pipe(Effect.ignore);
   });

--- a/packages/server/src/daemon/lock.ts
+++ b/packages/server/src/daemon/lock.ts
@@ -23,40 +23,34 @@ const lockPath = (home: string): string => path.join(home, "daemon.lock");
 export const tryAcquireLock = (
   home: string,
 ): Effect.Effect<boolean, PlatformError.PlatformError, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    return yield* fs
-      .writeFileString(lockPath(home), String(process.pid), { flag: "wx", mode: 0o600 })
-      .pipe(
-        Effect.as(true),
-        Effect.catchIf(
-          (error) => error.reason._tag === "AlreadyExists",
-          () => Effect.succeed(false),
-        ),
-      );
-  });
+  FileSystem.FileSystem.use((fs) =>
+    fs.writeFileString(lockPath(home), String(process.pid), { flag: "wx", mode: 0o600 }),
+  ).pipe(
+    Effect.as(true),
+    Effect.catchIf(
+      (error) => error.reason._tag === "AlreadyExists",
+      () => Effect.succeed(false),
+    ),
+  );
 
 /** The pid recorded in the lock, or `undefined` if missing/garbage. */
 export const readLockPid = (
   home: string,
 ): Effect.Effect<number | undefined, never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const raw = yield* fs.readFileString(lockPath(home)).pipe(Effect.orElseSucceed(() => ""));
-    const pid = Number.parseInt(raw, 10);
-    return Number.isInteger(pid) && pid > 0 ? pid : undefined;
-  });
+  FileSystem.FileSystem.use((fs) => fs.readFileString(lockPath(home))).pipe(
+    Effect.orElseSucceed(() => ""),
+    Effect.map((raw) => {
+      const pid = Number.parseInt(raw, 10);
+      return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+    }),
+  );
 
 /** Whether the lock still exists (a concurrent launcher is still spawning). */
 export const lockExists = (home: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    return yield* fs.exists(lockPath(home)).pipe(Effect.orElseSucceed(() => false));
-  });
+  FileSystem.FileSystem.use((fs) => fs.exists(lockPath(home))).pipe(
+    Effect.orElseSucceed(() => false),
+  );
 
 /** Release the lock; a missing lock (or a lost reclaim race) is not an error. */
 export const releaseLock = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    yield* fs.remove(lockPath(home), { force: true }).pipe(Effect.ignore);
-  });
+  FileSystem.FileSystem.use((fs) => fs.remove(lockPath(home), { force: true })).pipe(Effect.ignore);

--- a/packages/server/src/daemon/record.ts
+++ b/packages/server/src/daemon/record.ts
@@ -1,4 +1,4 @@
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Effect, FileSystem, type PlatformError } from "effect";
 
@@ -20,7 +20,7 @@ export type DaemonRecord = {
 };
 
 /** `$VIBEST_HOME/daemon.pid`. */
-export const recordPath = (home: string): string => nodePath.join(home, "daemon.pid");
+export const recordPath = (home: string): string => path.join(home, "daemon.pid");
 
 /** Read and validate the record, or `undefined` if missing/garbage. */
 export const readRecord = (

--- a/packages/server/src/daemon/record.ts
+++ b/packages/server/src/daemon/record.ts
@@ -74,7 +74,6 @@ export const writeRecord = (
 
 /** Remove the record; a missing file is not an error. */
 export const removeRecord = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    yield* fs.remove(recordPath(home), { force: true }).pipe(Effect.ignore);
-  });
+  FileSystem.FileSystem.use((fs) => fs.remove(recordPath(home), { force: true })).pipe(
+    Effect.ignore,
+  );

--- a/packages/server/src/daemon/record.ts
+++ b/packages/server/src/daemon/record.ts
@@ -1,5 +1,4 @@
-import fs from "node:fs";
-import path from "node:path";
+import { Effect, FileSystem, Path, type PlatformError } from "effect";
 
 /**
  * The discovery record the launcher writes to `$VIBEST_HOME/daemon.pid` — the
@@ -18,21 +17,30 @@ export type DaemonRecord = {
   readonly startedAt: number;
 };
 
+const recordFile = (path: Path.Path, home: string): string => path.join(home, "daemon.pid");
+
 /** `$VIBEST_HOME/daemon.pid`. */
-export function recordPath(home: string): string {
-  return path.join(home, "daemon.pid");
-}
+export const recordPath = (home: string): Effect.Effect<string, never, Path.Path> =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    return recordFile(path, home);
+  });
 
 /** Read and validate the record, or `undefined` if missing/garbage. */
-export function readRecord(home: string): DaemonRecord | undefined {
-  let raw: string;
-  try {
-    raw = fs.readFileSync(recordPath(home), "utf8");
-  } catch {
-    return undefined;
-  }
-  try {
-    const parsed = JSON.parse(raw) as Partial<DaemonRecord>;
+export const readRecord = (
+  home: string,
+): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const raw = yield* fs
+      .readFileString(recordFile(path, home))
+      .pipe(Effect.orElseSucceed(() => undefined));
+    if (raw === undefined) return undefined;
+
+    const parsed = yield* Effect.try(() => JSON.parse(raw) as Partial<DaemonRecord>).pipe(
+      Effect.orElseSucceed(() => undefined),
+    );
     if (
       typeof parsed?.pid === "number" &&
       typeof parsed?.address === "string" &&
@@ -45,31 +53,37 @@ export function readRecord(home: string): DaemonRecord | undefined {
         startedAt: typeof parsed.startedAt === "number" ? parsed.startedAt : 0,
       };
     }
-  } catch {
-    // fall through
-  }
-  return undefined;
-}
+    return undefined;
+  });
 
 /**
  * Atomically write the record with `0600` perms (token is a secret): write a
  * sibling temp file, chmod, then rename over the target so a concurrent reader
  * never sees a half-written file.
  */
-export function writeRecord(home: string, record: DaemonRecord): void {
-  fs.mkdirSync(home, { recursive: true });
-  const target = recordPath(home);
-  const tmp = `${target}.${process.pid}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(record), { mode: 0o600 });
-  fs.chmodSync(tmp, 0o600);
-  fs.renameSync(tmp, target);
-}
+export const writeRecord = (
+  home: string,
+  record: DaemonRecord,
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    yield* fs.makeDirectory(home, { recursive: true });
+    const target = recordFile(path, home);
+    const tmp = `${target}.${process.pid}.tmp`;
+    yield* fs.writeFileString(tmp, JSON.stringify(record), { mode: 0o600 });
+    // `mode` only applies when the write creates the file, so a leftover temp
+    // from a crashed launcher would otherwise keep its old perms.
+    yield* fs.chmod(tmp, 0o600);
+    yield* fs.rename(tmp, target);
+  });
 
 /** Remove the record; a missing file is not an error. */
-export function removeRecord(home: string): void {
-  try {
-    fs.rmSync(recordPath(home));
-  } catch {
-    // already gone
-  }
-}
+export const removeRecord = (
+  home: string,
+): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    yield* fs.remove(recordFile(path, home), { force: true }).pipe(Effect.ignore);
+  });

--- a/packages/server/src/daemon/record.ts
+++ b/packages/server/src/daemon/record.ts
@@ -1,4 +1,6 @@
-import { Effect, FileSystem, Path, type PlatformError } from "effect";
+import nodePath from "node:path";
+
+import { Effect, FileSystem, type PlatformError } from "effect";
 
 /**
  * The discovery record the launcher writes to `$VIBEST_HOME/daemon.pid` — the
@@ -17,24 +19,17 @@ export type DaemonRecord = {
   readonly startedAt: number;
 };
 
-const recordFile = (path: Path.Path, home: string): string => path.join(home, "daemon.pid");
-
 /** `$VIBEST_HOME/daemon.pid`. */
-export const recordPath = (home: string): Effect.Effect<string, never, Path.Path> =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    return recordFile(path, home);
-  });
+export const recordPath = (home: string): string => nodePath.join(home, "daemon.pid");
 
 /** Read and validate the record, or `undefined` if missing/garbage. */
 export const readRecord = (
   home: string,
-): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
     const raw = yield* fs
-      .readFileString(recordFile(path, home))
+      .readFileString(recordPath(home))
       .pipe(Effect.orElseSucceed(() => undefined));
     if (raw === undefined) return undefined;
 
@@ -64,12 +59,11 @@ export const readRecord = (
 export const writeRecord = (
   home: string,
   record: DaemonRecord,
-): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
     yield* fs.makeDirectory(home, { recursive: true });
-    const target = recordFile(path, home);
+    const target = recordPath(home);
     const tmp = `${target}.${process.pid}.tmp`;
     yield* fs.writeFileString(tmp, JSON.stringify(record), { mode: 0o600 });
     // `mode` only applies when the write creates the file, so a leftover temp
@@ -79,11 +73,8 @@ export const writeRecord = (
   });
 
 /** Remove the record; a missing file is not an error. */
-export const removeRecord = (
-  home: string,
-): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+export const removeRecord = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    yield* fs.remove(recordFile(path, home), { force: true }).pipe(Effect.ignore);
+    yield* fs.remove(recordPath(home), { force: true }).pipe(Effect.ignore);
   });

--- a/packages/server/src/daemon/tombstone.ts
+++ b/packages/server/src/daemon/tombstone.ts
@@ -1,4 +1,4 @@
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Clock, Effect, FileSystem, type PlatformError } from "effect";
 
@@ -8,7 +8,7 @@ import { Clock, Effect, FileSystem, type PlatformError } from "effect";
  * resurrect a daemon the user deliberately stopped. An explicit start clears
  * it. Its mere existence is the signal; the timestamp is only for debugging.
  */
-const tombstoneFile = (home: string): string => nodePath.join(home, "daemon.stopped");
+const tombstoneFile = (home: string): string => path.join(home, "daemon.stopped");
 
 export const hasTombstone = (home: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {

--- a/packages/server/src/daemon/tombstone.ts
+++ b/packages/server/src/daemon/tombstone.ts
@@ -11,10 +11,9 @@ import { Clock, Effect, FileSystem, type PlatformError } from "effect";
 const tombstoneFile = (home: string): string => path.join(home, "daemon.stopped");
 
 export const hasTombstone = (home: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    return yield* fs.exists(tombstoneFile(home)).pipe(Effect.orElseSucceed(() => false));
-  });
+  FileSystem.FileSystem.use((fs) => fs.exists(tombstoneFile(home))).pipe(
+    Effect.orElseSucceed(() => false),
+  );
 
 export const writeTombstone = (
   home: string,
@@ -27,7 +26,6 @@ export const writeTombstone = (
   });
 
 export const clearTombstone = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    yield* fs.remove(tombstoneFile(home), { force: true }).pipe(Effect.ignore);
-  });
+  FileSystem.FileSystem.use((fs) => fs.remove(tombstoneFile(home), { force: true })).pipe(
+    Effect.ignore,
+  );

--- a/packages/server/src/daemon/tombstone.ts
+++ b/packages/server/src/daemon/tombstone.ts
@@ -1,4 +1,6 @@
-import { Clock, Effect, FileSystem, Path, type PlatformError } from "effect";
+import nodePath from "node:path";
+
+import { Clock, Effect, FileSystem, type PlatformError } from "effect";
 
 /**
  * The stop tombstone — `$VIBEST_HOME/daemon.stopped`, written by an explicit
@@ -6,33 +8,26 @@ import { Clock, Effect, FileSystem, Path, type PlatformError } from "effect";
  * resurrect a daemon the user deliberately stopped. An explicit start clears
  * it. Its mere existence is the signal; the timestamp is only for debugging.
  */
-const tombstoneFile = (path: Path.Path, home: string): string => path.join(home, "daemon.stopped");
+const tombstoneFile = (home: string): string => nodePath.join(home, "daemon.stopped");
 
-export const hasTombstone = (
-  home: string,
-): Effect.Effect<boolean, never, FileSystem.FileSystem | Path.Path> =>
+export const hasTombstone = (home: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    return yield* fs.exists(tombstoneFile(path, home)).pipe(Effect.orElseSucceed(() => false));
+    return yield* fs.exists(tombstoneFile(home)).pipe(Effect.orElseSucceed(() => false));
   });
 
 export const writeTombstone = (
   home: string,
-): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
     const now = yield* Clock.currentTimeMillis;
     yield* fs.makeDirectory(home, { recursive: true });
-    yield* fs.writeFileString(tombstoneFile(path, home), String(now), { mode: 0o600 });
+    yield* fs.writeFileString(tombstoneFile(home), String(now), { mode: 0o600 });
   });
 
-export const clearTombstone = (
-  home: string,
-): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+export const clearTombstone = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    yield* fs.remove(tombstoneFile(path, home), { force: true }).pipe(Effect.ignore);
+    yield* fs.remove(tombstoneFile(home), { force: true }).pipe(Effect.ignore);
   });

--- a/packages/server/src/daemon/tombstone.ts
+++ b/packages/server/src/daemon/tombstone.ts
@@ -1,5 +1,4 @@
-import fs from "node:fs";
-import path from "node:path";
+import { Clock, Effect, FileSystem, Path, type PlatformError } from "effect";
 
 /**
  * The stop tombstone — `$VIBEST_HOME/daemon.stopped`, written by an explicit
@@ -7,23 +6,33 @@ import path from "node:path";
  * resurrect a daemon the user deliberately stopped. An explicit start clears
  * it. Its mere existence is the signal; the timestamp is only for debugging.
  */
-function tombstonePath(home: string): string {
-  return path.join(home, "daemon.stopped");
-}
+const tombstoneFile = (path: Path.Path, home: string): string => path.join(home, "daemon.stopped");
 
-export function hasTombstone(home: string): boolean {
-  return fs.existsSync(tombstonePath(home));
-}
+export const hasTombstone = (
+  home: string,
+): Effect.Effect<boolean, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    return yield* fs.exists(tombstoneFile(path, home)).pipe(Effect.orElseSucceed(() => false));
+  });
 
-export function writeTombstone(home: string): void {
-  fs.mkdirSync(home, { recursive: true });
-  fs.writeFileSync(tombstonePath(home), String(Date.now()), { mode: 0o600 });
-}
+export const writeTombstone = (
+  home: string,
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const now = yield* Clock.currentTimeMillis;
+    yield* fs.makeDirectory(home, { recursive: true });
+    yield* fs.writeFileString(tombstoneFile(path, home), String(now), { mode: 0o600 });
+  });
 
-export function clearTombstone(home: string): void {
-  try {
-    fs.rmSync(tombstonePath(home));
-  } catch {
-    // already gone
-  }
-}
+export const clearTombstone = (
+  home: string,
+): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    yield* fs.remove(tombstoneFile(path, home), { force: true }).pipe(Effect.ignore);
+  });

--- a/packages/server/src/fs/service.ts
+++ b/packages/server/src/fs/service.ts
@@ -1,4 +1,6 @@
-import { Context, Effect, FileSystem, Layer, Path } from "effect";
+import nodePath from "node:path";
+
+import { Context, Effect, FileSystem, Layer } from "effect";
 
 import {
   WorkspaceBinaryFile,
@@ -19,9 +21,12 @@ const NUL = String.fromCharCode(0);
  * and absolute paths that point elsewhere. (Same check opencode's `FSUtil.contains`
  * and t3code's `WorkspacePaths` use.)
  */
-const contains = (path: Path.Path, parent: string, child: string): boolean => {
-  const rel = path.relative(parent, child);
-  return rel === "" || (!path.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${path.sep}`));
+const contains = (parent: string, child: string): boolean => {
+  const rel = nodePath.relative(parent, child);
+  return (
+    rel === "" ||
+    (!nodePath.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${nodePath.sep}`))
+  );
 };
 
 type ReadFileError =
@@ -46,62 +51,60 @@ export class FileSystemService extends Context.Service<
   }
 >()("FileSystemService") {}
 
-export const FileSystemServiceLayer: Layer.Layer<
-  FileSystemService,
-  never,
-  FileSystem.FileSystem | Path.Path
-> = Layer.effect(
-  FileSystemService,
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
+export const FileSystemServiceLayer: Layer.Layer<FileSystemService, never, FileSystem.FileSystem> =
+  Layer.effect(
+    FileSystemService,
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
 
-    // `path` is the Path service here, so the caller-supplied relative path is
-    // `relPath` — it still reaches the errors under their `path` field.
-    const readErr = (relPath: string) => (cause: unknown) =>
-      new WorkspaceReadError({ path: relPath, cause });
+      const readErr = (relPath: string) => (cause: unknown) =>
+        new WorkspaceReadError({ path: relPath, cause });
 
-    // Resolve `relPath` against `cwd` and confine it there both lexically and
-    // after realpath — the first stops `..`, the second stops symlinks pointing out.
-    const resolveWithin = (cwd: string, relPath: string) =>
-      Effect.gen(function* () {
-        // `cwd` is the trusted root and must be absolute; `relPath` must be
-        // relative to it (an absolute one would silently ignore `cwd`).
-        if (!path.isAbsolute(cwd) || path.isAbsolute(relPath)) {
-          return yield* new WorkspacePathEscape({ cwd, path: relPath });
-        }
-        const absolute = path.resolve(cwd, relPath);
-        if (!contains(path, cwd, absolute)) {
-          return yield* new WorkspacePathEscape({ cwd, path: relPath });
-        }
-        const realRoot = yield* fs.realPath(cwd).pipe(Effect.mapError(readErr(relPath)));
-        const realTarget = yield* fs.realPath(absolute).pipe(Effect.mapError(readErr(relPath)));
-        if (!contains(path, realRoot, realTarget)) {
-          return yield* new WorkspacePathEscape({ cwd, path: relPath });
-        }
-        return absolute;
-      });
-
-    return {
-      readFileString: (cwd, relPath) =>
+      // Resolve `relPath` against `cwd` and confine it there both lexically and
+      // after realpath — the first stops `..`, the second stops symlinks pointing out.
+      const resolveWithin = (cwd: string, relPath: string) =>
         Effect.gen(function* () {
-          const absolute = yield* resolveWithin(cwd, relPath);
-          const info = yield* fs.stat(absolute).pipe(Effect.mapError(readErr(relPath)));
-          if (info.type !== "File") {
-            return yield* new WorkspaceNotFile({ path: relPath });
+          // `cwd` is the trusted root and must be absolute; `relPath` must be
+          // relative to it (an absolute one would silently ignore `cwd`).
+          if (!nodePath.isAbsolute(cwd) || nodePath.isAbsolute(relPath)) {
+            return yield* new WorkspacePathEscape({ cwd, path: relPath });
           }
-          const size = Number(info.size);
-          if (size > MAX_FILE_BYTES) {
-            return yield* new WorkspaceFileTooLarge({ path: relPath, size, limit: MAX_FILE_BYTES });
+          const absolute = nodePath.resolve(cwd, relPath);
+          if (!contains(cwd, absolute)) {
+            return yield* new WorkspacePathEscape({ cwd, path: relPath });
           }
-          const content = yield* fs
-            .readFileString(absolute)
-            .pipe(Effect.mapError(readErr(relPath)));
-          if (content.includes(NUL)) {
-            return yield* new WorkspaceBinaryFile({ path: relPath });
+          const realRoot = yield* fs.realPath(cwd).pipe(Effect.mapError(readErr(relPath)));
+          const realTarget = yield* fs.realPath(absolute).pipe(Effect.mapError(readErr(relPath)));
+          if (!contains(realRoot, realTarget)) {
+            return yield* new WorkspacePathEscape({ cwd, path: relPath });
           }
-          return content;
-        }),
-    };
-  }),
-);
+          return absolute;
+        });
+
+      return {
+        readFileString: (cwd, relPath) =>
+          Effect.gen(function* () {
+            const absolute = yield* resolveWithin(cwd, relPath);
+            const info = yield* fs.stat(absolute).pipe(Effect.mapError(readErr(relPath)));
+            if (info.type !== "File") {
+              return yield* new WorkspaceNotFile({ path: relPath });
+            }
+            const size = Number(info.size);
+            if (size > MAX_FILE_BYTES) {
+              return yield* new WorkspaceFileTooLarge({
+                path: relPath,
+                size,
+                limit: MAX_FILE_BYTES,
+              });
+            }
+            const content = yield* fs
+              .readFileString(absolute)
+              .pipe(Effect.mapError(readErr(relPath)));
+            if (content.includes(NUL)) {
+              return yield* new WorkspaceBinaryFile({ path: relPath });
+            }
+            return content;
+          }),
+      };
+    }),
+  );

--- a/packages/server/src/fs/service.ts
+++ b/packages/server/src/fs/service.ts
@@ -1,7 +1,4 @@
-import path from "node:path";
-
-import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
-import { Context, Effect, FileSystem, Layer } from "effect";
+import { Context, Effect, FileSystem, Layer, Path } from "effect";
 
 import {
   WorkspaceBinaryFile,
@@ -22,7 +19,7 @@ const NUL = String.fromCharCode(0);
  * and absolute paths that point elsewhere. (Same check opencode's `FSUtil.contains`
  * and t3code's `WorkspacePaths` use.)
  */
-const contains = (parent: string, child: string): boolean => {
+const contains = (path: Path.Path, parent: string, child: string): boolean => {
   const rel = path.relative(parent, child);
   return rel === "" || (!path.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${path.sep}`));
 };
@@ -49,30 +46,37 @@ export class FileSystemService extends Context.Service<
   }
 >()("FileSystemService") {}
 
-export const FileSystemServiceLayer: Layer.Layer<FileSystemService> = Layer.effect(
+export const FileSystemServiceLayer: Layer.Layer<
+  FileSystemService,
+  never,
+  FileSystem.FileSystem | Path.Path
+> = Layer.effect(
   FileSystemService,
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
 
+    // `path` is the Path service here, so the caller-supplied relative path is
+    // `relPath` — it still reaches the errors under their `path` field.
     const readErr = (relPath: string) => (cause: unknown) =>
       new WorkspaceReadError({ path: relPath, cause });
 
-    // Resolve `relPath` against `cwd` and confine it there both lexically and after
-    // realpath — the first stops `..`, the second stops symlinks pointing out.
+    // Resolve `relPath` against `cwd` and confine it there both lexically and
+    // after realpath — the first stops `..`, the second stops symlinks pointing out.
     const resolveWithin = (cwd: string, relPath: string) =>
       Effect.gen(function* () {
-        // `cwd` is the trusted root and must be absolute; `relPath` must be relative
-        // to it (an absolute `relPath` would silently ignore `cwd`).
+        // `cwd` is the trusted root and must be absolute; `relPath` must be
+        // relative to it (an absolute one would silently ignore `cwd`).
         if (!path.isAbsolute(cwd) || path.isAbsolute(relPath)) {
           return yield* new WorkspacePathEscape({ cwd, path: relPath });
         }
         const absolute = path.resolve(cwd, relPath);
-        if (!contains(cwd, absolute)) {
+        if (!contains(path, cwd, absolute)) {
           return yield* new WorkspacePathEscape({ cwd, path: relPath });
         }
         const realRoot = yield* fs.realPath(cwd).pipe(Effect.mapError(readErr(relPath)));
         const realTarget = yield* fs.realPath(absolute).pipe(Effect.mapError(readErr(relPath)));
-        if (!contains(realRoot, realTarget)) {
+        if (!contains(path, realRoot, realTarget)) {
           return yield* new WorkspacePathEscape({ cwd, path: relPath });
         }
         return absolute;
@@ -100,4 +104,4 @@ export const FileSystemServiceLayer: Layer.Layer<FileSystemService> = Layer.effe
         }),
     };
   }),
-).pipe(Layer.provide(NodeFileSystem.layer));
+);

--- a/packages/server/src/fs/service.ts
+++ b/packages/server/src/fs/service.ts
@@ -1,4 +1,4 @@
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Context, Effect, FileSystem, Layer } from "effect";
 
@@ -22,11 +22,8 @@ const NUL = String.fromCharCode(0);
  * and t3code's `WorkspacePaths` use.)
  */
 const contains = (parent: string, child: string): boolean => {
-  const rel = nodePath.relative(parent, child);
-  return (
-    rel === "" ||
-    (!nodePath.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${nodePath.sep}`))
-  );
+  const rel = path.relative(parent, child);
+  return rel === "" || (!path.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${path.sep}`));
 };
 
 type ReadFileError =
@@ -66,10 +63,10 @@ export const FileSystemServiceLayer: Layer.Layer<FileSystemService, never, FileS
         Effect.gen(function* () {
           // `cwd` is the trusted root and must be absolute; `relPath` must be
           // relative to it (an absolute one would silently ignore `cwd`).
-          if (!nodePath.isAbsolute(cwd) || nodePath.isAbsolute(relPath)) {
+          if (!path.isAbsolute(cwd) || path.isAbsolute(relPath)) {
             return yield* new WorkspacePathEscape({ cwd, path: relPath });
           }
-          const absolute = nodePath.resolve(cwd, relPath);
+          const absolute = path.resolve(cwd, relPath);
           if (!contains(cwd, absolute)) {
             return yield* new WorkspacePathEscape({ cwd, path: relPath });
           }

--- a/packages/server/src/harness/adapter.ts
+++ b/packages/server/src/harness/adapter.ts
@@ -8,7 +8,7 @@ import type {
   SessionCapabilities,
 } from "@vibest/contract";
 import { InspectorTargetSchema, SessionCapabilitiesSchema } from "@vibest/contract";
-import { Effect, type FileSystem, type Path, type Scope, type Stream } from "effect";
+import { Effect, type FileSystem, type Scope, type Stream } from "effect";
 
 import { AgentOpenError } from "./errors";
 import type {
@@ -170,11 +170,7 @@ export interface HarnessAgentAdapter {
    * channel out to whoever builds the service that calls it (list, session
    * service), which binds the platform layers at its own construction.
    */
-  readonly checkAvailability: Effect.Effect<
-    AvailabilityResult,
-    never,
-    FileSystem.FileSystem | Path.Path
-  >;
+  readonly checkAvailability: Effect.Effect<AvailabilityResult, never, FileSystem.FileSystem>;
   /**
    * The subset of vibest's permission vocabulary this harness can honour, and
    * which member to preselect. Plain values, not effects: they follow from the

--- a/packages/server/src/harness/adapter.ts
+++ b/packages/server/src/harness/adapter.ts
@@ -8,7 +8,7 @@ import type {
   SessionCapabilities,
 } from "@vibest/contract";
 import { InspectorTargetSchema, SessionCapabilitiesSchema } from "@vibest/contract";
-import { Effect, type Scope, type Stream } from "effect";
+import { Effect, type FileSystem, type Path, type Scope, type Stream } from "effect";
 
 import { AgentOpenError } from "./errors";
 import type {
@@ -165,7 +165,16 @@ export const applyInitialSessionConfig = (
 export interface HarnessAgentAdapter {
   readonly id: HarnessAgentId;
   readonly descriptor: AgentDescriptor;
-  readonly checkAvailability: Effect.Effect<AvailabilityResult>;
+  /**
+   * A PATH lookup, so it reads the filesystem — the requirement rides the `R`
+   * channel out to whoever builds the service that calls it (list, session
+   * service), which binds the platform layers at its own construction.
+   */
+  readonly checkAvailability: Effect.Effect<
+    AvailabilityResult,
+    never,
+    FileSystem.FileSystem | Path.Path
+  >;
   /**
    * The subset of vibest's permission vocabulary this harness can honour, and
    * which member to preselect. Plain values, not effects: they follow from the

--- a/packages/server/src/harness/claude-code/adapter.ts
+++ b/packages/server/src/harness/claude-code/adapter.ts
@@ -437,7 +437,7 @@ export const makeClaudeCodeAdapter = (agent: ClaudeCodeAgent): HarnessAgentAdapt
   // the SDK bundles reports as unavailable, so a too-old install fails fast
   // (AgentUnavailable → UNSUPPORTED) instead of launching against a CLI whose
   // wire protocol the harness types no longer match.
-  checkAvailability: Effect.promise(() => checkClaudeAvailability()),
+  checkAvailability: checkClaudeAvailability(),
   open: (input) =>
     agent.session.create({ cwd: input.cwd }).pipe(
       Effect.mapError((cause) => new AgentOpenError({ harnessAgentId: "claude-code", cause })),

--- a/packages/server/src/harness/claude-code/agent.ts
+++ b/packages/server/src/harness/claude-code/agent.ts
@@ -1,6 +1,17 @@
 import type * as sdk from "@anthropic-ai/claude-agent-sdk";
 import { getSessionInfo, query } from "@anthropic-ai/claude-agent-sdk";
-import { Deferred, Effect, Exit, FiberSet, Queue, Ref, Scope, Stream } from "effect";
+import {
+  Deferred,
+  Effect,
+  Exit,
+  FiberSet,
+  FileSystem,
+  Path,
+  Queue,
+  Ref,
+  Scope,
+  Stream,
+} from "effect";
 import type * as Cause from "effect/Cause";
 import { v7 as uuid } from "uuid";
 
@@ -159,9 +170,22 @@ export interface ClaudeCodeAgentOptions {
 export const makeClaudeCodeAgent = ({
   env = process.env,
   permissionMode,
-}: ClaudeCodeAgentOptions = {}): Effect.Effect<ClaudeCodeAgent, never, Scope.Scope> =>
+}: ClaudeCodeAgentOptions = {}): Effect.Effect<
+  ClaudeCodeAgent,
+  never,
+  Scope.Scope | FileSystem.FileSystem | Path.Path
+> =>
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
+    // Locating the `claude` binary reads the filesystem. Bind the platform
+    // services once here so the agent's own methods stay R-free; a machine
+    // with no Claude Code install is a defect at this point, since the
+    // adapter's availability check has already gated on it.
+    const platform = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
+    const claudeExecutable = resolveClaudeExecutable({ env }).pipe(
+      Effect.orDie,
+      Effect.provide(platform),
+    );
     const sessions = yield* Ref.make(new Map<string, SessionState>());
     const resumes = yield* Ref.make(
       new Map<string, Deferred.Deferred<SessionState, ClaudeAgentFailure>>(),
@@ -289,7 +313,7 @@ export const makeClaudeCodeAgent = ({
             allowDangerouslySkipPermissions: true,
             stderr: (error) => console.error(error),
             executable: process.execPath as "node",
-            pathToClaudeCodeExecutable: resolveClaudeExecutable({ env }),
+            pathToClaudeCodeExecutable: yield* claudeExecutable,
             env: { ...env },
             systemPrompt: { type: "preset", preset: "claude_code" },
             settingSources: ["user", "project", "local"],
@@ -513,24 +537,26 @@ export const makeClaudeCodeAgent = ({
     // file, byte-identical.
     const listModels = (cwd: string): Effect.Effect<sdk.ModelInfo[], ClaudeSdkError> =>
       Effect.acquireUseRelease(
-        Effect.try({
-          try: () =>
-            query({
-              prompt: Stream.toAsyncIterable(Stream.never),
-              options: {
-                cwd,
-                maxTurns: 0,
-                mcpServers: {},
-                strictMcpConfig: true,
-                settingSources: ["user", "project", "local"],
-                stderr: (error) => console.error(error),
-                executable: process.execPath as "node",
-                pathToClaudeCodeExecutable: resolveClaudeExecutable({ env }),
-                env: { ...env, CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1" },
-              },
-            }),
-          catch: (cause) => sdkError("list-models", cause),
-        }),
+        Effect.flatMap(claudeExecutable, (pathToClaudeCodeExecutable) =>
+          Effect.try({
+            try: () =>
+              query({
+                prompt: Stream.toAsyncIterable(Stream.never),
+                options: {
+                  cwd,
+                  maxTurns: 0,
+                  mcpServers: {},
+                  strictMcpConfig: true,
+                  settingSources: ["user", "project", "local"],
+                  stderr: (error) => console.error(error),
+                  executable: process.execPath as "node",
+                  pathToClaudeCodeExecutable,
+                  env: { ...env, CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1" },
+                },
+              }),
+            catch: (cause) => sdkError("list-models", cause),
+          }),
+        ),
         (probe) =>
           Effect.tryPromise({
             try: () => probe.supportedModels(),

--- a/packages/server/src/harness/claude-code/agent.ts
+++ b/packages/server/src/harness/claude-code/agent.ts
@@ -1,17 +1,6 @@
 import type * as sdk from "@anthropic-ai/claude-agent-sdk";
 import { getSessionInfo, query } from "@anthropic-ai/claude-agent-sdk";
-import {
-  Deferred,
-  Effect,
-  Exit,
-  FiberSet,
-  FileSystem,
-  Path,
-  Queue,
-  Ref,
-  Scope,
-  Stream,
-} from "effect";
+import { Deferred, Effect, Exit, FiberSet, FileSystem, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 import { v7 as uuid } from "uuid";
 
@@ -173,7 +162,7 @@ export const makeClaudeCodeAgent = ({
 }: ClaudeCodeAgentOptions = {}): Effect.Effect<
   ClaudeCodeAgent,
   never,
-  Scope.Scope | FileSystem.FileSystem | Path.Path
+  Scope.Scope | FileSystem.FileSystem
 > =>
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
@@ -181,7 +170,7 @@ export const makeClaudeCodeAgent = ({
     // services once here so the agent's own methods stay R-free; a machine
     // with no Claude Code install is a defect at this point, since the
     // adapter's availability check has already gated on it.
-    const platform = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
+    const platform = yield* Effect.context<FileSystem.FileSystem>();
     const claudeExecutable = resolveClaudeExecutable({ env }).pipe(
       Effect.orDie,
       Effect.provide(platform),

--- a/packages/server/src/harness/claude-code/agent.ts
+++ b/packages/server/src/harness/claude-code/agent.ts
@@ -170,10 +170,17 @@ export const makeClaudeCodeAgent = ({
     // services once here so the agent's own methods stay R-free; a machine
     // with no Claude Code install is a defect at this point, since the
     // adapter's availability check has already gated on it.
-    const platform = yield* Effect.context<FileSystem.FileSystem>();
-    const claudeExecutable = resolveClaudeExecutable({ env }).pipe(
-      Effect.orDie,
-      Effect.provide(platform),
+    // `Effect.provideService`, not `Effect.provide(Effect.context())`: the
+    // latter captures the whole layer-build context — including the `Scope`
+    // above — and wins the merge, so it would override a caller's scope.
+    const fileSystem = yield* FileSystem.FileSystem;
+    // Cached: the answer is fixed for the process, and both `buildSession` and
+    // `listModels` ask, so an uncached Effect re-walks PATH on every session.
+    const claudeExecutable = yield* Effect.cached(
+      resolveClaudeExecutable({ env }).pipe(
+        Effect.orDie,
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+      ),
     );
     const sessions = yield* Ref.make(new Map<string, SessionState>());
     const resumes = yield* Ref.make(

--- a/packages/server/src/harness/claude-code/executable.ts
+++ b/packages/server/src/harness/claude-code/executable.ts
@@ -1,7 +1,7 @@
 import childProcess from "node:child_process";
 import module from "node:module";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 import util from "node:util";
 
 import { Data, Effect, FileSystem } from "effect";
@@ -25,8 +25,8 @@ const NOT_FOUND =
 /** Where the native installer and the common package managers put `claude`. */
 function extraInstallDirs(home: string): string[] {
   return [
-    nodePath.join(home, ".local", "bin"),
-    nodePath.join(home, ".bun", "bin"),
+    path.join(home, ".local", "bin"),
+    path.join(home, ".bun", "bin"),
     "/opt/homebrew/bin",
     "/usr/local/bin",
   ];
@@ -48,7 +48,7 @@ function sdkBinary(binary: string): string | undefined {
   const pkg = `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`;
   try {
     const resolved = moduleRequire.resolve(`${pkg}/${binary}`);
-    return resolved.includes(`.asar${nodePath.sep}`) ? undefined : resolved;
+    return resolved.includes(`.asar${path.sep}`) ? undefined : resolved;
   } catch {
     return undefined;
   }
@@ -116,7 +116,7 @@ export const resolveClaudeExecutable = (
     const dirs = [...(env["PATH"] ?? "").split(pathDelimiter(platform)), ...extraInstallDirs(home)];
     for (const dir of dirs) {
       if (!dir) continue;
-      const candidate = nodePath.join(dir, binary);
+      const candidate = path.join(dir, binary);
       if (yield* isExecutable(candidate)) return candidate;
     }
 
@@ -133,7 +133,7 @@ export const requiredClaudeVersion = (): Effect.Effect<string, Error, FileSystem
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const main = yield* Effect.try(() => moduleRequire.resolve("@anthropic-ai/claude-agent-sdk"));
-    const raw = yield* fs.readFileString(nodePath.join(nodePath.dirname(main), "package.json"));
+    const raw = yield* fs.readFileString(path.join(path.dirname(main), "package.json"));
     const manifest = yield* Effect.try(() => JSON.parse(raw) as { claudeCodeVersion?: string });
     if (!manifest.claudeCodeVersion) {
       return yield* Effect.fail(
@@ -191,7 +191,7 @@ export const checkClaudeAvailability = (
 ): Effect.Effect<AvailabilityResult, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const executable = yield* resolveClaudeExecutable(deps).pipe(
-      Effect.map((path) => ({ ok: true as const, path })),
+      Effect.map((resolved) => ({ ok: true as const, path: resolved })),
       Effect.catch((cause) => Effect.succeed({ ok: false as const, reason: cause.message })),
     );
     if (!executable.ok) return { available: false, reason: executable.reason };

--- a/packages/server/src/harness/claude-code/executable.ts
+++ b/packages/server/src/harness/claude-code/executable.ts
@@ -1,15 +1,28 @@
 import childProcess from "node:child_process";
-import fs from "node:fs";
 import module from "node:module";
 import os from "node:os";
-import path from "node:path";
 import util from "node:util";
 
+import { Data, Effect, FileSystem, Path } from "effect";
+
 const moduleRequire = module.createRequire(import.meta.url);
-const execFileAsync = util.promisify(childProcess.execFile);
+const execFileAsync = util.promisify(execFile);
+
+/** No `claude` binary anywhere we look — carries the user-facing remedy. */
+export class ClaudeExecutableNotFound extends Data.TaggedError("ClaudeExecutableNotFound")<{
+  readonly reason: string;
+}> {
+  override get message() {
+    return this.reason;
+  }
+}
+
+const NOT_FOUND =
+  "Claude Code was not found. Install it from https://claude.com/claude-code, " +
+  "or set VIBEST_CLAUDE_EXECUTABLE to the path of the `claude` binary.";
 
 /** Where the native installer and the common package managers put `claude`. */
-function extraInstallDirs(home: string): string[] {
+function extraInstallDirs(path: Path.Path, home: string): string[] {
   return [
     path.join(home, ".local", "bin"),
     path.join(home, ".bun", "bin"),
@@ -18,26 +31,19 @@ function extraInstallDirs(home: string): string[] {
   ];
 }
 
-function isExecutableFile(candidate: string): boolean {
-  try {
-    fs.accessSync(candidate, fs.constants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 /**
  * The version-matched binary the Claude Agent SDK ships as an optional platform
  * dependency. Present when running from a checkout; absent in the packaged
  * desktop app, which excludes it (it is ~230 MB — the user's own Claude Code
  * install is used there instead).
  *
+ * `createRequire` has no Effect equivalent, so module resolution stays raw.
+ *
  * A path inside an asar archive is rejected: it resolves and stats fine, since
  * Electron's fs shim reads archives transparently — but an OS exec cannot
  * traverse one, and the SDK would fail late with a bare ENOTDIR.
  */
-function sdkBinary(binary: string): string | undefined {
+function sdkBinary(path: Path.Path, binary: string): string | undefined {
   const pkg = `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`;
   try {
     const resolved = moduleRequire.resolve(`${pkg}/${binary}`);
@@ -51,10 +57,28 @@ export type ResolveDeps = {
   env?: NodeJS.ProcessEnv;
   home?: string;
   /** The SDK's own bundled binary, if it is really on disk. */
-  bundled?: (binary: string) => string | undefined;
-  isExecutable?: (candidate: string) => boolean;
+  bundled?: (path: Path.Path, binary: string) => string | undefined;
   platform?: NodeJS.Platform;
 };
+
+/** PATH's separator. `effect/Path` exposes `sep`, but not this one. */
+const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32" ? ";" : ":");
+
+/**
+ * Executability by mode bits — see the note on the shared `findExecutable`:
+ * `effect/FileSystem.access` has no `X_OK`.
+ */
+const isExecutableFile = (
+  fs: FileSystem.FileSystem,
+  candidate: string,
+  platform: NodeJS.Platform,
+): Effect.Effect<boolean> =>
+  fs.stat(candidate).pipe(
+    Effect.map(
+      (info) => info.type === "File" && (platform === "win32" || (info.mode & 0o111) !== 0),
+    ),
+    Effect.catch(() => Effect.succeed(false)),
+  );
 
 /**
  * The `claude` binary the SDK should exec.
@@ -64,38 +88,43 @@ export type ResolveDeps = {
  * only option in the packaged app, which is why the desktop host has to hand
  * the server a login-shell PATH: launchd gives a GUI app a bare one.
  */
-export function resolveClaudeExecutable(deps: ResolveDeps = {}): string {
-  const {
-    env = process.env,
-    home = os.homedir(),
-    bundled = sdkBinary,
-    isExecutable = isExecutableFile,
-    platform = process.platform,
-  } = deps;
+export const resolveClaudeExecutable = (
+  deps: ResolveDeps = {},
+): Effect.Effect<string, ClaudeExecutableNotFound, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const {
+      env = process.env,
+      home = os.homedir(),
+      bundled = sdkBinary,
+      platform = process.platform,
+    } = deps;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const isExecutable = (candidate: string) => isExecutableFile(fs, candidate, platform);
 
-  const override =
-    env["VIBEST_E2E"] === "1"
-      ? env["VIBEST_E2E_CLAUDE_EXECUTABLE"]
-      : env["VIBEST_CLAUDE_EXECUTABLE"];
-  if (override) return override;
+    const override =
+      env["VIBEST_E2E"] === "1"
+        ? env["VIBEST_E2E_CLAUDE_EXECUTABLE"]
+        : env["VIBEST_CLAUDE_EXECUTABLE"];
+    if (override) return override;
 
-  const binary = platform === "win32" ? "claude.exe" : "claude";
+    const binary = platform === "win32" ? "claude.exe" : "claude";
 
-  const fromSdk = bundled(binary);
-  if (fromSdk && isExecutable(fromSdk)) return fromSdk;
+    const fromSdk = bundled(path, binary);
+    if (fromSdk && (yield* isExecutable(fromSdk))) return fromSdk;
 
-  const dirs = [...(env["PATH"] ?? "").split(path.delimiter), ...extraInstallDirs(home)];
-  for (const dir of dirs) {
-    if (!dir) continue;
-    const candidate = path.join(dir, binary);
-    if (isExecutable(candidate)) return candidate;
-  }
+    const dirs = [
+      ...(env["PATH"] ?? "").split(pathDelimiter(platform)),
+      ...extraInstallDirs(path, home),
+    ];
+    for (const dir of dirs) {
+      if (!dir) continue;
+      const candidate = path.join(dir, binary);
+      if (yield* isExecutable(candidate)) return candidate;
+    }
 
-  throw new Error(
-    "Claude Code was not found. Install it from https://claude.com/claude-code, " +
-      "or set VIBEST_CLAUDE_EXECUTABLE to the path of the `claude` binary.",
-  );
-}
+    return yield* Effect.fail(new ClaudeExecutableNotFound({ reason: NOT_FOUND }));
+  });
 
 /**
  * The CLI version vibest is built against: the version the Agent SDK bundles,
@@ -103,22 +132,37 @@ export function resolveClaudeExecutable(deps: ResolveDeps = {}): string {
  * (no hand-maintained constant). In a checkout the resolved binary IS this
  * version, so the floor never trips; only a user's own (older) install can.
  */
-export function requiredClaudeVersion(): string {
-  const main = moduleRequire.resolve("@anthropic-ai/claude-agent-sdk");
-  const manifest = JSON.parse(
-    fs.readFileSync(path.join(path.dirname(main), "package.json"), "utf8"),
-  ) as { claudeCodeVersion?: string };
-  if (!manifest.claudeCodeVersion) {
-    throw new Error("Claude Agent SDK manifest is missing claudeCodeVersion.");
-  }
-  return manifest.claudeCodeVersion;
-}
+export const requiredClaudeVersion = (): Effect.Effect<
+  string,
+  Error,
+  FileSystem.FileSystem | Path.Path
+> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const main = yield* Effect.try(() => moduleRequire.resolve("@anthropic-ai/claude-agent-sdk"));
+    const raw = yield* fs.readFileString(path.join(path.dirname(main), "package.json"));
+    const manifest = yield* Effect.try(() => JSON.parse(raw) as { claudeCodeVersion?: string });
+    if (!manifest.claudeCodeVersion) {
+      return yield* Effect.fail(
+        new Error("Claude Agent SDK manifest is missing claudeCodeVersion."),
+      );
+    }
+    return manifest.claudeCodeVersion;
+  }).pipe(Effect.mapError((cause) => (cause instanceof Error ? cause : new Error(String(cause)))));
 
-/** Runs `<executable> --version`; returns its raw stdout (e.g. "2.1.216 (Claude Code)"). */
-async function readClaudeVersion(executable: string): Promise<string> {
+/**
+ * Runs `<executable> --version`; returns its raw stdout (e.g. "2.1.216 (Claude Code)").
+ *
+ * Still `node:child_process`: `ChildProcessSpawner` supervises its children
+ * through a `Scope`, and threading one into `checkAvailability` would push
+ * `Scope` onto every harness adapter's availability check for a single
+ * short-lived capture. Left as a follow-up rather than widened here.
+ */
+const readClaudeVersion = async (executable: string): Promise<string> => {
   const { stdout } = await execFileAsync(executable, ["--version"], { timeout: 5000 });
   return stdout.trim();
-}
+};
 
 /** "2.1.216 (Claude Code)" → [2, 1, 216]; undefined when no x.y.z is present. */
 function parseVersion(raw: string): readonly number[] | undefined {
@@ -141,7 +185,7 @@ export type AvailabilityDeps = ResolveDeps & {
   /** Reads the CLI's reported version; injectable for tests. */
   readVersion?: (executable: string) => Promise<string>;
   /** The version floor; injectable for tests. */
-  requiredVersion?: () => string;
+  requiredVersion?: () => Effect.Effect<string, Error, FileSystem.FileSystem | Path.Path>;
 };
 
 /**
@@ -150,35 +194,36 @@ export type AvailabilityDeps = ResolveDeps & {
  * unparseable `--version` fails OPEN (available) rather than blocking on a
  * version we could not establish — the SDK will surface any real launch fault.
  */
-export async function checkClaudeAvailability(
+export const checkClaudeAvailability = (
   deps: AvailabilityDeps = {},
-): Promise<AvailabilityResult> {
-  let executable: string;
-  try {
-    executable = resolveClaudeExecutable(deps);
-  } catch (cause) {
-    return { available: false, reason: cause instanceof Error ? cause.message : String(cause) };
-  }
+): Effect.Effect<AvailabilityResult, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const executable = yield* resolveClaudeExecutable(deps).pipe(
+      Effect.map((path) => ({ ok: true as const, path })),
+      Effect.catch((cause) => Effect.succeed({ ok: false as const, reason: cause.message })),
+    );
+    if (!executable.ok) return { available: false, reason: executable.reason };
 
-  const required = (deps.requiredVersion ?? requiredClaudeVersion)();
-  const floor = parseVersion(required);
+    // An unreadable floor is as unknowable as an unreadable version: fail open.
+    const required = yield* (deps.requiredVersion ?? requiredClaudeVersion)().pipe(
+      Effect.catch(() => Effect.succeed(undefined)),
+    );
+    const floor = required ? parseVersion(required) : undefined;
 
-  let raw: string;
-  try {
-    raw = await (deps.readVersion ?? readClaudeVersion)(executable);
-  } catch {
+    const raw = yield* Effect.tryPromise(() =>
+      (deps.readVersion ?? readClaudeVersion)(executable.path),
+    ).pipe(Effect.catch(() => Effect.succeed(undefined)));
+    if (raw === undefined) return { available: true };
+
+    const actual = parseVersion(raw);
+    if (required && floor && actual && isBelow(actual, floor)) {
+      const reported = raw.split(/\s+/)[0] ?? raw;
+      return {
+        available: false,
+        reason:
+          `Claude Code ${reported} is too old — vibest requires ${required} or newer. ` +
+          "Update it from https://claude.com/claude-code.",
+      };
+    }
     return { available: true };
-  }
-
-  const actual = parseVersion(raw);
-  if (floor && actual && isBelow(actual, floor)) {
-    const reported = raw.split(/\s+/)[0] ?? raw;
-    return {
-      available: false,
-      reason:
-        `Claude Code ${reported} is too old — vibest requires ${required} or newer. ` +
-        "Update it from https://claude.com/claude-code.",
-    };
-  }
-  return { available: true };
-}
+  });

--- a/packages/server/src/harness/claude-code/executable.ts
+++ b/packages/server/src/harness/claude-code/executable.ts
@@ -1,12 +1,13 @@
 import childProcess from "node:child_process";
 import module from "node:module";
 import os from "node:os";
+import nodePath from "node:path";
 import util from "node:util";
 
-import { Data, Effect, FileSystem, Path } from "effect";
+import { Data, Effect, FileSystem } from "effect";
 
 const moduleRequire = module.createRequire(import.meta.url);
-const execFileAsync = util.promisify(execFile);
+const execFileAsync = util.promisify(childProcess.execFile);
 
 /** No `claude` binary anywhere we look — carries the user-facing remedy. */
 export class ClaudeExecutableNotFound extends Data.TaggedError("ClaudeExecutableNotFound")<{
@@ -22,10 +23,10 @@ const NOT_FOUND =
   "or set VIBEST_CLAUDE_EXECUTABLE to the path of the `claude` binary.";
 
 /** Where the native installer and the common package managers put `claude`. */
-function extraInstallDirs(path: Path.Path, home: string): string[] {
+function extraInstallDirs(home: string): string[] {
   return [
-    path.join(home, ".local", "bin"),
-    path.join(home, ".bun", "bin"),
+    nodePath.join(home, ".local", "bin"),
+    nodePath.join(home, ".bun", "bin"),
     "/opt/homebrew/bin",
     "/usr/local/bin",
   ];
@@ -37,17 +38,17 @@ function extraInstallDirs(path: Path.Path, home: string): string[] {
  * desktop app, which excludes it (it is ~230 MB — the user's own Claude Code
  * install is used there instead).
  *
- * `createRequire` has no Effect equivalent, so module resolution stays raw.
+ * `module.createRequire` has no Effect equivalent, so module resolution stays raw.
  *
  * A path inside an asar archive is rejected: it resolves and stats fine, since
  * Electron's fs shim reads archives transparently — but an OS exec cannot
  * traverse one, and the SDK would fail late with a bare ENOTDIR.
  */
-function sdkBinary(path: Path.Path, binary: string): string | undefined {
+function sdkBinary(binary: string): string | undefined {
   const pkg = `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`;
   try {
     const resolved = moduleRequire.resolve(`${pkg}/${binary}`);
-    return resolved.includes(`.asar${path.sep}`) ? undefined : resolved;
+    return resolved.includes(`.asar${nodePath.sep}`) ? undefined : resolved;
   } catch {
     return undefined;
   }
@@ -57,11 +58,11 @@ export type ResolveDeps = {
   env?: NodeJS.ProcessEnv;
   home?: string;
   /** The SDK's own bundled binary, if it is really on disk. */
-  bundled?: (path: Path.Path, binary: string) => string | undefined;
+  bundled?: (binary: string) => string | undefined;
   platform?: NodeJS.Platform;
 };
 
-/** PATH's separator. `effect/Path` exposes `sep`, but not this one. */
+/** PATH's separator — `node:path.delimiter` is fixed to the host platform. */
 const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32" ? ";" : ":");
 
 /**
@@ -90,7 +91,7 @@ const isExecutableFile = (
  */
 export const resolveClaudeExecutable = (
   deps: ResolveDeps = {},
-): Effect.Effect<string, ClaudeExecutableNotFound, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<string, ClaudeExecutableNotFound, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const {
       env = process.env,
@@ -99,7 +100,6 @@ export const resolveClaudeExecutable = (
       platform = process.platform,
     } = deps;
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
     const isExecutable = (candidate: string) => isExecutableFile(fs, candidate, platform);
 
     const override =
@@ -110,16 +110,13 @@ export const resolveClaudeExecutable = (
 
     const binary = platform === "win32" ? "claude.exe" : "claude";
 
-    const fromSdk = bundled(path, binary);
+    const fromSdk = bundled(binary);
     if (fromSdk && (yield* isExecutable(fromSdk))) return fromSdk;
 
-    const dirs = [
-      ...(env["PATH"] ?? "").split(pathDelimiter(platform)),
-      ...extraInstallDirs(path, home),
-    ];
+    const dirs = [...(env["PATH"] ?? "").split(pathDelimiter(platform)), ...extraInstallDirs(home)];
     for (const dir of dirs) {
       if (!dir) continue;
-      const candidate = path.join(dir, binary);
+      const candidate = nodePath.join(dir, binary);
       if (yield* isExecutable(candidate)) return candidate;
     }
 
@@ -132,16 +129,11 @@ export const resolveClaudeExecutable = (
  * (no hand-maintained constant). In a checkout the resolved binary IS this
  * version, so the floor never trips; only a user's own (older) install can.
  */
-export const requiredClaudeVersion = (): Effect.Effect<
-  string,
-  Error,
-  FileSystem.FileSystem | Path.Path
-> =>
+export const requiredClaudeVersion = (): Effect.Effect<string, Error, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
     const main = yield* Effect.try(() => moduleRequire.resolve("@anthropic-ai/claude-agent-sdk"));
-    const raw = yield* fs.readFileString(path.join(path.dirname(main), "package.json"));
+    const raw = yield* fs.readFileString(nodePath.join(nodePath.dirname(main), "package.json"));
     const manifest = yield* Effect.try(() => JSON.parse(raw) as { claudeCodeVersion?: string });
     if (!manifest.claudeCodeVersion) {
       return yield* Effect.fail(
@@ -185,7 +177,7 @@ export type AvailabilityDeps = ResolveDeps & {
   /** Reads the CLI's reported version; injectable for tests. */
   readVersion?: (executable: string) => Promise<string>;
   /** The version floor; injectable for tests. */
-  requiredVersion?: () => Effect.Effect<string, Error, FileSystem.FileSystem | Path.Path>;
+  requiredVersion?: () => Effect.Effect<string, Error, FileSystem.FileSystem>;
 };
 
 /**
@@ -196,7 +188,7 @@ export type AvailabilityDeps = ResolveDeps & {
  */
 export const checkClaudeAvailability = (
   deps: AvailabilityDeps = {},
-): Effect.Effect<AvailabilityResult, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<AvailabilityResult, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const executable = yield* resolveClaudeExecutable(deps).pipe(
       Effect.map((path) => ({ ok: true as const, path })),

--- a/packages/server/src/harness/claude-code/executable.ts
+++ b/packages/server/src/harness/claude-code/executable.ts
@@ -6,6 +6,8 @@ import util from "node:util";
 
 import { Data, Effect, FileSystem } from "effect";
 
+import { isExecutableFile, pathDelimiter } from "../executable";
+
 const moduleRequire = module.createRequire(import.meta.url);
 const execFileAsync = util.promisify(childProcess.execFile);
 
@@ -61,25 +63,6 @@ export type ResolveDeps = {
   bundled?: (binary: string) => string | undefined;
   platform?: NodeJS.Platform;
 };
-
-/** PATH's separator — `node:path.delimiter` is fixed to the host platform. */
-const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32" ? ";" : ":");
-
-/**
- * Executability by mode bits — see the note on the shared `findExecutable`:
- * `effect/FileSystem.access` has no `X_OK`.
- */
-const isExecutableFile = (
-  fs: FileSystem.FileSystem,
-  candidate: string,
-  platform: NodeJS.Platform,
-): Effect.Effect<boolean> =>
-  fs.stat(candidate).pipe(
-    Effect.map(
-      (info) => info.type === "File" && (platform === "win32" || (info.mode & 0o111) !== 0),
-    ),
-    Effect.catch(() => Effect.succeed(false)),
-  );
 
 /**
  * The `claude` binary the SDK should exec.

--- a/packages/server/src/harness/codex/adapter.ts
+++ b/packages/server/src/harness/codex/adapter.ts
@@ -348,10 +348,10 @@ export const makeCodexAdapter = (
     ),
   // A PATH lookup, not a spawn: negotiate has to stay cheap on machines where
   // codex simply isn't installed, which is the common case.
-  checkAvailability: Effect.sync(() =>
-    findExecutable(options.executablePath ?? "codex")
-      ? { available: true }
-      : { available: false, reason: "Codex was not found on PATH." },
+  checkAvailability: findExecutable(options.executablePath ?? "codex").pipe(
+    Effect.map((found) =>
+      found ? { available: true } : { available: false, reason: "Codex was not found on PATH." },
+    ),
   ),
   open: (input) =>
     agent.session.create({ cwd: input.cwd }).pipe(

--- a/packages/server/src/harness/executable.ts
+++ b/packages/server/src/harness/executable.ts
@@ -1,4 +1,6 @@
-import { Effect, FileSystem, Path } from "effect";
+import nodePath from "node:path";
+
+import { Effect, FileSystem } from "effect";
 
 /**
  * Locating the CLI a harness spawns. Claude Code has its own resolver (it
@@ -26,7 +28,7 @@ import { Effect, FileSystem, Path } from "effect";
  */
 const WINDOWS_EXTENSIONS = [".com", ".exe", ".bat", ".cmd"];
 
-/** PATH's separator. `effect/Path` exposes `sep`, but not this one. */
+/** PATH's separator — `node:path.delimiter` is fixed to the host platform. */
 const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32" ? ";" : ":");
 
 export type FindExecutableDeps = {
@@ -64,19 +66,18 @@ const isExecutableFile = (
 export const findExecutable = (
   command: string,
   deps: FindExecutableDeps = {},
-): Effect.Effect<string | undefined, never, FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<string | undefined, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const { env = process.env, platform = process.platform } = deps;
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
     const isExecutable = (candidate: string) => isExecutableFile(fs, candidate, platform);
 
-    if (path.isAbsolute(command)) {
+    if (nodePath.isAbsolute(command)) {
       return (yield* isExecutable(command)) ? command : undefined;
     }
 
     const names =
-      platform !== "win32" || path.extname(command)
+      platform !== "win32" || nodePath.extname(command)
         ? [command]
         : WINDOWS_EXTENSIONS.map((extension) => `${command}${extension}`);
 
@@ -85,7 +86,7 @@ export const findExecutable = (
     for (const dir of (env["PATH"] ?? "").split(pathDelimiter(platform))) {
       if (!dir) continue;
       for (const name of names) {
-        const candidate = path.join(dir, name);
+        const candidate = nodePath.join(dir, name);
         if (yield* isExecutable(candidate)) return candidate;
       }
     }

--- a/packages/server/src/harness/executable.ts
+++ b/packages/server/src/harness/executable.ts
@@ -29,7 +29,7 @@ import { Effect, FileSystem } from "effect";
 const WINDOWS_EXTENSIONS = [".com", ".exe", ".bat", ".cmd"];
 
 /** PATH's separator — `node:path.delimiter` is fixed to the host platform. */
-const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32" ? ";" : ":");
+export const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32" ? ";" : ":");
 
 export type FindExecutableDeps = {
   env?: NodeJS.ProcessEnv;
@@ -45,7 +45,7 @@ export type FindExecutableDeps = {
  * Windows has no execute bit at all, so there existence is the whole test —
  * which is also all `access(X_OK)` ever checked there.
  */
-const isExecutableFile = (
+export const isExecutableFile = (
   fs: FileSystem.FileSystem,
   candidate: string,
   platform: NodeJS.Platform,

--- a/packages/server/src/harness/executable.ts
+++ b/packages/server/src/harness/executable.ts
@@ -1,5 +1,4 @@
-import fs from "node:fs";
-import path from "node:path";
+import { Effect, FileSystem, Path } from "effect";
 
 /**
  * Locating the CLI a harness spawns. Claude Code has its own resolver (it
@@ -9,8 +8,8 @@ import path from "node:path";
  * It exists for availability: `negotiate` has to answer "is this harness usable
  * right now" before it spends anything probing capabilities, and a missing
  * binary is the common case on a machine where the user only installed one
- * agent. A PATH lookup answers that synchronously; spawning to find out would
- * make the app's first paint wait on a process that was never going to start.
+ * agent. A PATH lookup answers that cheaply; spawning to find out would make
+ * the app's first paint wait on a process that was never going to start.
  *
  * It searches PATH and nothing else, deliberately. The transports spawn the
  * bare command name (`spawn("codex")`), which the OS resolves through PATH
@@ -27,44 +26,68 @@ import path from "node:path";
  */
 const WINDOWS_EXTENSIONS = [".com", ".exe", ".bat", ".cmd"];
 
-function candidateNames(command: string, platform: NodeJS.Platform): string[] {
-  if (platform !== "win32") return [command];
-  if (path.extname(command)) return [command];
-  return WINDOWS_EXTENSIONS.map((extension) => `${command}${extension}`);
-}
-
-function isExecutableFile(candidate: string): boolean {
-  try {
-    fs.accessSync(candidate, fs.constants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
+/** PATH's separator. `effect/Path` exposes `sep`, but not this one. */
+const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32" ? ";" : ":");
 
 export type FindExecutableDeps = {
   env?: NodeJS.ProcessEnv;
-  isExecutable?: (candidate: string) => boolean;
   platform?: NodeJS.Platform;
 };
+
+/**
+ * Is this path a runnable file? `effect/FileSystem.access` has no `X_OK`, so
+ * executability is read off the mode bits instead of asked of the kernel: this
+ * accepts a binary only the owner may run, where `access(X_OK)` would have
+ * rejected it for everyone else. The consequence is an EACCES at spawn time
+ * rather than an up-front "not found" — rare for a CLI installed on PATH.
+ * Windows has no execute bit at all, so there existence is the whole test —
+ * which is also all `access(X_OK)` ever checked there.
+ */
+const isExecutableFile = (
+  fs: FileSystem.FileSystem,
+  candidate: string,
+  platform: NodeJS.Platform,
+): Effect.Effect<boolean> =>
+  fs.stat(candidate).pipe(
+    Effect.map(
+      (info) => info.type === "File" && (platform === "win32" || (info.mode & 0o111) !== 0),
+    ),
+    // A candidate that cannot be stat'd (absent, unreadable dir) is not here.
+    Effect.catch(() => Effect.succeed(false)),
+  );
 
 /**
  * The path a bare command name resolves to, or `undefined` when it is not
  * installed. An absolute `command` is taken as an explicit override and only
  * checked for executability.
  */
-export function findExecutable(command: string, deps: FindExecutableDeps = {}): string | undefined {
-  const { env = process.env, isExecutable = isExecutableFile, platform = process.platform } = deps;
+export const findExecutable = (
+  command: string,
+  deps: FindExecutableDeps = {},
+): Effect.Effect<string | undefined, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const { env = process.env, platform = process.platform } = deps;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const isExecutable = (candidate: string) => isExecutableFile(fs, candidate, platform);
 
-  if (path.isAbsolute(command)) return isExecutable(command) ? command : undefined;
-
-  const names = candidateNames(command, platform);
-  for (const dir of (env["PATH"] ?? "").split(path.delimiter)) {
-    if (!dir) continue;
-    for (const name of names) {
-      const candidate = path.join(dir, name);
-      if (isExecutable(candidate)) return candidate;
+    if (path.isAbsolute(command)) {
+      return (yield* isExecutable(command)) ? command : undefined;
     }
-  }
-  return undefined;
-}
+
+    const names =
+      platform !== "win32" || path.extname(command)
+        ? [command]
+        : WINDOWS_EXTENSIONS.map((extension) => `${command}${extension}`);
+
+    // First hit wins, and PATH order is the answer — so this walks candidates
+    // sequentially and stops, rather than stat'ing the whole search space.
+    for (const dir of (env["PATH"] ?? "").split(pathDelimiter(platform))) {
+      if (!dir) continue;
+      for (const name of names) {
+        const candidate = path.join(dir, name);
+        if (yield* isExecutable(candidate)) return candidate;
+      }
+    }
+    return undefined;
+  });

--- a/packages/server/src/harness/executable.ts
+++ b/packages/server/src/harness/executable.ts
@@ -1,4 +1,4 @@
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Effect, FileSystem } from "effect";
 
@@ -72,12 +72,12 @@ export const findExecutable = (
     const fs = yield* FileSystem.FileSystem;
     const isExecutable = (candidate: string) => isExecutableFile(fs, candidate, platform);
 
-    if (nodePath.isAbsolute(command)) {
+    if (path.isAbsolute(command)) {
       return (yield* isExecutable(command)) ? command : undefined;
     }
 
     const names =
-      platform !== "win32" || nodePath.extname(command)
+      platform !== "win32" || path.extname(command)
         ? [command]
         : WINDOWS_EXTENSIONS.map((extension) => `${command}${extension}`);
 
@@ -86,7 +86,7 @@ export const findExecutable = (
     for (const dir of (env["PATH"] ?? "").split(pathDelimiter(platform))) {
       if (!dir) continue;
       for (const name of names) {
-        const candidate = nodePath.join(dir, name);
+        const candidate = path.join(dir, name);
         if (yield* isExecutable(candidate)) return candidate;
       }
     }

--- a/packages/server/src/harness/list.ts
+++ b/packages/server/src/harness/list.ts
@@ -1,5 +1,5 @@
 import type { HarnessAgentInfo, HarnessListOutput } from "@vibest/contract";
-import { Context, Effect, FileSystem, Layer, Path } from "effect";
+import { Context, Effect, FileSystem, Layer } from "effect";
 
 import { HarnessAgentRegistry, type HarnessAgentRegistryShape } from "./registry";
 
@@ -24,7 +24,7 @@ export type HarnessListShape = {
 
 /** What {@link makeHarnessList} returns before its layer binds the platform. */
 type UnboundHarnessList = {
-  readonly list: Effect.Effect<HarnessListOutput, never, FileSystem.FileSystem | Path.Path>;
+  readonly list: Effect.Effect<HarnessListOutput, never, FileSystem.FileSystem>;
 };
 
 export class HarnessListService extends Context.Service<HarnessListService, HarnessListShape>()(
@@ -62,14 +62,14 @@ export const makeHarnessList = (registry: HarnessAgentRegistryShape): UnboundHar
 export const HarnessListLayer: Layer.Layer<
   HarnessListService,
   never,
-  HarnessAgentRegistry | FileSystem.FileSystem | Path.Path
+  HarnessAgentRegistry | FileSystem.FileSystem
 > = Layer.effect(
   HarnessListService,
   Effect.gen(function* () {
     const registry = yield* HarnessAgentRegistry;
     // Availability is a PATH lookup, so it needs the filesystem. Bind it once
     // here and the service's `list` stays R-free for its RPC caller.
-    const platform = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
+    const platform = yield* Effect.context<FileSystem.FileSystem>();
     const { list } = makeHarnessList(registry);
     return { list: list.pipe(Effect.provide(platform)) };
   }),

--- a/packages/server/src/harness/list.ts
+++ b/packages/server/src/harness/list.ts
@@ -1,5 +1,5 @@
 import type { HarnessAgentInfo, HarnessListOutput } from "@vibest/contract";
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, FileSystem, Layer, Path } from "effect";
 
 import { HarnessAgentRegistry, type HarnessAgentRegistryShape } from "./registry";
 
@@ -22,11 +22,16 @@ export type HarnessListShape = {
   readonly list: Effect.Effect<HarnessListOutput>;
 };
 
+/** What {@link makeHarnessList} returns before its layer binds the platform. */
+type UnboundHarnessList = {
+  readonly list: Effect.Effect<HarnessListOutput, never, FileSystem.FileSystem | Path.Path>;
+};
+
 export class HarnessListService extends Context.Service<HarnessListService, HarnessListShape>()(
   "HarnessListService",
 ) {}
 
-export const makeHarnessList = (registry: HarnessAgentRegistryShape): HarnessListShape => ({
+export const makeHarnessList = (registry: HarnessAgentRegistryShape): UnboundHarnessList => ({
   list: registry.list.pipe(
     Effect.flatMap((descriptors) =>
       Effect.forEach(descriptors, (descriptor) =>
@@ -54,11 +59,18 @@ export const makeHarnessList = (registry: HarnessAgentRegistryShape): HarnessLis
   ),
 });
 
-export const HarnessListLayer: Layer.Layer<HarnessListService, never, HarnessAgentRegistry> =
-  Layer.effect(
-    HarnessListService,
-    Effect.gen(function* () {
-      const registry = yield* HarnessAgentRegistry;
-      return makeHarnessList(registry);
-    }),
-  );
+export const HarnessListLayer: Layer.Layer<
+  HarnessListService,
+  never,
+  HarnessAgentRegistry | FileSystem.FileSystem | Path.Path
+> = Layer.effect(
+  HarnessListService,
+  Effect.gen(function* () {
+    const registry = yield* HarnessAgentRegistry;
+    // Availability is a PATH lookup, so it needs the filesystem. Bind it once
+    // here and the service's `list` stays R-free for its RPC caller.
+    const platform = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
+    const { list } = makeHarnessList(registry);
+    return { list: list.pipe(Effect.provide(platform)) };
+  }),
+);

--- a/packages/server/src/harness/list.ts
+++ b/packages/server/src/harness/list.ts
@@ -7,10 +7,13 @@ import { HarnessAgentRegistry, type HarnessAgentRegistryShape } from "./registry
  * Declaring every harness the server hosts: what it is, whether it can run
  * right now, and which members of vibest's permission vocabulary it honours.
  *
- * All of it is declared. Availability is a PATH lookup and the permission
- * subset is a literal in the adapter, so this cannot fail, has nothing to
- * cache, and returns in well under a millisecond — which is why the client can
- * keep awaiting it before first paint.
+ * All of it is declared: the permission subset is a literal in the adapter and
+ * availability is a filesystem question, so this cannot fail.
+ *
+ * It is not free, though, and the client awaits it before first paint:
+ * claude-code's check spawns `claude --version` (~45 ms) on every call, and
+ * nothing memoizes it. Worth caching per process — see the note in
+ * `checkClaudeAvailability`.
  *
  * Anything that needs a CLI to answer belongs to {@link HarnessProbeService}
  * instead. That split is about acquisition cost and failure mode only — it
@@ -22,37 +25,37 @@ export type HarnessListShape = {
   readonly list: Effect.Effect<HarnessListOutput>;
 };
 
-/** What {@link makeHarnessList} returns before its layer binds the platform. */
-type UnboundHarnessList = {
-  readonly list: Effect.Effect<HarnessListOutput, never, FileSystem.FileSystem>;
-};
-
 export class HarnessListService extends Context.Service<HarnessListService, HarnessListShape>()(
   "HarnessListService",
 ) {}
 
-export const makeHarnessList = (registry: HarnessAgentRegistryShape): UnboundHarnessList => ({
+export const makeHarnessList = (registry: HarnessAgentRegistryShape) => ({
   list: registry.list.pipe(
     Effect.flatMap((descriptors) =>
-      Effect.forEach(descriptors, (descriptor) =>
-        Effect.gen(function* () {
-          // `descriptor.id` came from `registry.list`, so the lookup can't miss.
-          const adapter = yield* registry.get(descriptor.id).pipe(Effect.orDie);
-          const availability = yield* adapter.checkAvailability;
-          return {
-            id: descriptor.id,
-            name: descriptor.name,
-            available: availability.available,
-            ...(availability.reason ? { reason: availability.reason } : {}),
-            // Declared even when the CLI is missing: the picker shows the
-            // harness greyed out with its reason, and the reason it can't be
-            // used has nothing to do with what it would be able to do.
-            permissionModes: adapter.permissionModes,
-            ...(adapter.defaultPermissionMode
-              ? { defaultPermissionMode: adapter.defaultPermissionMode }
-              : {}),
-          } satisfies HarnessAgentInfo;
-        }),
+      Effect.forEach(
+        descriptors,
+        (descriptor) =>
+          Effect.gen(function* () {
+            // `descriptor.id` came from `registry.list`, so the lookup can't miss.
+            const adapter = yield* registry.get(descriptor.id).pipe(Effect.orDie);
+            const availability = yield* adapter.checkAvailability;
+            return {
+              id: descriptor.id,
+              name: descriptor.name,
+              available: availability.available,
+              ...(availability.reason ? { reason: availability.reason } : {}),
+              // Declared even when the CLI is missing: the picker shows the
+              // harness greyed out with its reason, and the reason it can't be
+              // used has nothing to do with what it would be able to do.
+              permissionModes: adapter.permissionModes,
+              ...(adapter.defaultPermissionMode
+                ? { defaultPermissionMode: adapter.defaultPermissionMode }
+                : {}),
+            } satisfies HarnessAgentInfo;
+          }),
+        // The three checks are independent and this RPC blocks the app's first
+        // paint; bounded by the registry, so no cap is needed.
+        { concurrency: "unbounded" },
       ),
     ),
     Effect.map((harnessAgents) => ({ harnessAgents })),
@@ -67,8 +70,9 @@ export const HarnessListLayer: Layer.Layer<
   HarnessListService,
   Effect.gen(function* () {
     const registry = yield* HarnessAgentRegistry;
-    // Availability is a PATH lookup, so it needs the filesystem. Bind it once
-    // here and the service's `list` stays R-free for its RPC caller.
+    // Availability reads the filesystem (and, for claude-code, spawns
+    // `claude --version`). Bind the platform once here so the service's `list`
+    // stays R-free for its RPC caller.
     const platform = yield* Effect.context<FileSystem.FileSystem>();
     const { list } = makeHarnessList(registry);
     return { list: list.pipe(Effect.provide(platform)) };

--- a/packages/server/src/harness/pi/adapter.ts
+++ b/packages/server/src/harness/pi/adapter.ts
@@ -229,10 +229,10 @@ export const makePiAdapter = (
   // nothing (empty subset, no probe) is what makes the UI render no config
   // controls for it.
   permissionModes: [],
-  checkAvailability: Effect.sync(() =>
-    findExecutable(options.executablePath ?? "pi")
-      ? { available: true }
-      : { available: false, reason: "Pi was not found on PATH." },
+  checkAvailability: findExecutable(options.executablePath ?? "pi").pipe(
+    Effect.map((found) =>
+      found ? { available: true } : { available: false, reason: "Pi was not found on PATH." },
+    ),
   ),
   open: (input) =>
     agent.session.create({ cwd: input.cwd }).pipe(

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -149,9 +149,11 @@ export const makeHarnessAgentSessionService = (
 ): Effect.Effect<HarnessAgentSessionServiceShape, never, Scope.Scope | FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
-    // An adapter's availability check is a PATH lookup; bind the platform
-    // services once here so the service's own methods stay R-free.
-    const platform = yield* Effect.context<FileSystem.FileSystem>();
+    // An adapter's availability check reads the filesystem; bind it once here
+    // so the service's own methods stay R-free. `provideService` rather than
+    // `provide(Effect.context())` — the latter captures the whole layer-build
+    // context, `ownerScope` included, and wins the merge over a caller's.
+    const fileSystem = yield* FileSystem.FileSystem;
     const state = yield* Ref.make<ServiceState>({
       active: new Map(),
       inFlight: new Map(),
@@ -193,7 +195,7 @@ export const makeHarnessAgentSessionService = (
             ),
           ),
         ),
-        Effect.provide(platform),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
       );
 
     const build = (

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -1,17 +1,6 @@
 import type { PermissionMode, ReasoningEffort } from "@vibest/contract";
 import type { AgentResponse, HarnessAgentId } from "@vibest/contract";
-import {
-  Context,
-  Deferred,
-  Effect,
-  Exit,
-  FileSystem,
-  Layer,
-  Path,
-  Ref,
-  Scope,
-  Stream,
-} from "effect";
+import { Context, Deferred, Effect, Exit, FileSystem, Layer, Ref, Scope, Stream } from "effect";
 
 import type {
   CreateSessionInput,
@@ -157,16 +146,12 @@ export class HarnessAgentSessionService extends Context.Service<
 
 export const makeHarnessAgentSessionService = (
   registry: HarnessAgentRegistryShape,
-): Effect.Effect<
-  HarnessAgentSessionServiceShape,
-  never,
-  Scope.Scope | FileSystem.FileSystem | Path.Path
-> =>
+): Effect.Effect<HarnessAgentSessionServiceShape, never, Scope.Scope | FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
     // An adapter's availability check is a PATH lookup; bind the platform
     // services once here so the service's own methods stay R-free.
-    const platform = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
+    const platform = yield* Effect.context<FileSystem.FileSystem>();
     const state = yield* Ref.make<ServiceState>({
       active: new Map(),
       inFlight: new Map(),

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -1,6 +1,17 @@
 import type { PermissionMode, ReasoningEffort } from "@vibest/contract";
 import type { AgentResponse, HarnessAgentId } from "@vibest/contract";
-import { Context, Deferred, Effect, Exit, Layer, Ref, Scope, Stream } from "effect";
+import {
+  Context,
+  Deferred,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Path,
+  Ref,
+  Scope,
+  Stream,
+} from "effect";
 
 import type {
   CreateSessionInput,
@@ -146,9 +157,16 @@ export class HarnessAgentSessionService extends Context.Service<
 
 export const makeHarnessAgentSessionService = (
   registry: HarnessAgentRegistryShape,
-): Effect.Effect<HarnessAgentSessionServiceShape, never, Scope.Scope> =>
+): Effect.Effect<
+  HarnessAgentSessionServiceShape,
+  never,
+  Scope.Scope | FileSystem.FileSystem | Path.Path
+> =>
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
+    // An adapter's availability check is a PATH lookup; bind the platform
+    // services once here so the service's own methods stay R-free.
+    const platform = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
     const state = yield* Ref.make<ServiceState>({
       active: new Map(),
       inFlight: new Map(),
@@ -190,6 +208,7 @@ export const makeHarnessAgentSessionService = (
             ),
           ),
         ),
+        Effect.provide(platform),
       );
 
     const build = (

--- a/packages/server/src/http/app.ts
+++ b/packages/server/src/http/app.ts
@@ -1,0 +1,96 @@
+import * as NodeHttpServerRequest from "@effect/platform-node/NodeHttpServerRequest";
+import { Effect } from "effect";
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+
+import { bearerToken, type TicketStore, tokensMatch } from "./auth";
+import { corsHeaders, isLoopbackHost } from "./cors";
+import type { UIApp } from "./ui";
+
+export type RequestAppOptions = {
+  /**
+   * When set, every `/api/*` request except `/api/health` must present
+   * `Authorization: Bearer <token>`. Unset (browser mode) disables the check.
+   */
+  readonly authToken: string | undefined;
+  /** Extra cross-origin allowlist entries on top of the built-in trusted set. */
+  readonly corsOrigins: readonly string[];
+  readonly tickets: TicketStore;
+  /** Everything the API routes below do not claim. */
+  readonly ui: UIApp;
+};
+
+const forbidden = HttpServerResponse.text("Forbidden", { status: 403 });
+const unauthorized = HttpServerResponse.text("Unauthorized", { status: 401 });
+const notFound = HttpServerResponse.text("Not Found", { status: 404 });
+
+/**
+ * The request half of the server. The WebSocket upgrade half stays on raw
+ * `node:http` (see `server.ts`) because oRPC owns that event.
+ *
+ * Deliberately a plain sequence rather than an `HttpRouter`: the order here
+ * *is* the security policy — rebinding check, then CORS, then auth, then
+ * routes — and a router's middleware layering would obscure it. There are no
+ * path parameters anywhere, so nothing else is on offer.
+ */
+export const makeRequestApp = (
+  options: RequestAppOptions,
+): Effect.Effect<
+  HttpServerResponse.HttpServerResponse,
+  never,
+  HttpServerRequest.HttpServerRequest
+> =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+
+    // Anti DNS-rebinding: the server binds loopback, so a request whose Host
+    // is not loopback comes from an attacker page whose domain rebound to
+    // 127.0.0.1 — CORS would not stop it, this does. Answered before the CORS
+    // headers are computed, so a rebound request gets none of them.
+    if (!isLoopbackHost(request.headers.host)) {
+      return forbidden;
+    }
+
+    const headers = corsHeaders(request.headers.origin, options.corsOrigins);
+    const withCors = (response: HttpServerResponse.HttpServerResponse) =>
+      headers ? HttpServerResponse.setHeaders(response, headers) : response;
+
+    if (request.method === "OPTIONS") {
+      // A preflight from an origin we don't allow gets no headers, so the
+      // browser blocks the real request that would have followed.
+      return withCors(HttpServerResponse.empty({ status: headers ? 204 : 403 }));
+    }
+
+    const pathname = new URL(request.url, "http://localhost").pathname;
+
+    // Unauthenticated on purpose: the desktop supervisor polls this before
+    // it holds a token, and it discloses nothing.
+    if (request.method === "GET" && pathname === "/api/health") {
+      return withCors(HttpServerResponse.text("ok"));
+    }
+
+    if (options.authToken !== undefined && pathname.startsWith("/api/")) {
+      if (!tokensMatch(options.authToken, bearerToken(request.headers.authorization))) {
+        return withCors(unauthorized);
+      }
+    }
+
+    if (request.method === "POST" && pathname === "/api/ws-ticket") {
+      return withCors(HttpServerResponse.jsonUnsafe({ ticket: options.tickets.issue() }));
+    }
+
+    if (pathname.startsWith("/api/")) {
+      return withCors(notFound);
+    }
+
+    // The dev branch of the UI app writes its own bytes to the raw response, so
+    // a header added to the value it returns would never reach the socket. Set
+    // them on the socket as well; node merges `setHeader` into `writeHead`, so
+    // the static branch below still ends up with exactly one of each.
+    if (headers) {
+      const nodeResponse = NodeHttpServerRequest.toServerResponse(request);
+      for (const [name, value] of Object.entries(headers)) {
+        nodeResponse.setHeader(name, value);
+      }
+    }
+    return withCors(yield* options.ui);
+  });

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -1,12 +1,15 @@
-import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import type { Server } from "node:http";
 import http from "node:http";
 
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import { Effect, Exit, Scope } from "effect";
 import type { WebSocket } from "ws";
 import { WebSocketServer } from "ws";
 
 import { createRpcRuntime, createWsRPCHandler } from "../rpc";
-import { bearerToken, createTicketStore, tokensMatch } from "./auth";
-import { corsHeaders, isAllowedOrigin, isLoopbackHost } from "./cors";
+import { makeRequestApp } from "./app";
+import { createTicketStore } from "./auth";
+import { isAllowedOrigin, isLoopbackHost } from "./cors";
 import { createUIHandler } from "./ui";
 
 export type ManagedServer = Server & {
@@ -28,89 +31,28 @@ export type CreateServerOptions = {
   corsOrigins?: readonly string[] | undefined;
 };
 
-function notFound(res: ServerResponse) {
-  res.statusCode = 404;
-  res.end("Not Found");
-}
-
 export async function createServer(options: CreateServerOptions = {}): Promise<ManagedServer> {
   const { authToken, corsOrigins = [] } = options;
 
   const rpcRuntime = await createRpcRuntime();
   const wsHandler = createWsRPCHandler(rpcRuntime.context);
   const tickets = createTicketStore();
-  // The UI handler is Effect-native; run it on the RPC runtime rather than
-  // building a second platform layer inside this Promise-shaped module.
-  const serveUI = await rpcRuntime.run(createUIHandler());
 
-  const server = http.createServer((req, res) => {
-    void handleRequest(req, res);
-  });
+  const server = http.createServer();
 
-  async function handleRequest(req: IncomingMessage, res: ServerResponse) {
-    try {
-      // Anti DNS-rebinding: the server binds loopback, so a request whose Host
-      // is not loopback comes from an attacker page whose domain rebound to
-      // 127.0.0.1 — CORS would not stop it, this does.
-      if (!isLoopbackHost(req.headers.host)) {
-        res.statusCode = 403;
-        res.end("Forbidden");
-        return;
-      }
-
-      const headers = corsHeaders(req.headers.origin, corsOrigins);
-      if (headers) {
-        for (const [name, value] of Object.entries(headers)) {
-          res.setHeader(name, value);
-        }
-      }
-
-      if (req.method === "OPTIONS") {
-        // A preflight from an origin we don't allow gets no headers, so the
-        // browser blocks the real request that would have followed.
-        res.statusCode = headers ? 204 : 403;
-        res.end();
-        return;
-      }
-
-      const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
-
-      // Unauthenticated on purpose: the desktop supervisor polls this before
-      // it holds a token, and it discloses nothing.
-      if (req.method === "GET" && pathname === "/api/health") {
-        res.setHeader("content-type", "text/plain");
-        res.end("ok");
-        return;
-      }
-
-      if (authToken !== undefined && pathname.startsWith("/api/")) {
-        if (!tokensMatch(authToken, bearerToken(req.headers.authorization))) {
-          res.statusCode = 401;
-          res.end("Unauthorized");
-          return;
-        }
-      }
-
-      if (req.method === "POST" && pathname === "/api/ws-ticket") {
-        res.setHeader("content-type", "application/json");
-        res.end(JSON.stringify({ ticket: tickets.issue() }));
-        return;
-      }
-
-      if (pathname.startsWith("/api/")) {
-        notFound(res);
-        return;
-      }
-
-      serveUI(req, res);
-    } catch (error) {
-      console.error(error);
-      if (!res.headersSent) {
-        res.statusCode = 500;
-      }
-      res.end();
-    }
-  }
+  // The request half is Effect-native and runs on the RPC runtime, which
+  // already carries FileSystem/Path/HttpPlatform. `makeHandler` gives back a
+  // plain node `request` listener, which is the whole point: it leaves the
+  // `upgrade` event below untouched. (`HttpServer.serve` would register its own
+  // upgrade handler and fight oRPC for it.)
+  const ui = await rpcRuntime.run(createUIHandler());
+  const requestScope = Scope.makeUnsafe();
+  const handleRequest = await rpcRuntime.run(
+    NodeHttpServer.makeHandler(makeRequestApp({ authToken, corsOrigins, tickets, ui }), {
+      scope: requestScope,
+    }),
+  );
+  server.on("request", handleRequest);
 
   const wss = new WebSocketServer({ noServer: true });
 
@@ -121,8 +63,9 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     console.error(e);
   });
 
-  // The only upgrade this server answers. Vite's HMR socket used to share it;
-  // now `apps/app` runs its own dev server and proxies `/ws/rpc` here instead.
+  // The only upgrade this server answers. Raw on purpose: oRPC owns this event,
+  // so Effect's own websocket support (`NodeHttpServer.makeUpgradeHandler`)
+  // must stay out of it.
   server.on("upgrade", (req, socket, head) => {
     const requestUrl = new URL(req.url ?? "/", "http://localhost");
     if (requestUrl.pathname !== "/ws/rpc") {
@@ -172,6 +115,8 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
       for (const client of wss.clients) client.terminate();
       await new Promise<void>((resolve) => wss.close(() => resolve()));
       await serverClosed;
+      // Interrupts any request fiber still in flight before the runtime goes.
+      await Effect.runPromise(Scope.close(requestScope, Exit.void));
       await rpcRuntime.dispose();
     })());
 

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -39,7 +39,9 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
   const rpcRuntime = await createRpcRuntime();
   const wsHandler = createWsRPCHandler(rpcRuntime.context);
   const tickets = createTicketStore();
-  const serveUI = createUIHandler();
+  // The UI handler is Effect-native; run it on the RPC runtime rather than
+  // building a second platform layer inside this Promise-shaped module.
+  const serveUI = await rpcRuntime.run(createUIHandler());
 
   const server = http.createServer((req, res) => {
     void handleRequest(req, res);

--- a/packages/server/src/http/ui.ts
+++ b/packages/server/src/http/ui.ts
@@ -69,6 +69,10 @@ export const createUIHandler = (): Effect.Effect<
 
     // `spa: true` is the old `sirv(dir, { single: true })`: an unknown path
     // falls back to index.html so the client router owns deep links.
+    // No `cacheControl` here, despite the hashed asset names: the option is
+    // global, and `HttpStaticServer` reuses `serveFile` for the SPA fallback
+    // (`HttpStaticServer.js:104`), so `immutable` would pin `index.html` too
+    // and strand clients on a stale app. Per-asset headers need a wrapper.
     const assets = yield* HttpStaticServer.make({ root: staticDir, spa: true }).pipe(Effect.orDie);
 
     // A path that matches no file is a 404; anything else went wrong on our

--- a/packages/server/src/http/ui.ts
+++ b/packages/server/src/http/ui.ts
@@ -1,8 +1,7 @@
-import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import path from "node:path";
 import url from "node:url";
 
+import { Effect, FileSystem, Path } from "effect";
 import sirv from "sirv";
 
 export type UIHandler = (req: IncomingMessage, res: ServerResponse) => void;
@@ -12,25 +11,36 @@ function notFound(res: ServerResponse) {
   res.end("Not Found");
 }
 
+/** `node:url` has no Effect equivalent; the URLs below are all module-relative. */
+const fromModuleUrl = (relative: string) => url.fileURLToPath(new URL(relative, import.meta.url));
+
 /**
  * Locate the built web UI: the packaged layout ships it next to the server
  * bundle as `client/`, while running from monorepo source falls back to
  * `apps/app/dist`.
  */
-function resolveStaticDir(): string | undefined {
-  const candidates = [
-    new URL("./client/", import.meta.url), // packaged: dist/client next to dist/cli.js
-    new URL("../../../../apps/app/dist/", import.meta.url), // monorepo, from src/node
-    new URL("../../../apps/app/dist/", import.meta.url), // monorepo, from packages/vibest/dist
-  ];
-  for (const candidate of candidates) {
-    const dir = path.resolve(url.fileURLToPath(candidate));
-    if (fs.existsSync(path.join(dir, "index.html"))) {
-      return dir;
+const resolveStaticDir = (): Effect.Effect<
+  string | undefined,
+  never,
+  FileSystem.FileSystem | Path.Path
+> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const candidates = [
+      "./client/", // packaged: dist/client next to dist/cli.js
+      "../../../../apps/app/dist/", // monorepo, from src/node
+      "../../../apps/app/dist/", // monorepo, from packages/vibest/dist
+    ];
+    for (const candidate of candidates) {
+      const dir = path.resolve(fromModuleUrl(candidate));
+      const built = yield* fs
+        .exists(path.join(dir, "index.html"))
+        .pipe(Effect.orElseSucceed(() => false));
+      if (built) return dir;
     }
-  }
-  return undefined;
-}
+    return undefined;
+  });
 
 /**
  * The UI-serving half of the server, isolated from auth/CORS/routing: `sirv`
@@ -39,15 +49,20 @@ function resolveStaticDir(): string | undefined {
  * `/ws/rpc` here, so this server serves files in every mode and never hosts a
  * bundler.
  */
-export function createUIHandler(): UIHandler {
-  const staticDir = resolveStaticDir();
-  if (!staticDir) {
-    return (_req, res) => {
-      res.statusCode = 503;
-      res.end("Web UI not built. Run the @vibest/app build first.");
-    };
-  }
+export const createUIHandler = (): Effect.Effect<
+  UIHandler,
+  never,
+  FileSystem.FileSystem | Path.Path
+> =>
+  Effect.gen(function* () {
+    const staticDir = yield* resolveStaticDir();
+    if (!staticDir) {
+      return (_req, res) => {
+        res.statusCode = 503;
+        res.end("Web UI not built. Run the @vibest/app build first.");
+      };
+    }
 
-  const assets = sirv(staticDir, { single: true });
-  return (req, res) => assets(req, res, () => notFound(res));
-}
+    const assets = sirv(staticDir, { single: true });
+    return (req, res) => assets(req, res, () => notFound(res));
+  });

--- a/packages/server/src/http/ui.ts
+++ b/packages/server/src/http/ui.ts
@@ -1,6 +1,7 @@
+import path from "node:path";
 import url from "node:url";
 
-import { Effect, FileSystem, Path } from "effect";
+import { Effect, FileSystem, type Path } from "effect";
 import type { HttpPlatform } from "effect/unstable/http";
 import { HttpServerRequest, HttpServerResponse, HttpStaticServer } from "effect/unstable/http";
 
@@ -24,14 +25,9 @@ const fromModuleUrl = (relative: string) => url.fileURLToPath(new URL(relative, 
  * bundle as `client/`, while running from monorepo source falls back to
  * `apps/app/dist`.
  */
-const resolveStaticDir = (): Effect.Effect<
-  string | undefined,
-  never,
-  FileSystem.FileSystem | Path.Path
-> =>
+const resolveStaticDir = (): Effect.Effect<string | undefined, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
     const candidates = [
       "./client/", // packaged: dist/client next to dist/cli.js
       "../../../../apps/app/dist/", // monorepo, from src/node
@@ -57,7 +53,9 @@ const resolveStaticDir = (): Effect.Effect<
 export const createUIHandler = (): Effect.Effect<
   UIApp,
   never,
-  FileSystem.FileSystem | Path.Path | HttpPlatform.HttpPlatform
+  // `Path` is not ours: `HttpStaticServer.make` asks for it. Our own path math
+  // below is pure and stays on `node:path`.
+  FileSystem.FileSystem | HttpPlatform.HttpPlatform | Path.Path
 > =>
   Effect.gen(function* () {
     const staticDir = yield* resolveStaticDir();
@@ -87,5 +85,4 @@ export const createUIHandler = (): Effect.Effect<
             ),
       ),
     );
-  });
   });

--- a/packages/server/src/http/ui.ts
+++ b/packages/server/src/http/ui.ts
@@ -1,15 +1,20 @@
-import type { IncomingMessage, ServerResponse } from "node:http";
 import url from "node:url";
 
 import { Effect, FileSystem, Path } from "effect";
-import sirv from "sirv";
+import type { HttpPlatform } from "effect/unstable/http";
+import { HttpServerRequest, HttpServerResponse, HttpStaticServer } from "effect/unstable/http";
 
-export type UIHandler = (req: IncomingMessage, res: ServerResponse) => void;
+/**
+ * Answers everything the API routes did not claim. `never` on the error channel
+ * because a UI miss is a response (404 / 503), not a failure.
+ */
+export type UIApp = Effect.Effect<
+  HttpServerResponse.HttpServerResponse,
+  never,
+  HttpServerRequest.HttpServerRequest
+>;
 
-function notFound(res: ServerResponse) {
-  res.statusCode = 404;
-  res.end("Not Found");
-}
+const notFound = HttpServerResponse.text("Not Found", { status: 404 });
 
 /** `node:url` has no Effect equivalent; the URLs below are all module-relative. */
 const fromModuleUrl = (relative: string) => url.fileURLToPath(new URL(relative, import.meta.url));
@@ -43,26 +48,44 @@ const resolveStaticDir = (): Effect.Effect<
   });
 
 /**
- * The UI-serving half of the server, isolated from auth/CORS/routing: `sirv`
- * over the built bundle, and a 503 when the bundle has not been built. There is
- * no dev branch — `apps/app` runs its own `vite dev` and proxies `/api` and
- * `/ws/rpc` here, so this server serves files in every mode and never hosts a
- * bundler.
+ * The UI-serving half of the server, isolated from auth/CORS/routing:
+ * `HttpStaticServer` over the built bundle, and a 503 when the bundle has not
+ * been built. There is no dev branch — `apps/app` runs its own `vite dev` and
+ * proxies `/api` and `/ws/rpc` here, so this server serves files in every mode
+ * and never hosts a bundler.
  */
 export const createUIHandler = (): Effect.Effect<
-  UIHandler,
+  UIApp,
   never,
-  FileSystem.FileSystem | Path.Path
+  FileSystem.FileSystem | Path.Path | HttpPlatform.HttpPlatform
 > =>
   Effect.gen(function* () {
     const staticDir = yield* resolveStaticDir();
     if (!staticDir) {
-      return (_req, res) => {
-        res.statusCode = 503;
-        res.end("Web UI not built. Run the @vibest/app build first.");
-      };
+      return Effect.succeed(
+        HttpServerResponse.text("Web UI not built. Run the @vibest/app build first.", {
+          status: 503,
+        }),
+      );
     }
 
-    const assets = sirv(staticDir, { single: true });
-    return (req, res) => assets(req, res, () => notFound(res));
+    // `spa: true` is the old `sirv(dir, { single: true })`: an unknown path
+    // falls back to index.html so the client router owns deep links.
+    const assets = yield* HttpStaticServer.make({ root: staticDir, spa: true }).pipe(Effect.orDie);
+
+    // A path that matches no file is a 404; anything else went wrong on our
+    // side. `RouteNotFound` covers both a missing asset and a deep link the
+    // SPA fallback declined (it only rewrites extensionless paths from a
+    // client that accepts HTML — a browser navigation, never a fetch).
+    return assets.pipe(
+      Effect.catch((error) =>
+        error.reason._tag === "RouteNotFound"
+          ? Effect.succeed(notFound)
+          : Effect.as(
+              Effect.logError("static asset read failed", error),
+              HttpServerResponse.text("Internal Server Error", { status: 500 }),
+            ),
+      ),
+    );
+  });
   });

--- a/packages/server/src/infra/json-store.ts
+++ b/packages/server/src/infra/json-store.ts
@@ -1,32 +1,37 @@
-import crypto from "node:crypto";
-import fs from "node:fs/promises";
-import path from "node:path";
-
-import { Effect } from "effect";
+import { Crypto, Effect, FileSystem, Path, type PlatformError } from "effect";
 
 import { StoreReadError, StoreWriteError } from "../errors";
 
-export const isEnoent = (cause: unknown): boolean =>
-  typeof cause === "object" && cause !== null && (cause as NodeJS.ErrnoException).code === "ENOENT";
+/**
+ * The platform services the JSON store runs on. Callers bind them once at layer
+ * construction so their own methods stay `R`-free; the requirement rides the
+ * Layer's `R` up to the composition root, which provides the Node layers.
+ */
+export type JsonStorePlatform = FileSystem.FileSystem | Path.Path | Crypto.Crypto;
+
+/**
+ * "The file isn't there" in platform terms: the Node `FileSystem` normalises
+ * `ENOENT` to a `NotFound` reason, so callers test that instead of an errno.
+ */
+export const isNotFound = (error: PlatformError.PlatformError): boolean =>
+  error.reason._tag === "NotFound";
 
 /**
  * Read a JSON file, returning `fallback` if it does not exist yet.
  * A malformed or unreadable existing file fails with `StoreReadError`.
  */
-export const readJson = <A>(file: string, fallback: A): Effect.Effect<A, StoreReadError> =>
-  Effect.tryPromise({
-    try: async () => {
-      let raw: string;
-      try {
-        raw = await fs.readFile(file, "utf8");
-      } catch (cause) {
-        if (isEnoent(cause)) return fallback;
-        throw cause;
-      }
-      return JSON.parse(raw) as A;
-    },
-    catch: (cause) => new StoreReadError({ file, cause }),
-  });
+export const readJson = <A>(
+  file: string,
+  fallback: A,
+): Effect.Effect<A, StoreReadError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const raw = yield* fs
+      .readFileString(file)
+      .pipe(Effect.catchIf(isNotFound, () => Effect.succeed(undefined)));
+    if (raw === undefined) return fallback;
+    return yield* Effect.try(() => JSON.parse(raw) as A);
+  }).pipe(Effect.mapError((cause) => new StoreReadError({ file, cause })));
 
 /**
  * Write JSON via "temp file + atomic rename" so a crash mid-write can never
@@ -35,13 +40,16 @@ export const readJson = <A>(file: string, fallback: A): Effect.Effect<A, StoreRe
 export const writeJsonAtomic = (
   file: string,
   data: unknown,
-): Effect.Effect<void, StoreWriteError> =>
-  Effect.tryPromise({
-    try: async () => {
-      await fs.mkdir(path.dirname(file), { recursive: true });
-      const tmp = `${file}.${crypto.randomUUID()}.tmp`;
-      await fs.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-      await fs.rename(tmp, file);
-    },
-    catch: (cause) => new StoreWriteError({ file, cause }),
-  });
+): Effect.Effect<void, StoreWriteError, JsonStorePlatform> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const crypto = yield* Crypto.Crypto;
+
+    const body = yield* Effect.try(() => `${JSON.stringify(data, null, 2)}\n`);
+    yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+    const id = yield* crypto.randomUUIDv4;
+    const tmp = `${file}.${id}.tmp`;
+    yield* fs.writeFileString(tmp, body);
+    yield* fs.rename(tmp, file);
+  }).pipe(Effect.mapError((cause) => new StoreWriteError({ file, cause })));

--- a/packages/server/src/infra/json-store.ts
+++ b/packages/server/src/infra/json-store.ts
@@ -54,3 +54,23 @@ export const writeJsonAtomic = (
     yield* fs.writeFileString(tmp, body);
     yield* fs.rename(tmp, file);
   }).pipe(Effect.mapError((cause) => new StoreWriteError({ file, cause })));
+
+/**
+ * The store with the platform bound once. Repositories yield this while their
+ * Layer is being built, so their own methods stay `R`-free and the requirement
+ * rides the Layer's `R` up to the composition root.
+ */
+export const boundJsonStore: Effect.Effect<
+  {
+    readonly read: <A>(file: string, fallback: A) => Effect.Effect<A, StoreReadError>;
+    readonly write: (file: string, data: unknown) => Effect.Effect<void, StoreWriteError>;
+  },
+  never,
+  JsonStorePlatform
+> = Effect.gen(function* () {
+  const platform = yield* Effect.context<JsonStorePlatform>();
+  return {
+    read: (file, fallback) => readJson(file, fallback).pipe(Effect.provide(platform)),
+    write: (file, data) => writeJsonAtomic(file, data).pipe(Effect.provide(platform)),
+  };
+});

--- a/packages/server/src/infra/json-store.ts
+++ b/packages/server/src/infra/json-store.ts
@@ -1,4 +1,4 @@
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Crypto, Effect, FileSystem, type PlatformError } from "effect";
 
@@ -48,7 +48,7 @@ export const writeJsonAtomic = (
     const crypto = yield* Crypto.Crypto;
 
     const body = yield* Effect.try(() => `${JSON.stringify(data, null, 2)}\n`);
-    yield* fs.makeDirectory(nodePath.dirname(file), { recursive: true });
+    yield* fs.makeDirectory(path.dirname(file), { recursive: true });
     const id = yield* crypto.randomUUIDv4;
     const tmp = `${file}.${id}.tmp`;
     yield* fs.writeFileString(tmp, body);

--- a/packages/server/src/infra/json-store.ts
+++ b/packages/server/src/infra/json-store.ts
@@ -1,4 +1,6 @@
-import { Crypto, Effect, FileSystem, Path, type PlatformError } from "effect";
+import nodePath from "node:path";
+
+import { Crypto, Effect, FileSystem, type PlatformError } from "effect";
 
 import { StoreReadError, StoreWriteError } from "../errors";
 
@@ -7,7 +9,7 @@ import { StoreReadError, StoreWriteError } from "../errors";
  * construction so their own methods stay `R`-free; the requirement rides the
  * Layer's `R` up to the composition root, which provides the Node layers.
  */
-export type JsonStorePlatform = FileSystem.FileSystem | Path.Path | Crypto.Crypto;
+export type JsonStorePlatform = FileSystem.FileSystem | Crypto.Crypto;
 
 /**
  * "The file isn't there" in platform terms: the Node `FileSystem` normalises
@@ -43,11 +45,10 @@ export const writeJsonAtomic = (
 ): Effect.Effect<void, StoreWriteError, JsonStorePlatform> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
     const crypto = yield* Crypto.Crypto;
 
     const body = yield* Effect.try(() => `${JSON.stringify(data, null, 2)}\n`);
-    yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+    yield* fs.makeDirectory(nodePath.dirname(file), { recursive: true });
     const id = yield* crypto.randomUUIDv4;
     const tmp = `${file}.${id}.tmp`;
     yield* fs.writeFileString(tmp, body);

--- a/packages/server/src/mcp/repository.ts
+++ b/packages/server/src/mcp/repository.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect";
 
 import { Paths } from "../config/paths";
 import type { StoreReadError, StoreWriteError } from "../errors";
-import { readJson, writeJsonAtomic, type JsonStorePlatform } from "../infra/json-store";
+import { boundJsonStore, type JsonStorePlatform } from "../infra/json-store";
 import type { McpServerConfig, RuntimeConfig } from "../types";
 
 /**
@@ -24,24 +24,14 @@ export const McpRepositoryLayer: Layer.Layer<McpRepository, never, Paths | JsonS
     McpRepository,
     Effect.gen(function* () {
       const paths = yield* Paths;
-      // Bind the platform services once so the methods below stay R-free; the
-      // Layer's R carries the requirement to the composition root instead.
-      const platform = yield* Effect.context<JsonStorePlatform>();
-      const readConfig = () => readJson<RuntimeConfig>(paths.configFile, {});
+      const json = yield* boundJsonStore;
+      const readConfig = () => json.read<RuntimeConfig>(paths.configFile, {});
       return {
-        list: () =>
-          readConfig().pipe(
-            Effect.map((config) => config.mcp ?? []),
-            Effect.provide(platform),
-          ),
+        list: () => readConfig().pipe(Effect.map((config) => config.mcp ?? [])),
         save: (servers) =>
-          Effect.gen(function* () {
-            const config = yield* readConfig();
-            yield* writeJsonAtomic(paths.configFile, {
-              ...config,
-              mcp: servers,
-            });
-          }).pipe(Effect.provide(platform)),
+          readConfig().pipe(
+            Effect.flatMap((config) => json.write(paths.configFile, { ...config, mcp: servers })),
+          ),
       };
     }),
   );

--- a/packages/server/src/mcp/repository.ts
+++ b/packages/server/src/mcp/repository.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect";
 
 import { Paths } from "../config/paths";
 import type { StoreReadError, StoreWriteError } from "../errors";
-import { readJson, writeJsonAtomic } from "../infra/json-store";
+import { readJson, writeJsonAtomic, type JsonStorePlatform } from "../infra/json-store";
 import type { McpServerConfig, RuntimeConfig } from "../types";
 
 /**
@@ -19,21 +19,29 @@ export class McpRepository extends Context.Service<
   }
 >()("McpRepository") {}
 
-export const McpRepositoryLayer: Layer.Layer<McpRepository, never, Paths> = Layer.effect(
-  McpRepository,
-  Effect.gen(function* () {
-    const paths = yield* Paths;
-    const readConfig = () => readJson<RuntimeConfig>(paths.configFile, {});
-    return {
-      list: () => readConfig().pipe(Effect.map((config) => config.mcp ?? [])),
-      save: (servers) =>
-        Effect.gen(function* () {
-          const config = yield* readConfig();
-          yield* writeJsonAtomic(paths.configFile, {
-            ...config,
-            mcp: servers,
-          });
-        }),
-    };
-  }),
-);
+export const McpRepositoryLayer: Layer.Layer<McpRepository, never, Paths | JsonStorePlatform> =
+  Layer.effect(
+    McpRepository,
+    Effect.gen(function* () {
+      const paths = yield* Paths;
+      // Bind the platform services once so the methods below stay R-free; the
+      // Layer's R carries the requirement to the composition root instead.
+      const platform = yield* Effect.context<JsonStorePlatform>();
+      const readConfig = () => readJson<RuntimeConfig>(paths.configFile, {});
+      return {
+        list: () =>
+          readConfig().pipe(
+            Effect.map((config) => config.mcp ?? []),
+            Effect.provide(platform),
+          ),
+        save: (servers) =>
+          Effect.gen(function* () {
+            const config = yield* readConfig();
+            yield* writeJsonAtomic(paths.configFile, {
+              ...config,
+              mcp: servers,
+            });
+          }).pipe(Effect.provide(platform)),
+      };
+    }),
+  );

--- a/packages/server/src/project/index.ts
+++ b/packages/server/src/project/index.ts
@@ -1,12 +1,16 @@
 import { Layer } from "effect";
 
 import type { Paths } from "../config/paths";
+import type { JsonStorePlatform } from "../infra/json-store";
 import { ProjectRepositoryLayer } from "./repository";
 import { ProjectService, ProjectServiceLayer } from "./service";
 
 export { ProjectRepository, ProjectRepositoryLayer } from "./repository";
 export { ProjectService, ProjectServiceLayer } from "./service";
 
-/** The project module fully wired — callers supply only a `Paths` layer. */
-export const ProjectModuleLayer: Layer.Layer<ProjectService, never, Paths> =
+/**
+ * The project module fully wired — callers supply a `Paths` layer plus the
+ * platform services the JSON store runs on.
+ */
+export const ProjectModuleLayer: Layer.Layer<ProjectService, never, Paths | JsonStorePlatform> =
   ProjectServiceLayer.pipe(Layer.provide(ProjectRepositoryLayer));

--- a/packages/server/src/project/index.ts
+++ b/packages/server/src/project/index.ts
@@ -10,7 +10,7 @@ export { ProjectService, ProjectServiceLayer } from "./service";
 
 /**
  * The project module fully wired — callers supply a `Paths` layer plus the
- * platform services the JSON store runs on.
+ * platform services the repository and id generation run on.
  */
 export const ProjectModuleLayer: Layer.Layer<ProjectService, never, Paths | JsonStorePlatform> =
   ProjectServiceLayer.pipe(Layer.provide(ProjectRepositoryLayer));

--- a/packages/server/src/project/repository.ts
+++ b/packages/server/src/project/repository.ts
@@ -1,4 +1,3 @@
-import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import { ProjectSchema } from "@vibest/contract";
 import { type JsonDocument, makeJsonDocument } from "@vibest/effect-json-store";
 import { Context, Effect, FileSystem, Layer, Option, Ref, Schema, Semaphore } from "effect";
@@ -26,7 +25,11 @@ export class ProjectRepository extends Context.Service<
   }
 >()("ProjectRepository") {}
 
-export const ProjectRepositoryLayer: Layer.Layer<ProjectRepository, never, Paths> = Layer.effect(
+export const ProjectRepositoryLayer: Layer.Layer<
+  ProjectRepository,
+  never,
+  Paths | FileSystem.FileSystem
+> = Layer.effect(
   ProjectRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
@@ -76,4 +79,4 @@ export const ProjectRepositoryLayer: Layer.Layer<ProjectRepository, never, Paths
         ),
     };
   }),
-).pipe(Layer.provide(NodeFileSystem.layer));
+);

--- a/packages/server/src/project/service.ts
+++ b/packages/server/src/project/service.ts
@@ -1,7 +1,4 @@
-import crypto from "node:crypto";
-import path from "node:path";
-
-import { Context, Effect, Layer } from "effect";
+import { Context, Crypto, Effect, Layer, Path } from "effect";
 
 import { ProjectNotFound, type StoreReadError, type StoreWriteError } from "../errors";
 import type { Project } from "../types";
@@ -29,59 +26,67 @@ export class ProjectService extends Context.Service<
   }
 >()("ProjectService") {}
 
-export const ProjectServiceLayer: Layer.Layer<ProjectService, never, ProjectRepository> =
-  Layer.effect(
-    ProjectService,
-    Effect.gen(function* () {
-      const repo = yield* ProjectRepository;
+export const ProjectServiceLayer: Layer.Layer<
+  ProjectService,
+  never,
+  ProjectRepository | Path.Path | Crypto.Crypto
+> = Layer.effect(
+  ProjectService,
+  Effect.gen(function* () {
+    const repo = yield* ProjectRepository;
+    const { basename, resolve: resolvePath } = yield* Path.Path;
+    const crypto = yield* Crypto.Crypto;
+    // A platform RNG that cannot produce a uuid is a defect, not a domain
+    // failure — keep it out of the service's error channel.
+    const newId = crypto.randomUUIDv4.pipe(Effect.orDie);
 
-      return {
-        list: () => repo.list(),
+    return {
+      list: () => repo.list(),
 
-        findById: (id) =>
-          Effect.gen(function* () {
-            const projects = yield* repo.list();
-            const found = projects.find((p) => p.id === id);
-            if (found === undefined) {
-              return yield* Effect.fail(new ProjectNotFound({ projectId: id }));
-            }
-            return found;
-          }),
+      findById: (id) =>
+        Effect.gen(function* () {
+          const projects = yield* repo.list();
+          const found = projects.find((p) => p.id === id);
+          if (found === undefined) {
+            return yield* Effect.fail(new ProjectNotFound({ projectId: id }));
+          }
+          return found;
+        }),
 
-        findByPath: (targetPath) =>
-          Effect.gen(function* () {
-            const projects = yield* repo.list();
-            const target = path.resolve(targetPath);
-            return projects.find((p) => path.resolve(p.path) === target);
-          }),
+      findByPath: (path) =>
+        Effect.gen(function* () {
+          const projects = yield* repo.list();
+          const target = resolvePath(path);
+          return projects.find((p) => resolvePath(p.path) === target);
+        }),
 
-        create: (input) =>
-          Effect.gen(function* () {
-            const normalized = path.resolve(input.path);
-            const projects = yield* repo.list();
-            // Reuse an existing project pointing at the same path.
-            const existing = projects.find((p) => path.resolve(p.path) === normalized);
-            if (existing !== undefined) return existing;
+      create: (input) =>
+        Effect.gen(function* () {
+          const normalized = resolvePath(input.path);
+          const projects = yield* repo.list();
+          // Reuse an existing project pointing at the same path.
+          const existing = projects.find((p) => resolvePath(p.path) === normalized);
+          if (existing !== undefined) return existing;
 
-            const project: Project = {
-              id: crypto.randomUUID(),
-              name: input.name ?? path.basename(normalized),
-              path: normalized,
-              createdAt: new Date().toISOString(),
-            };
-            yield* repo.save([...projects, project]);
-            return project;
-          }),
+          const project: Project = {
+            id: yield* newId,
+            name: input.name ?? basename(normalized),
+            path: normalized,
+            createdAt: new Date().toISOString(),
+          };
+          yield* repo.save([...projects, project]);
+          return project;
+        }),
 
-        remove: (id) =>
-          Effect.gen(function* () {
-            const projects = yield* repo.list();
-            const target = projects.find((p) => p.id === id);
-            if (target === undefined) {
-              return yield* Effect.fail(new ProjectNotFound({ projectId: id }));
-            }
-            yield* repo.save(projects.filter((p) => p.id !== id));
-          }),
-      };
-    }),
-  );
+      remove: (id) =>
+        Effect.gen(function* () {
+          const projects = yield* repo.list();
+          const target = projects.find((p) => p.id === id);
+          if (target === undefined) {
+            return yield* Effect.fail(new ProjectNotFound({ projectId: id }));
+          }
+          yield* repo.save(projects.filter((p) => p.id !== id));
+        }),
+    };
+  }),
+);

--- a/packages/server/src/project/service.ts
+++ b/packages/server/src/project/service.ts
@@ -1,4 +1,6 @@
-import { Context, Crypto, Effect, Layer, Path } from "effect";
+import nodePath from "node:path";
+
+import { Context, Crypto, Effect, Layer } from "effect";
 
 import { ProjectNotFound, type StoreReadError, type StoreWriteError } from "../errors";
 import type { Project } from "../types";
@@ -29,12 +31,11 @@ export class ProjectService extends Context.Service<
 export const ProjectServiceLayer: Layer.Layer<
   ProjectService,
   never,
-  ProjectRepository | Path.Path | Crypto.Crypto
+  ProjectRepository | Crypto.Crypto
 > = Layer.effect(
   ProjectService,
   Effect.gen(function* () {
     const repo = yield* ProjectRepository;
-    const { basename, resolve: resolvePath } = yield* Path.Path;
     const crypto = yield* Crypto.Crypto;
     // A platform RNG that cannot produce a uuid is a defect, not a domain
     // failure — keep it out of the service's error channel.
@@ -56,21 +57,21 @@ export const ProjectServiceLayer: Layer.Layer<
       findByPath: (path) =>
         Effect.gen(function* () {
           const projects = yield* repo.list();
-          const target = resolvePath(path);
-          return projects.find((p) => resolvePath(p.path) === target);
+          const target = nodePath.resolve(path);
+          return projects.find((p) => nodePath.resolve(p.path) === target);
         }),
 
       create: (input) =>
         Effect.gen(function* () {
-          const normalized = resolvePath(input.path);
+          const normalized = nodePath.resolve(input.path);
           const projects = yield* repo.list();
           // Reuse an existing project pointing at the same path.
-          const existing = projects.find((p) => resolvePath(p.path) === normalized);
+          const existing = projects.find((p) => nodePath.resolve(p.path) === normalized);
           if (existing !== undefined) return existing;
 
           const project: Project = {
             id: yield* newId,
-            name: input.name ?? basename(normalized),
+            name: input.name ?? nodePath.basename(normalized),
             path: normalized,
             createdAt: new Date().toISOString(),
           };

--- a/packages/server/src/project/service.ts
+++ b/packages/server/src/project/service.ts
@@ -1,4 +1,4 @@
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Context, Crypto, Effect, Layer } from "effect";
 
@@ -16,7 +16,7 @@ export class ProjectService extends Context.Service<
     readonly list: () => Effect.Effect<ReadonlyArray<Project>, StoreReadError>;
     readonly findById: (id: string) => Effect.Effect<Project, StoreReadError | ProjectNotFound>;
     /** The project registered at a workspace path, if any (paths are resolved). */
-    readonly findByPath: (path: string) => Effect.Effect<Project | undefined, StoreReadError>;
+    readonly findByPath: (workspace: string) => Effect.Effect<Project | undefined, StoreReadError>;
     /** `name` defaults to the folder's basename. */
     readonly create: (input: {
       readonly name?: string;
@@ -54,24 +54,24 @@ export const ProjectServiceLayer: Layer.Layer<
           return found;
         }),
 
-      findByPath: (path) =>
+      findByPath: (workspace) =>
         Effect.gen(function* () {
           const projects = yield* repo.list();
-          const target = nodePath.resolve(path);
-          return projects.find((p) => nodePath.resolve(p.path) === target);
+          const target = path.resolve(workspace);
+          return projects.find((p) => path.resolve(p.path) === target);
         }),
 
       create: (input) =>
         Effect.gen(function* () {
-          const normalized = nodePath.resolve(input.path);
+          const normalized = path.resolve(input.path);
           const projects = yield* repo.list();
           // Reuse an existing project pointing at the same path.
-          const existing = projects.find((p) => nodePath.resolve(p.path) === normalized);
+          const existing = projects.find((p) => path.resolve(p.path) === normalized);
           if (existing !== undefined) return existing;
 
           const project: Project = {
             id: yield* newId,
-            name: input.name ?? nodePath.basename(normalized),
+            name: input.name ?? path.basename(normalized),
             path: normalized,
             createdAt: new Date().toISOString(),
           };

--- a/packages/server/src/provider/repository.ts
+++ b/packages/server/src/provider/repository.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect";
 
 import { Paths } from "../config/paths";
 import type { StoreReadError, StoreWriteError } from "../errors";
-import { readJson, writeJsonAtomic } from "../infra/json-store";
+import { readJson, writeJsonAtomic, type JsonStorePlatform } from "../infra/json-store";
 import type { ProviderConfig, RuntimeConfig } from "../types";
 
 /**
@@ -20,13 +20,24 @@ export class ProviderRepository extends Context.Service<
   }
 >()("ProviderRepository") {}
 
-export const ProviderRepositoryLayer: Layer.Layer<ProviderRepository, never, Paths> = Layer.effect(
+export const ProviderRepositoryLayer: Layer.Layer<
+  ProviderRepository,
+  never,
+  Paths | JsonStorePlatform
+> = Layer.effect(
   ProviderRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
+    // Bind the platform services once so the methods below stay R-free; the
+    // Layer's R carries the requirement to the composition root instead.
+    const platform = yield* Effect.context<JsonStorePlatform>();
     const readConfig = () => readJson<RuntimeConfig>(paths.configFile, {});
     return {
-      list: () => readConfig().pipe(Effect.map((config) => config.provider ?? [])),
+      list: () =>
+        readConfig().pipe(
+          Effect.map((config) => config.provider ?? []),
+          Effect.provide(platform),
+        ),
       save: (providers) =>
         Effect.gen(function* () {
           const config = yield* readConfig();
@@ -34,7 +45,7 @@ export const ProviderRepositoryLayer: Layer.Layer<ProviderRepository, never, Pat
             ...config,
             provider: providers,
           });
-        }),
+        }).pipe(Effect.provide(platform)),
     };
   }),
 );

--- a/packages/server/src/provider/repository.ts
+++ b/packages/server/src/provider/repository.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect";
 
 import { Paths } from "../config/paths";
 import type { StoreReadError, StoreWriteError } from "../errors";
-import { readJson, writeJsonAtomic, type JsonStorePlatform } from "../infra/json-store";
+import { boundJsonStore, type JsonStorePlatform } from "../infra/json-store";
 import type { ProviderConfig, RuntimeConfig } from "../types";
 
 /**
@@ -28,24 +28,16 @@ export const ProviderRepositoryLayer: Layer.Layer<
   ProviderRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
-    // Bind the platform services once so the methods below stay R-free; the
-    // Layer's R carries the requirement to the composition root instead.
-    const platform = yield* Effect.context<JsonStorePlatform>();
-    const readConfig = () => readJson<RuntimeConfig>(paths.configFile, {});
+    const json = yield* boundJsonStore;
+    const readConfig = () => json.read<RuntimeConfig>(paths.configFile, {});
     return {
-      list: () =>
-        readConfig().pipe(
-          Effect.map((config) => config.provider ?? []),
-          Effect.provide(platform),
-        ),
+      list: () => readConfig().pipe(Effect.map((config) => config.provider ?? [])),
       save: (providers) =>
-        Effect.gen(function* () {
-          const config = yield* readConfig();
-          yield* writeJsonAtomic(paths.configFile, {
-            ...config,
-            provider: providers,
-          });
-        }).pipe(Effect.provide(platform)),
+        readConfig().pipe(
+          Effect.flatMap((config) =>
+            json.write(paths.configFile, { ...config, provider: providers }),
+          ),
+        ),
     };
   }),
 );

--- a/packages/server/src/rpc/context.ts
+++ b/packages/server/src/rpc/context.ts
@@ -1,5 +1,6 @@
 import type { WithEffectContext } from "@orpc/experimental-effect";
 import type { FileSystem } from "effect/FileSystem";
+import type { Path } from "effect/Path";
 
 import type { EventBus } from "../events";
 import type { FileSystemService } from "../fs";
@@ -11,6 +12,7 @@ import type { SessionService } from "../session";
 export type RpcContext = WithEffectContext<
   | EventBus
   | FileSystem
+  | Path
   | HarnessAgentRegistry
   | HarnessListService
   | HarnessProbeService

--- a/packages/server/src/rpc/context.ts
+++ b/packages/server/src/rpc/context.ts
@@ -1,6 +1,5 @@
 import type { WithEffectContext } from "@orpc/experimental-effect";
 import type { FileSystem } from "effect/FileSystem";
-import type { Path } from "effect/Path";
 
 import type { EventBus } from "../events";
 import type { FileSystemService } from "../fs";
@@ -12,7 +11,6 @@ import type { SessionService } from "../session";
 export type RpcContext = WithEffectContext<
   | EventBus
   | FileSystem
-  | Path
   | HarnessAgentRegistry
   | HarnessListService
   | HarnessProbeService

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -1,11 +1,11 @@
 import "@orpc/experimental-effect/extensions/effect";
 import os from "node:os";
+import nodePath from "node:path";
 
 import { implement } from "@orpc/server";
 import { fsContract } from "@vibest/contract/fs";
 import { Effect } from "effect";
 import { FileSystem } from "effect/FileSystem";
-import { Path } from "effect/Path";
 
 import { FileSystemService } from "../fs";
 import type { RpcContext } from "./context";
@@ -36,10 +36,8 @@ export const fsRouter = orpc.router({
   }),
   browse: orpc.browse.effect(function* ({ input, errors }) {
     const fs = yield* FileSystem;
-    const pathService = yield* Path;
-    // `node:os.homedir` has no Effect equivalent; everything else is the
-    // Path service.
-    const path = pathService.resolve(input.path ?? os.homedir());
+    // Resolving and joining are pure string math, so they stay on `node:path`.
+    const path = nodePath.resolve(input.path ?? os.homedir());
     // Folder-picker policy (owned here, not a shared fs service): directories
     // only, hide dotfolders and node_modules, sorted by name.
     const names = yield* fs
@@ -51,7 +49,7 @@ export const fsRouter = orpc.router({
     const flagged = yield* Effect.forEach(
       candidates,
       (name) =>
-        fs.stat(pathService.join(path, name)).pipe(
+        fs.stat(nodePath.join(path, name)).pipe(
           Effect.map((info) => info.type === "Directory"),
           Effect.catch(() => Effect.succeed(false)),
           Effect.map((isDirectory) => ({ name, isDirectory })),
@@ -60,9 +58,9 @@ export const fsRouter = orpc.router({
     );
     const directories = flagged
       .filter((e) => e.isDirectory)
-      .map((e) => ({ name: e.name, path: pathService.join(path, e.name) }));
+      .map((e) => ({ name: e.name, path: nodePath.join(path, e.name) }));
     directories.sort((a, b) => a.name.localeCompare(b.name));
-    const parent = pathService.dirname(path);
+    const parent = nodePath.dirname(path);
     return { path, parent: parent === path ? null : parent, directories };
   }),
 });

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -1,6 +1,6 @@
 import "@orpc/experimental-effect/extensions/effect";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { implement } from "@orpc/server";
 import { fsContract } from "@vibest/contract/fs";
@@ -37,19 +37,19 @@ export const fsRouter = orpc.router({
   browse: orpc.browse.effect(function* ({ input, errors }) {
     const fs = yield* FileSystem;
     // Resolving and joining are pure string math, so they stay on `node:path`.
-    const path = nodePath.resolve(input.path ?? os.homedir());
+    const dir = path.resolve(input.path ?? os.homedir());
     // Folder-picker policy (owned here, not a shared fs service): directories
     // only, hide dotfolders and node_modules, sorted by name.
     const names = yield* fs
-      .readDirectory(path)
-      .pipe(Effect.mapError(() => errors.READ_FAILED({ data: { path } })));
+      .readDirectory(dir)
+      .pipe(Effect.mapError(() => errors.READ_FAILED({ data: { path: dir } })));
     const candidates = names.filter((name) => !name.startsWith(".") && !IGNORED_DIRS.has(name));
     // readDirectory yields names only, so stat each to keep just directories. A
     // failing stat (e.g. broken symlink) drops that entry rather than the list.
     const flagged = yield* Effect.forEach(
       candidates,
       (name) =>
-        fs.stat(nodePath.join(path, name)).pipe(
+        fs.stat(path.join(dir, name)).pipe(
           Effect.map((info) => info.type === "Directory"),
           Effect.catch(() => Effect.succeed(false)),
           Effect.map((isDirectory) => ({ name, isDirectory })),
@@ -58,10 +58,10 @@ export const fsRouter = orpc.router({
     );
     const directories = flagged
       .filter((e) => e.isDirectory)
-      .map((e) => ({ name: e.name, path: nodePath.join(path, e.name) }));
+      .map((e) => ({ name: e.name, path: path.join(dir, e.name) }));
     directories.sort((a, b) => a.name.localeCompare(b.name));
-    const parent = nodePath.dirname(path);
-    return { path, parent: parent === path ? null : parent, directories };
+    const parent = path.dirname(dir);
+    return { path: dir, parent: parent === dir ? null : parent, directories };
   }),
 });
 

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -1,11 +1,11 @@
 import "@orpc/experimental-effect/extensions/effect";
 import os from "node:os";
-import path from "node:path";
 
 import { implement } from "@orpc/server";
 import { fsContract } from "@vibest/contract/fs";
 import { Effect } from "effect";
 import { FileSystem } from "effect/FileSystem";
+import { Path } from "effect/Path";
 
 import { FileSystemService } from "../fs";
 import type { RpcContext } from "./context";
@@ -36,19 +36,22 @@ export const fsRouter = orpc.router({
   }),
   browse: orpc.browse.effect(function* ({ input, errors }) {
     const fs = yield* FileSystem;
-    const root = path.resolve(input.path ?? os.homedir());
+    const pathService = yield* Path;
+    // `node:os.homedir` has no Effect equivalent; everything else is the
+    // Path service.
+    const path = pathService.resolve(input.path ?? os.homedir());
     // Folder-picker policy (owned here, not a shared fs service): directories
     // only, hide dotfolders and node_modules, sorted by name.
     const names = yield* fs
-      .readDirectory(root)
-      .pipe(Effect.mapError(() => errors.READ_FAILED({ data: { path: root } })));
+      .readDirectory(path)
+      .pipe(Effect.mapError(() => errors.READ_FAILED({ data: { path } })));
     const candidates = names.filter((name) => !name.startsWith(".") && !IGNORED_DIRS.has(name));
     // readDirectory yields names only, so stat each to keep just directories. A
     // failing stat (e.g. broken symlink) drops that entry rather than the list.
     const flagged = yield* Effect.forEach(
       candidates,
       (name) =>
-        fs.stat(path.join(root, name)).pipe(
+        fs.stat(pathService.join(path, name)).pipe(
           Effect.map((info) => info.type === "Directory"),
           Effect.catch(() => Effect.succeed(false)),
           Effect.map((isDirectory) => ({ name, isDirectory })),
@@ -57,10 +60,10 @@ export const fsRouter = orpc.router({
     );
     const directories = flagged
       .filter((e) => e.isDirectory)
-      .map((e) => ({ name: e.name, path: path.join(root, e.name) }));
+      .map((e) => ({ name: e.name, path: pathService.join(path, e.name) }));
     directories.sort((a, b) => a.name.localeCompare(b.name));
-    const parent = path.dirname(root);
-    return { path: root, parent: parent === root ? null : parent, directories };
+    const parent = pathService.dirname(path);
+    return { path, parent: parent === path ? null : parent, directories };
   }),
 });
 

--- a/packages/server/src/rpc/handlers.ts
+++ b/packages/server/src/rpc/handlers.ts
@@ -1,4 +1,5 @@
 import { RPCHandler as WsRPCHandler } from "@orpc/server/websocket";
+import type { Effect, Layer } from "effect";
 import { ManagedRuntime } from "effect";
 import type { WebSocket } from "ws";
 
@@ -21,8 +22,18 @@ async function logErrors<T>({ next }: { next: () => Promise<T> }): Promise<T> {
 
 export type RpcRuntime = {
   readonly context: RpcContext;
+  /**
+   * Run an effect on the server's own runtime. `http/server.ts` is Promise-
+   * shaped (node:http + ws + Vite share one server), so this is how the
+   * Effect-native pieces it wires up — the UI handler — get their services
+   * without a second composition root.
+   */
+  readonly run: <A, E>(effect: Effect.Effect<A, E, AgentRuntime>) => Promise<A>;
   readonly dispose: () => Promise<void>;
 };
+
+/** Everything `AgentRuntimeLayer` provides, as a requirement. */
+type AgentRuntime = Layer.Success<typeof AgentRuntimeLayer>;
 
 export async function createRpcRuntime(): Promise<RpcRuntime> {
   const runtime = ManagedRuntime.make(AgentRuntimeLayer);
@@ -32,6 +43,7 @@ export async function createRpcRuntime(): Promise<RpcRuntime> {
   let disposing: Promise<void> | undefined;
   return {
     context,
+    run: (effect) => runtime.runPromise(effect),
     dispose: () => (disposing ??= runtime.dispose()),
   };
 }

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -3,12 +3,13 @@ import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodeHttpPlatform from "@effect/platform-node/NodeHttpPlatform";
 import * as NodePath from "@effect/platform-node/NodePath";
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, type FileSystem, Layer } from "effect";
 
 import { PathsLayer } from "../config/paths";
 import { EventBusLayer } from "../events";
 import { FileSystemServiceLayer } from "../fs";
 import {
+  type HarnessAgentAdapter,
   HarnessAgentRegistry,
   HarnessAgentSessionServiceLayer,
   HarnessListLayer,
@@ -58,19 +59,37 @@ export const PiLayer: Layer.Layer<Pi> = Layer.effect(Pi, makePiAgent()).pipe(
 
 const ProvidersLayer = Layer.mergeAll(ClaudeCodeLayer, CodexLayer, PiLayer);
 
+/**
+ * Which CLI is installed, and whether it is new enough, is fixed for the life
+ * of the process — but `harness.list` is awaited before first paint and every
+ * `session.create` asks again, and claude-code's check spawns `claude
+ * --version` (~45ms) each time. Cache it here, at the one place that builds the
+ * registry, so the answer costs one spawn per server rather than one per call.
+ *
+ * The trade is that a CLI installed while the server is running is not noticed
+ * until it restarts.
+ */
+const cacheAvailability = (
+  adapter: HarnessAgentAdapter,
+): Effect.Effect<HarnessAgentAdapter, never, FileSystem.FileSystem> =>
+  Effect.map(Effect.cached(adapter.checkAvailability), (checkAvailability) => ({
+    ...adapter,
+    checkAvailability,
+  }));
+
 const RegistryLayer = Layer.effect(
   HarnessAgentRegistry,
   Effect.gen(function* () {
     const claudeCode = yield* ClaudeCode;
     const codex = yield* Codex;
     const pi = yield* Pi;
-    return makeHarnessAgentRegistry([
-      makeClaudeCodeAdapter(claudeCode),
-      makeCodexAdapter(codex),
-      makePiAdapter(pi),
-    ]);
+    const adapters = yield* Effect.forEach(
+      [makeClaudeCodeAdapter(claudeCode), makeCodexAdapter(codex), makePiAdapter(pi)],
+      cacheAvailability,
+    );
+    return makeHarnessAgentRegistry(adapters);
   }),
-).pipe(Layer.provide(ProvidersLayer));
+).pipe(Layer.provide(ProvidersLayer), Layer.provide(PlatformLayer));
 
 // Both harness routes read the same registry instance. It matters most for the
 // probe: one cache, shared by every connecting client, so N tabs on the same

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -124,6 +124,6 @@ export const AgentRuntimeLayer = Layer.mergeAll(
   RegistryLayer,
   HarnessListProvided,
   HarnessProbeProvided,
-  FileSystemServiceLayer,
+  FileSystemServiceLayer.pipe(Layer.provide(PlatformLayer)),
   PlatformLayer,
 );

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -107,6 +107,7 @@ const SessionServiceProvided = SessionServiceLayer.pipe(
   Layer.provide(HarnessAgentSessionPortProvided),
   Layer.provide(SessionManagerProvided),
   Layer.provide(EventBusLayer),
+  Layer.provide(PlatformLayer),
 );
 
 // RegistryLayer is merged in as well as provided into SessionServiceLayer;

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -33,11 +33,6 @@ export class ClaudeCode extends Context.Service<ClaudeCode, ClaudeCodeAgent>()("
 export class Codex extends Context.Service<Codex, CodexAgent>()("Codex") {}
 export class Pi extends Context.Service<Pi, PiAgent>()("Pi") {}
 
-export const ClaudeCodeLayer: Layer.Layer<ClaudeCode> = Layer.effect(
-  ClaudeCode,
-  makeClaudeCodeAgent(),
-);
-
 /**
  * The Node platform services. Every effect that touches disk, paths, or random
  * bytes bubbles these up its `R` channel; this is the one place they are
@@ -46,6 +41,11 @@ export const ClaudeCodeLayer: Layer.Layer<ClaudeCode> = Layer.effect(
 const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer, NodeCrypto.layer);
 
 const NodeProcessLayer = NodeChildProcessSpawner.layer.pipe(Layer.provide(PlatformLayer));
+
+export const ClaudeCodeLayer: Layer.Layer<ClaudeCode> = Layer.effect(
+  ClaudeCode,
+  makeClaudeCodeAgent(),
+).pipe(Layer.provide(PlatformLayer));
 
 export const CodexLayer: Layer.Layer<Codex> = Layer.effect(Codex, makeCodexAgent()).pipe(
   Layer.provide(NodeProcessLayer),
@@ -74,12 +74,16 @@ const RegistryLayer = Layer.effect(
 // Both harness routes read the same registry instance. It matters most for the
 // probe: one cache, shared by every connecting client, so N tabs on the same
 // directory still cost one CLI spawn.
-const HarnessListProvided = HarnessListLayer.pipe(Layer.provide(RegistryLayer));
+const HarnessListProvided = HarnessListLayer.pipe(
+  Layer.provide(RegistryLayer),
+  Layer.provide(PlatformLayer),
+);
 const HarnessProbeProvided = HarnessProbeLayer.pipe(Layer.provide(RegistryLayer));
 
 // Harness session lifecycle (agent-native ids only); shared by the port and RPC.
 const HarnessSessionServiceLayer = HarnessAgentSessionServiceLayer.pipe(
   Layer.provide(RegistryLayer),
+  Layer.provide(PlatformLayer),
 );
 
 // Server-owned services. Each shared dependency (EventBus, harness service,

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -1,6 +1,7 @@
 import * as NodeChildProcessSpawner from "@effect/platform-node/NodeChildProcessSpawner";
 import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodeHttpPlatform from "@effect/platform-node/NodeHttpPlatform";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { Context, Effect, Layer } from "effect";
 
@@ -126,4 +127,7 @@ export const AgentRuntimeLayer = Layer.mergeAll(
   HarnessProbeProvided,
   FileSystemServiceLayer.pipe(Layer.provide(PlatformLayer)),
   PlatformLayer,
+  // For the HTTP request app: `HttpStaticServer` needs it to turn a file into a
+  // response. Sealed by the vendor layer, hence no `Layer.provide` here.
+  NodeHttpPlatform.layer,
 );

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -1,4 +1,5 @@
 import * as NodeChildProcessSpawner from "@effect/platform-node/NodeChildProcessSpawner";
+import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { Context, Effect, Layer } from "effect";
@@ -37,9 +38,14 @@ export const ClaudeCodeLayer: Layer.Layer<ClaudeCode> = Layer.effect(
   makeClaudeCodeAgent(),
 );
 
-const NodeProcessLayer = NodeChildProcessSpawner.layer.pipe(
-  Layer.provide(Layer.merge(NodeFileSystem.layer, NodePath.layer)),
-);
+/**
+ * The Node platform services. Every effect that touches disk, paths, or random
+ * bytes bubbles these up its `R` channel; this is the one place they are
+ * satisfied for the server runtime.
+ */
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer, NodeCrypto.layer);
+
+const NodeProcessLayer = NodeChildProcessSpawner.layer.pipe(Layer.provide(PlatformLayer));
 
 export const CodexLayer: Layer.Layer<Codex> = Layer.effect(Codex, makeCodexAgent()).pipe(
   Layer.provide(NodeProcessLayer),
@@ -82,8 +88,12 @@ const HarnessSessionServiceLayer = HarnessAgentSessionServiceLayer.pipe(
 const ProjectServiceProvided = ProjectServiceLayer.pipe(
   Layer.provide(ProjectRepositoryLayer),
   Layer.provide(PathsLayer),
+  Layer.provide(PlatformLayer),
 );
-const SessionRepositoryProvided = SessionRepositoryLayer.pipe(Layer.provide(PathsLayer));
+const SessionRepositoryProvided = SessionRepositoryLayer.pipe(
+  Layer.provide(PathsLayer),
+  Layer.provide(PlatformLayer),
+);
 const HarnessAgentSessionPortProvided = HarnessAgentSessionPortLayer.pipe(
   Layer.provide(HarnessSessionServiceLayer),
 );
@@ -110,5 +120,5 @@ export const AgentRuntimeLayer = Layer.mergeAll(
   HarnessListProvided,
   HarnessProbeProvided,
   FileSystemServiceLayer,
-  NodeFileSystem.layer,
+  PlatformLayer,
 );

--- a/packages/server/src/session/repository.ts
+++ b/packages/server/src/session/repository.ts
@@ -1,6 +1,5 @@
-import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import { type JsonStoreLoadError, makeJsonCollection } from "@vibest/effect-json-store";
-import { Context, Effect, Layer, Option, Schema } from "effect";
+import { Context, Effect, FileSystem, Layer, Option, Schema } from "effect";
 
 import { Paths } from "../config/paths";
 import { SessionNotFound, SessionRefNotFound, StoreReadError, StoreWriteError } from "../errors";
@@ -61,7 +60,11 @@ export class SessionRepository extends Context.Service<
 const isSafeId = (id: string): boolean =>
   id.length > 0 && !/[/\\]/.test(id) && id !== "." && id !== "..";
 
-export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths> = Layer.effect(
+export const SessionRepositoryLayer: Layer.Layer<
+  SessionRepository,
+  never,
+  Paths | FileSystem.FileSystem
+> = Layer.effect(
   SessionRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
@@ -128,4 +131,4 @@ export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths
           : sessions.remove(entryId(projectId, sessionId)).pipe(Effect.mapError(asWriteError)),
     };
   }),
-).pipe(Layer.provide(NodeFileSystem.layer));
+);

--- a/packages/server/src/session/service.ts
+++ b/packages/server/src/session/service.ts
@@ -1,5 +1,3 @@
-import crypto from "node:crypto";
-
 import type {
   AgentResponse,
   PermissionMode,
@@ -10,7 +8,7 @@ import type {
   SessionStatus,
   SessionSummary,
 } from "@vibest/contract";
-import { Context, Effect, Layer } from "effect";
+import { Context, Crypto, Effect, Layer } from "effect";
 
 import {
   type ProjectNotFound,
@@ -181,7 +179,12 @@ export class SessionService extends Context.Service<
 export const SessionServiceLayer: Layer.Layer<
   SessionService,
   never,
-  ProjectService | SessionRepository | HarnessAgentSessionPort | SessionManager | EventBus
+  | ProjectService
+  | SessionRepository
+  | HarnessAgentSessionPort
+  | SessionManager
+  | EventBus
+  | Crypto.Crypto
 > = Layer.effect(
   SessionService,
   Effect.gen(function* () {
@@ -190,6 +193,10 @@ export const SessionServiceLayer: Layer.Layer<
     const port = yield* HarnessAgentSessionPort;
     const manager = yield* SessionManager;
     const bus = yield* EventBus;
+    const crypto = yield* Crypto.Crypto;
+    // A platform RNG that cannot produce a uuid is a defect, not a domain
+    // failure — keep it out of the service's error channel.
+    const newSessionId = crypto.randomUUIDv4.pipe(Effect.orDie);
 
     const readChecked = (ref: SessionRef) =>
       repo
@@ -241,35 +248,29 @@ export const SessionServiceLayer: Layer.Layer<
 
     return {
       create: (projectId, harnessAgentId, config) =>
-        projects.findById(projectId).pipe(
-          Effect.flatMap((project) =>
-            port.create(harnessAgentId, project.path, config).pipe(
-              Effect.flatMap((harnessSessionId) => {
-                const sessionId = crypto.randomUUID();
-                const metadata: Session = {
-                  version: 1,
-                  sessionId,
-                  projectId,
-                  harnessAgentId,
-                  harnessSessionId,
-                  createdAt: new Date().toISOString(),
-                  // Our own floor field: the session's working directory. Stored
-                  // so an imported/rehomed session stays self-contained and a
-                  // resume has cwd before it can call getSessionInfo.
-                  cwd: project.path,
-                };
-                const ref: SessionRef = { projectId, harnessAgentId, sessionId };
-                return repo.write(metadata).pipe(
-                  // A failed metadata write must not leak the native session.
-                  Effect.tapError(() => port.close(harnessSessionId)),
-                  Effect.andThen(startRuntime(ref, harnessSessionId)),
-                  Effect.andThen(bus.publish({ ref, type: "session.created" })),
-                  Effect.as(ref),
-                );
-              }),
-            ),
-          ),
-        ),
+        Effect.gen(function* () {
+          const project = yield* projects.findById(projectId);
+          const harnessSessionId = yield* port.create(harnessAgentId, project.path, config);
+          const sessionId = yield* newSessionId;
+          const metadata: Session = {
+            version: 1,
+            sessionId,
+            projectId,
+            harnessAgentId,
+            harnessSessionId,
+            createdAt: new Date().toISOString(),
+            // Our own floor field: the session's working directory. Stored
+            // so an imported/rehomed session stays self-contained and a
+            // resume has cwd before it can call getSessionInfo.
+            cwd: project.path,
+          };
+          const ref: SessionRef = { projectId, harnessAgentId, sessionId };
+          // A failed metadata write must not leak the native session.
+          yield* repo.write(metadata).pipe(Effect.tapError(() => port.close(harnessSessionId)));
+          yield* startRuntime(ref, harnessSessionId);
+          yield* bus.publish({ ref, type: "session.created" });
+          return ref;
+        }),
 
       resume: (ref) =>
         readChecked(ref).pipe(

--- a/packages/server/test/daemon/launcher.test.ts
+++ b/packages/server/test/daemon/launcher.test.ts
@@ -1,11 +1,10 @@
+import assert from "node:assert/strict";
 import childProcess from "node:child_process";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import url from "node:url";
 
-import { Effect } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { layer } from "@effect/vitest";
+import { Effect, FileSystem } from "effect";
 
 import { DaemonStoppedError } from "../../src/daemon/errors";
 import {
@@ -16,7 +15,6 @@ import {
 } from "../../src/daemon/launcher";
 import { pidAlive } from "../../src/daemon/liveness";
 import { readRecord, writeRecord } from "../../src/daemon/record";
-import { runNode } from "../platform";
 
 const FAKE_SERVER = url.fileURLToPath(new URL("./fixtures/fake-server.mjs", import.meta.url));
 
@@ -26,120 +24,154 @@ const FAKE_SERVER = url.fileURLToPath(new URL("./fixtures/fake-server.mjs", impo
 const serverArgv = [process.execPath, FAKE_SERVER];
 
 const resolve = (options: Omit<ResolveDaemonOptions, "serverArgv">) =>
-  runNode(resolveOrSpawnDaemon({ serverArgv, ...options }));
+  resolveOrSpawnDaemon({ serverArgv, ...options });
 
-describe("resolveOrSpawnDaemon", () => {
-  let home: string;
+// `excludeTestServices` because the launcher polls a real daemon's health on a
+// real clock: under the default TestClock its retry schedule never advances.
+// The timeout covers a spawn + readiness handshake, not a unit assertion.
+layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
+  "resolveOrSpawnDaemon",
+  (it) => {
+    /**
+     * A temp `$VIBEST_HOME` bound to the test's scope. Finalizers run LIFO, so
+     * the daemon is stopped before the directory holding its record goes away —
+     * and both happen however the test ends, which is what the old
+     * `afterEach` could only do on the happy path.
+     */
+    const tempHome = Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-daemon-" });
+      yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(home)));
+      return home;
+    });
 
-  beforeEach(() => {
-    home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-daemon-"));
-  });
-  afterEach(async () => {
-    await runNode(stopDaemon(home));
-    fs.rmSync(home, { recursive: true, force: true });
-  });
+    it.effect("spawns a daemon, records it, then attaches on the next call", () =>
+      Effect.gen(function* () {
+        const home = yield* tempHome;
+        const spawned = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        assert.equal(spawned.reused, false);
+        assert.match(spawned.address, /^http:\/\/127\.0\.0\.1:\d+$/);
+        assert.ok(pidAlive(spawned.pid));
 
-  it("spawns a daemon, records it, then attaches on the next call", async () => {
-    const spawned = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    expect(spawned.reused).toBe(false);
-    expect(spawned.address).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
-    expect(pidAlive(spawned.pid)).toBe(true);
+        const record = yield* readRecord(home);
+        assert.equal(record?.pid, spawned.pid);
+        assert.equal(record?.address, spawned.address);
+        assert.equal(record?.token, spawned.token);
 
-    const record = await runNode(readRecord(home));
-    expect(record?.pid).toBe(spawned.pid);
-    expect(record?.address).toBe(spawned.address);
-    expect(record?.token).toBe(spawned.token);
-
-    const attached = await resolve({ home, port: 0 });
-    expect(attached.reused).toBe(true);
-    expect(attached.pid).toBe(spawned.pid);
-    expect(attached.address).toBe(spawned.address);
-  });
-
-  it("reports status and stops the daemon", async () => {
-    const spawned = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-
-    const running = await runNode(statusDaemon(home));
-    expect(running.running).toBe(true);
-    expect(running.record?.pid).toBe(spawned.pid);
-
-    expect(await runNode(stopDaemon(home))).toBe("stopped");
-    expect(pidAlive(spawned.pid)).toBe(false);
-    expect(await runNode(readRecord(home))).toBeUndefined();
-    expect((await runNode(statusDaemon(home))).running).toBe(false);
-  });
-
-  it("respawns when the recorded daemon is dead", async () => {
-    const first = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    await runNode(stopDaemon(home));
-    expect(pidAlive(first.pid)).toBe(false);
-
-    const second = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    expect(second.reused).toBe(false);
-    expect(second.pid).not.toBe(first.pid);
-    expect(pidAlive(second.pid)).toBe(true);
-  });
-
-  it("reports not-running when stopping with no daemon", async () => {
-    expect(await runNode(stopDaemon(home))).toBe("not-running");
-  });
-
-  it("respawns after a crash that left the record behind", async () => {
-    const first = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-
-    // Simulate a crash: kill the process without stopDaemon, so the stale
-    // record (pid dead) stays and must be replaced, not attached to.
-    process.kill(first.pid, "SIGKILL");
-    while (pidAlive(first.pid)) await new Promise((done) => setTimeout(done, 20));
-
-    const second = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    expect(second.reused).toBe(false);
-    expect(second.pid).not.toBe(first.pid);
-    expect(pidAlive(second.pid)).toBe(true);
-  });
-
-  it("kills a wedged daemon (pid alive, health failing) before respawning", async () => {
-    // A live process that is not a server: pid answers signals, health fails.
-    const wedged = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
-    const wedgedPid = wedged.pid!;
-    await runNode(
-      writeRecord(home, {
-        pid: wedgedPid,
-        address: "http://127.0.0.1:1",
-        token: "stale",
-        startedAt: 0,
+        const attached = yield* resolve({ home, port: 0 });
+        assert.equal(attached.reused, true);
+        assert.equal(attached.pid, spawned.pid);
+        assert.equal(attached.address, spawned.address);
       }),
     );
 
-    const handle = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    expect(handle.reused).toBe(false);
-    expect(pidAlive(wedgedPid)).toBe(false);
-    expect(handle.pid).not.toBe(wedgedPid);
-  });
+    it.effect("reports status and stops the daemon", () =>
+      Effect.gen(function* () {
+        const home = yield* tempHome;
+        const spawned = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
 
-  it("refuses to auto-respawn a daemon the user explicitly stopped", async () => {
-    await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    await runNode(stopDaemon(home));
+        const running = yield* statusDaemon(home);
+        assert.equal(running.running, true);
+        assert.equal(running.record?.pid, spawned.pid);
 
-    const error = await runNode(
-      Effect.flip(resolveOrSpawnDaemon({ home, serverArgv, port: 0, autoRespawn: true })),
+        assert.equal(yield* stopDaemon(home), "stopped");
+        assert.equal(pidAlive(spawned.pid), false);
+        assert.equal(yield* readRecord(home), undefined);
+        assert.equal((yield* statusDaemon(home)).running, false);
+      }),
     );
-    expect(error).toBeInstanceOf(DaemonStoppedError);
 
-    // An explicit start clears the tombstone; auto-respawn works again after.
-    const restarted = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    expect(restarted.reused).toBe(false);
-    const attached = await resolve({ home, port: 0, autoRespawn: true });
-    expect(attached.pid).toBe(restarted.pid);
-  });
+    it.effect("respawns when the recorded daemon is dead", () =>
+      Effect.gen(function* () {
+        const home = yield* tempHome;
+        const first = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        yield* stopDaemon(home);
+        assert.equal(pidAlive(first.pid), false);
 
-  it("serializes concurrent launchers onto a single daemon", async () => {
-    const [a, b] = await Promise.all([
-      resolve({ home, port: 0, readyTimeoutMs: 15_000 }),
-      resolve({ home, port: 0, readyTimeoutMs: 15_000 }),
-    ]);
-    expect(a.pid).toBe(b.pid);
-    expect(a.address).toBe(b.address);
-    expect([a.reused, b.reused].filter((reused) => !reused)).toHaveLength(1);
-  });
-});
+        const second = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        assert.equal(second.reused, false);
+        assert.notEqual(second.pid, first.pid);
+        assert.ok(pidAlive(second.pid));
+      }),
+    );
+
+    it.effect("reports not-running when stopping with no daemon", () =>
+      Effect.gen(function* () {
+        const home = yield* tempHome;
+        assert.equal(yield* stopDaemon(home), "not-running");
+      }),
+    );
+
+    it.effect("respawns after a crash that left the record behind", () =>
+      Effect.gen(function* () {
+        const home = yield* tempHome;
+        const first = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+
+        // Simulate a crash: kill the process without stopDaemon, so the stale
+        // record (pid dead) stays and must be replaced, not attached to.
+        process.kill(first.pid, "SIGKILL");
+        yield* Effect.sleep("20 millis").pipe(Effect.repeat({ while: () => pidAlive(first.pid) }));
+
+        const second = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        assert.equal(second.reused, false);
+        assert.notEqual(second.pid, first.pid);
+        assert.ok(pidAlive(second.pid));
+      }),
+    );
+
+    it.effect("kills a wedged daemon (pid alive, health failing) before respawning", () =>
+      Effect.gen(function* () {
+        const home = yield* tempHome;
+        // A live process that is not a server: pid answers signals, health fails.
+        // Deliberately not `ChildProcessSpawner` — the launcher killing it is the
+        // assertion, so it must not be tied to the test's scope.
+        const wedged = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
+        const wedgedPid = wedged.pid!;
+        yield* writeRecord(home, {
+          pid: wedgedPid,
+          address: "http://127.0.0.1:1",
+          token: "stale",
+          startedAt: 0,
+        });
+
+        const handle = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        assert.equal(handle.reused, false);
+        assert.equal(pidAlive(wedgedPid), false);
+        assert.notEqual(handle.pid, wedgedPid);
+      }),
+    );
+
+    it.effect("refuses to auto-respawn a daemon the user explicitly stopped", () =>
+      Effect.gen(function* () {
+        const home = yield* tempHome;
+        yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        yield* stopDaemon(home);
+
+        const error = yield* Effect.flip(resolve({ home, port: 0, autoRespawn: true }));
+        assert.ok(error instanceof DaemonStoppedError);
+
+        // An explicit start clears the tombstone; auto-respawn works again after.
+        const restarted = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        assert.equal(restarted.reused, false);
+        const attached = yield* resolve({ home, port: 0, autoRespawn: true });
+        assert.equal(attached.pid, restarted.pid);
+      }),
+    );
+
+    it.effect("serializes concurrent launchers onto a single daemon", () =>
+      Effect.gen(function* () {
+        const home = yield* tempHome;
+        const [a, b] = yield* Effect.all(
+          [
+            resolve({ home, port: 0, readyTimeoutMs: 15_000 }),
+            resolve({ home, port: 0, readyTimeoutMs: 15_000 }),
+          ],
+          { concurrency: 2 },
+        );
+        assert.equal(a.pid, b.pid);
+        assert.equal(a.address, b.address);
+        assert.equal([a.reused, b.reused].filter((reused) => !reused).length, 1);
+      }),
+    );
+  },
+);

--- a/packages/server/test/daemon/launcher.test.ts
+++ b/packages/server/test/daemon/launcher.test.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import url from "node:url";
 
-import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -17,6 +16,7 @@ import {
 } from "../../src/daemon/launcher";
 import { pidAlive } from "../../src/daemon/liveness";
 import { readRecord, writeRecord } from "../../src/daemon/record";
+import { runNode } from "../platform";
 
 const FAKE_SERVER = url.fileURLToPath(new URL("./fixtures/fake-server.mjs", import.meta.url));
 
@@ -25,13 +25,8 @@ const FAKE_SERVER = url.fileURLToPath(new URL("./fixtures/fake-server.mjs", impo
 // booting the real runtime.
 const serverArgv = [process.execPath, FAKE_SERVER];
 
-// The launcher's file state runs on the platform services; the real ones here,
-// exactly as the CLI and the desktop provide them.
-const run = <A, E>(effect: Effect.Effect<A, E, NodeServices.NodeServices>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)));
-
 const resolve = (options: Omit<ResolveDaemonOptions, "serverArgv">) =>
-  run(resolveOrSpawnDaemon({ serverArgv, ...options }));
+  runNode(resolveOrSpawnDaemon({ serverArgv, ...options }));
 
 describe("resolveOrSpawnDaemon", () => {
   let home: string;
@@ -40,7 +35,7 @@ describe("resolveOrSpawnDaemon", () => {
     home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-daemon-"));
   });
   afterEach(async () => {
-    await run(stopDaemon(home));
+    await runNode(stopDaemon(home));
     fs.rmSync(home, { recursive: true, force: true });
   });
 
@@ -50,7 +45,7 @@ describe("resolveOrSpawnDaemon", () => {
     expect(spawned.address).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
     expect(pidAlive(spawned.pid)).toBe(true);
 
-    const record = await run(readRecord(home));
+    const record = await runNode(readRecord(home));
     expect(record?.pid).toBe(spawned.pid);
     expect(record?.address).toBe(spawned.address);
     expect(record?.token).toBe(spawned.token);
@@ -64,19 +59,19 @@ describe("resolveOrSpawnDaemon", () => {
   it("reports status and stops the daemon", async () => {
     const spawned = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
 
-    const running = await run(statusDaemon(home));
+    const running = await runNode(statusDaemon(home));
     expect(running.running).toBe(true);
     expect(running.record?.pid).toBe(spawned.pid);
 
-    expect(await run(stopDaemon(home))).toBe("stopped");
+    expect(await runNode(stopDaemon(home))).toBe("stopped");
     expect(pidAlive(spawned.pid)).toBe(false);
-    expect(await run(readRecord(home))).toBeUndefined();
-    expect((await run(statusDaemon(home))).running).toBe(false);
+    expect(await runNode(readRecord(home))).toBeUndefined();
+    expect((await runNode(statusDaemon(home))).running).toBe(false);
   });
 
   it("respawns when the recorded daemon is dead", async () => {
     const first = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    await run(stopDaemon(home));
+    await runNode(stopDaemon(home));
     expect(pidAlive(first.pid)).toBe(false);
 
     const second = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
@@ -86,7 +81,7 @@ describe("resolveOrSpawnDaemon", () => {
   });
 
   it("reports not-running when stopping with no daemon", async () => {
-    expect(await run(stopDaemon(home))).toBe("not-running");
+    expect(await runNode(stopDaemon(home))).toBe("not-running");
   });
 
   it("respawns after a crash that left the record behind", async () => {
@@ -107,7 +102,7 @@ describe("resolveOrSpawnDaemon", () => {
     // A live process that is not a server: pid answers signals, health fails.
     const wedged = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
     const wedgedPid = wedged.pid!;
-    await run(
+    await runNode(
       writeRecord(home, {
         pid: wedgedPid,
         address: "http://127.0.0.1:1",
@@ -124,9 +119,9 @@ describe("resolveOrSpawnDaemon", () => {
 
   it("refuses to auto-respawn a daemon the user explicitly stopped", async () => {
     await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    await run(stopDaemon(home));
+    await runNode(stopDaemon(home));
 
-    const error = await run(
+    const error = await runNode(
       Effect.flip(resolveOrSpawnDaemon({ home, serverArgv, port: 0, autoRespawn: true })),
     );
     expect(error).toBeInstanceOf(DaemonStoppedError);

--- a/packages/server/test/daemon/launcher.test.ts
+++ b/packages/server/test/daemon/launcher.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import url from "node:url";
 
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -24,8 +25,13 @@ const FAKE_SERVER = url.fileURLToPath(new URL("./fixtures/fake-server.mjs", impo
 // booting the real runtime.
 const serverArgv = [process.execPath, FAKE_SERVER];
 
+// The launcher's file state runs on the platform services; the real ones here,
+// exactly as the CLI and the desktop provide them.
+const run = <A, E>(effect: Effect.Effect<A, E, NodeServices.NodeServices>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)));
+
 const resolve = (options: Omit<ResolveDaemonOptions, "serverArgv">) =>
-  Effect.runPromise(resolveOrSpawnDaemon({ serverArgv, ...options }));
+  run(resolveOrSpawnDaemon({ serverArgv, ...options }));
 
 describe("resolveOrSpawnDaemon", () => {
   let home: string;
@@ -34,7 +40,7 @@ describe("resolveOrSpawnDaemon", () => {
     home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-daemon-"));
   });
   afterEach(async () => {
-    await Effect.runPromise(stopDaemon(home));
+    await run(stopDaemon(home));
     fs.rmSync(home, { recursive: true, force: true });
   });
 
@@ -44,7 +50,7 @@ describe("resolveOrSpawnDaemon", () => {
     expect(spawned.address).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
     expect(pidAlive(spawned.pid)).toBe(true);
 
-    const record = readRecord(home);
+    const record = await run(readRecord(home));
     expect(record?.pid).toBe(spawned.pid);
     expect(record?.address).toBe(spawned.address);
     expect(record?.token).toBe(spawned.token);
@@ -58,19 +64,19 @@ describe("resolveOrSpawnDaemon", () => {
   it("reports status and stops the daemon", async () => {
     const spawned = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
 
-    const running = await Effect.runPromise(statusDaemon(home));
+    const running = await run(statusDaemon(home));
     expect(running.running).toBe(true);
     expect(running.record?.pid).toBe(spawned.pid);
 
-    expect(await Effect.runPromise(stopDaemon(home))).toBe("stopped");
+    expect(await run(stopDaemon(home))).toBe("stopped");
     expect(pidAlive(spawned.pid)).toBe(false);
-    expect(readRecord(home)).toBeUndefined();
-    expect((await Effect.runPromise(statusDaemon(home))).running).toBe(false);
+    expect(await run(readRecord(home))).toBeUndefined();
+    expect((await run(statusDaemon(home))).running).toBe(false);
   });
 
   it("respawns when the recorded daemon is dead", async () => {
     const first = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    await Effect.runPromise(stopDaemon(home));
+    await run(stopDaemon(home));
     expect(pidAlive(first.pid)).toBe(false);
 
     const second = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
@@ -80,7 +86,7 @@ describe("resolveOrSpawnDaemon", () => {
   });
 
   it("reports not-running when stopping with no daemon", async () => {
-    expect(await Effect.runPromise(stopDaemon(home))).toBe("not-running");
+    expect(await run(stopDaemon(home))).toBe("not-running");
   });
 
   it("respawns after a crash that left the record behind", async () => {
@@ -101,12 +107,14 @@ describe("resolveOrSpawnDaemon", () => {
     // A live process that is not a server: pid answers signals, health fails.
     const wedged = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
     const wedgedPid = wedged.pid!;
-    writeRecord(home, {
-      pid: wedgedPid,
-      address: "http://127.0.0.1:1",
-      token: "stale",
-      startedAt: 0,
-    });
+    await run(
+      writeRecord(home, {
+        pid: wedgedPid,
+        address: "http://127.0.0.1:1",
+        token: "stale",
+        startedAt: 0,
+      }),
+    );
 
     const handle = await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
     expect(handle.reused).toBe(false);
@@ -116,9 +124,9 @@ describe("resolveOrSpawnDaemon", () => {
 
   it("refuses to auto-respawn a daemon the user explicitly stopped", async () => {
     await resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-    await Effect.runPromise(stopDaemon(home));
+    await run(stopDaemon(home));
 
-    const error = await Effect.runPromise(
+    const error = await run(
       Effect.flip(resolveOrSpawnDaemon({ home, serverArgv, port: 0, autoRespawn: true })),
     );
     expect(error).toBeInstanceOf(DaemonStoppedError);

--- a/packages/server/test/daemon/record.test.ts
+++ b/packages/server/test/daemon/record.test.ts
@@ -41,7 +41,7 @@ describe("daemon record", () => {
 
   it("writes daemon.pid at the expected path", async () => {
     await run(writeRecord(home, record));
-    expect(await run(recordPath(home))).toBe(path.join(home, "daemon.pid"));
+    expect(recordPath(home)).toBe(path.join(home, "daemon.pid"));
   });
 
   // Windows does not honor unix perms; the token is only a secret on posix.

--- a/packages/server/test/daemon/record.test.ts
+++ b/packages/server/test/daemon/record.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -19,6 +21,9 @@ const record: DaemonRecord = {
   startedAt: 1_700_000_000_000,
 };
 
+const run = <A, E>(effect: Effect.Effect<A, E, NodeServices.NodeServices>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)));
+
 describe("daemon record", () => {
   let home: string;
 
@@ -29,38 +34,39 @@ describe("daemon record", () => {
     fs.rmSync(home, { recursive: true, force: true });
   });
 
-  it("round-trips through daemon.pid", () => {
-    writeRecord(home, record);
-    expect(readRecord(home)).toEqual(record);
+  it("round-trips through daemon.pid", async () => {
+    await run(writeRecord(home, record));
+    expect(await run(readRecord(home))).toEqual(record);
   });
 
-  it("writes daemon.pid at the expected path", () => {
-    writeRecord(home, record);
-    expect(recordPath(home)).toBe(path.join(home, "daemon.pid"));
+  it("writes daemon.pid at the expected path", async () => {
+    await run(writeRecord(home, record));
+    expect(await run(recordPath(home))).toBe(path.join(home, "daemon.pid"));
   });
 
   // Windows does not honor unix perms; the token is only a secret on posix.
-  it.skipIf(process.platform === "win32")("writes daemon.pid with 0600 perms", () => {
-    writeRecord(home, record);
-    expect(fs.statSync(recordPath(home)).mode & 0o777).toBe(0o600);
+  it.skipIf(process.platform === "win32")("writes daemon.pid with 0600 perms", async () => {
+    await run(writeRecord(home, record));
+    expect(fs.statSync(path.join(home, "daemon.pid")).mode & 0o777).toBe(0o600);
   });
 
-  it("returns undefined when the record is missing", () => {
-    expect(readRecord(home)).toBeUndefined();
+  it("returns undefined when the record is missing", async () => {
+    expect(await run(readRecord(home))).toBeUndefined();
   });
 
-  it("returns undefined for a garbage or incomplete record", () => {
-    fs.writeFileSync(recordPath(home), "not json");
-    expect(readRecord(home)).toBeUndefined();
+  it("returns undefined for a garbage or incomplete record", async () => {
+    const file = path.join(home, "daemon.pid");
+    fs.writeFileSync(file, "not json");
+    expect(await run(readRecord(home))).toBeUndefined();
 
-    fs.writeFileSync(recordPath(home), JSON.stringify({ pid: 1 }));
-    expect(readRecord(home)).toBeUndefined();
+    fs.writeFileSync(file, JSON.stringify({ pid: 1 }));
+    expect(await run(readRecord(home))).toBeUndefined();
   });
 
-  it("removeRecord is a no-op when the file is already gone", () => {
-    expect(() => removeRecord(home)).not.toThrow();
-    writeRecord(home, record);
-    removeRecord(home);
-    expect(readRecord(home)).toBeUndefined();
+  it("removeRecord is a no-op when the file is already gone", async () => {
+    await expect(run(removeRecord(home))).resolves.toBeUndefined();
+    await run(writeRecord(home, record));
+    await run(removeRecord(home));
+    expect(await run(readRecord(home))).toBeUndefined();
   });
 });

--- a/packages/server/test/daemon/record.test.ts
+++ b/packages/server/test/daemon/record.test.ts
@@ -1,8 +1,9 @@
-import fs from "node:fs";
-import os from "node:os";
+import assert from "node:assert/strict";
 import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { layer } from "@effect/vitest";
+import { Effect, FileSystem } from "effect";
 
 import {
   type DaemonRecord,
@@ -11,7 +12,6 @@ import {
   removeRecord,
   writeRecord,
 } from "../../src/daemon/record";
-import { runNode } from "../platform";
 
 const record: DaemonRecord = {
   pid: 4321,
@@ -20,49 +20,69 @@ const record: DaemonRecord = {
   startedAt: 1_700_000_000_000,
 };
 
-describe("daemon record", () => {
-  let home: string;
+layer(NodeServices.layer)("daemon record", (it) => {
+  // `it.effect` bodies are scoped, so the temp home is removed when the test
+  // ends however it ends — no afterEach.
+  const tempHome = FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.makeTempDirectoryScoped({ prefix: "vibest-daemon-" })),
+  );
 
-  beforeEach(() => {
-    home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-daemon-"));
-  });
-  afterEach(() => {
-    fs.rmSync(home, { recursive: true, force: true });
-  });
+  it.effect("round-trips through daemon.pid", () =>
+    Effect.gen(function* () {
+      const home = yield* tempHome;
+      yield* writeRecord(home, record);
+      assert.deepEqual(yield* readRecord(home), record);
+    }),
+  );
 
-  it("round-trips through daemon.pid", async () => {
-    await runNode(writeRecord(home, record));
-    expect(await runNode(readRecord(home))).toEqual(record);
-  });
-
-  it("writes daemon.pid at the expected path", async () => {
-    await runNode(writeRecord(home, record));
-    expect(recordPath(home)).toBe(path.join(home, "daemon.pid"));
-  });
+  it.effect("writes daemon.pid at the expected path", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
+      yield* writeRecord(home, record);
+      assert.equal(recordPath(home), path.join(home, "daemon.pid"));
+      assert.ok(yield* fs.exists(recordPath(home)));
+    }),
+  );
 
   // Windows does not honor unix perms; the token is only a secret on posix.
-  it.skipIf(process.platform === "win32")("writes daemon.pid with 0600 perms", async () => {
-    await runNode(writeRecord(home, record));
-    expect(fs.statSync(path.join(home, "daemon.pid")).mode & 0o777).toBe(0o600);
-  });
+  it.effect.skipIf(process.platform === "win32")("writes daemon.pid with 0600 perms", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
+      yield* writeRecord(home, record);
+      const info = yield* fs.stat(recordPath(home));
+      assert.equal((info.mode ?? 0) & 0o777, 0o600);
+    }),
+  );
 
-  it("returns undefined when the record is missing", async () => {
-    expect(await runNode(readRecord(home))).toBeUndefined();
-  });
+  it.effect("returns undefined when the record is missing", () =>
+    Effect.gen(function* () {
+      const home = yield* tempHome;
+      assert.equal(yield* readRecord(home), undefined);
+    }),
+  );
 
-  it("returns undefined for a garbage or incomplete record", async () => {
-    const file = path.join(home, "daemon.pid");
-    fs.writeFileSync(file, "not json");
-    expect(await runNode(readRecord(home))).toBeUndefined();
+  it.effect("returns undefined for a garbage or incomplete record", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
 
-    fs.writeFileSync(file, JSON.stringify({ pid: 1 }));
-    expect(await runNode(readRecord(home))).toBeUndefined();
-  });
+      yield* fs.writeFileString(recordPath(home), "not json");
+      assert.equal(yield* readRecord(home), undefined);
 
-  it("removeRecord is a no-op when the file is already gone", async () => {
-    await expect(runNode(removeRecord(home))).resolves.toBeUndefined();
-    await runNode(writeRecord(home, record));
-    await runNode(removeRecord(home));
-    expect(await runNode(readRecord(home))).toBeUndefined();
-  });
+      yield* fs.writeFileString(recordPath(home), JSON.stringify({ pid: 1 }));
+      assert.equal(yield* readRecord(home), undefined);
+    }),
+  );
+
+  it.effect("removeRecord is a no-op when the file is already gone", () =>
+    Effect.gen(function* () {
+      const home = yield* tempHome;
+      yield* removeRecord(home);
+      yield* writeRecord(home, record);
+      yield* removeRecord(home);
+      assert.equal(yield* readRecord(home), undefined);
+    }),
+  );
 });

--- a/packages/server/test/daemon/record.test.ts
+++ b/packages/server/test/daemon/record.test.ts
@@ -2,8 +2,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import * as NodeServices from "@effect/platform-node/NodeServices";
-import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -13,6 +11,7 @@ import {
   removeRecord,
   writeRecord,
 } from "../../src/daemon/record";
+import { runNode } from "../platform";
 
 const record: DaemonRecord = {
   pid: 4321,
@@ -20,9 +19,6 @@ const record: DaemonRecord = {
   token: "sekret",
   startedAt: 1_700_000_000_000,
 };
-
-const run = <A, E>(effect: Effect.Effect<A, E, NodeServices.NodeServices>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)));
 
 describe("daemon record", () => {
   let home: string;
@@ -35,38 +31,38 @@ describe("daemon record", () => {
   });
 
   it("round-trips through daemon.pid", async () => {
-    await run(writeRecord(home, record));
-    expect(await run(readRecord(home))).toEqual(record);
+    await runNode(writeRecord(home, record));
+    expect(await runNode(readRecord(home))).toEqual(record);
   });
 
   it("writes daemon.pid at the expected path", async () => {
-    await run(writeRecord(home, record));
+    await runNode(writeRecord(home, record));
     expect(recordPath(home)).toBe(path.join(home, "daemon.pid"));
   });
 
   // Windows does not honor unix perms; the token is only a secret on posix.
   it.skipIf(process.platform === "win32")("writes daemon.pid with 0600 perms", async () => {
-    await run(writeRecord(home, record));
+    await runNode(writeRecord(home, record));
     expect(fs.statSync(path.join(home, "daemon.pid")).mode & 0o777).toBe(0o600);
   });
 
   it("returns undefined when the record is missing", async () => {
-    expect(await run(readRecord(home))).toBeUndefined();
+    expect(await runNode(readRecord(home))).toBeUndefined();
   });
 
   it("returns undefined for a garbage or incomplete record", async () => {
     const file = path.join(home, "daemon.pid");
     fs.writeFileSync(file, "not json");
-    expect(await run(readRecord(home))).toBeUndefined();
+    expect(await runNode(readRecord(home))).toBeUndefined();
 
     fs.writeFileSync(file, JSON.stringify({ pid: 1 }));
-    expect(await run(readRecord(home))).toBeUndefined();
+    expect(await runNode(readRecord(home))).toBeUndefined();
   });
 
   it("removeRecord is a no-op when the file is already gone", async () => {
-    await expect(run(removeRecord(home))).resolves.toBeUndefined();
-    await run(writeRecord(home, record));
-    await run(removeRecord(home));
-    expect(await run(readRecord(home))).toBeUndefined();
+    await expect(runNode(removeRecord(home))).resolves.toBeUndefined();
+    await runNode(writeRecord(home, record));
+    await runNode(removeRecord(home));
+    expect(await runNode(readRecord(home))).toBeUndefined();
   });
 });

--- a/packages/server/test/fake-file-system.ts
+++ b/packages/server/test/fake-file-system.ts
@@ -1,0 +1,56 @@
+import { Effect, FileSystem, Layer, Option, PlatformError } from "effect";
+
+/** The `NotFound` a real platform FileSystem reports for a missing path. */
+export const notFound = (method: string, path: string): PlatformError.PlatformError =>
+  PlatformError.systemError({
+    _tag: "NotFound",
+    module: "FileSystem",
+    method,
+    pathOrDescriptor: path,
+  });
+
+/** A `File.Info` carrying only the two fields these tests read. */
+export const fileInfo = (
+  type: FileSystem.File.Info["type"],
+  mode: number,
+): FileSystem.File.Info => ({
+  type,
+  mode,
+  mtime: Option.none(),
+  atime: Option.none(),
+  birthtime: Option.none(),
+  dev: 0,
+  ino: Option.none(),
+  nlink: Option.none(),
+  uid: Option.none(),
+  gid: Option.none(),
+  rdev: Option.none(),
+  size: FileSystem.Size(0),
+  blksize: Option.none(),
+  blocks: Option.none(),
+});
+
+/**
+ * A `FileSystem` whose `stat` knows exactly the listed paths; everything else
+ * fails `NotFound`. `stat` is the whole surface the executable resolvers read,
+ * so this stands in for a machine with a given set of CLIs installed without
+ * touching a real disk.
+ */
+export const fakeStats = (
+  entries: Readonly<Record<string, FileSystem.File.Info>>,
+): Layer.Layer<FileSystem.FileSystem> =>
+  Layer.succeed(
+    FileSystem.FileSystem,
+    FileSystem.makeNoop({
+      stat: (path) => {
+        const info = entries[path];
+        return info ? Effect.succeed(info) : Effect.fail(notFound("stat", path));
+      },
+    }),
+  );
+
+/** {@link fakeStats} for the common case: these paths are executable files. */
+export const fakeExecutables = (
+  ...paths: ReadonlyArray<string>
+): Layer.Layer<FileSystem.FileSystem> =>
+  fakeStats(Object.fromEntries(paths.map((path) => [path, fileInfo("File", 0o755)])));

--- a/packages/server/test/fake-file-system.ts
+++ b/packages/server/test/fake-file-system.ts
@@ -9,6 +9,25 @@ export const notFound = (method: string, path: string): PlatformError.PlatformEr
     pathOrDescriptor: path,
   });
 
+/** A failure that is *not* `NotFound`, so it must not be swallowed as "absent". */
+export const permissionDenied = (method: string, path: string): PlatformError.PlatformError =>
+  PlatformError.systemError({
+    _tag: "PermissionDenied",
+    module: "FileSystem",
+    method,
+    pathOrDescriptor: path,
+  });
+
+/**
+ * A `FileSystem` with only the listed methods implemented. Everything else
+ * fails `NotFound`, which is what `FileSystem.makeNoop` does — so a bare
+ * `fakeFileSystem({})` is a machine where nothing exists.
+ */
+export const fakeFileSystem = (
+  overrides: Partial<FileSystem.FileSystem>,
+): Layer.Layer<FileSystem.FileSystem> =>
+  Layer.succeed(FileSystem.FileSystem, FileSystem.makeNoop(overrides));
+
 /** A `File.Info` carrying only the two fields these tests read. */
 export const fileInfo = (
   type: FileSystem.File.Info["type"],

--- a/packages/server/test/fs.test.ts
+++ b/packages/server/test/fs.test.ts
@@ -1,76 +1,83 @@
-import fs from "node:fs/promises";
-import os from "node:os";
+import assert from "node:assert/strict";
 import path from "node:path";
 
-import { Effect, Layer } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { layer } from "@effect/vitest";
+import { Effect, FileSystem, Layer } from "effect";
 
 import { FileSystemService, FileSystemServiceLayer } from "../src/index";
 import { NodePlatformLayer } from "./platform";
 
-const fsServiceLayer = FileSystemServiceLayer.pipe(Layer.provide(NodePlatformLayer));
-
-describe("FileSystemService", () => {
-  let cwd: string;
-  let outside: string;
-  beforeEach(async () => {
-    cwd = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-fs-"));
-    outside = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-out-"));
-    await fs.writeFile(path.join(cwd, "a.txt"), "hello\nworld");
-    await fs.mkdir(path.join(cwd, "sub"), { recursive: true });
-    await fs.writeFile(path.join(outside, "secret.txt"), "top secret");
-    await fs.symlink(path.join(outside, "secret.txt"), path.join(cwd, "link"));
-    await fs.writeFile(path.join(cwd, "bin"), Buffer.from([104, 0, 105])); // "h\0i"
-  });
-  afterEach(async () => {
-    await fs.rm(cwd, { recursive: true, force: true });
-    await fs.rm(outside, { recursive: true, force: true });
-  });
-
-  const run = <A, E>(program: Effect.Effect<A, E, FileSystemService>) =>
-    Effect.runPromise(Effect.provide(program, fsServiceLayer));
-
-  // Run a program expected to fail and surface the error's `_tag` (or a sentinel
-  // if it unexpectedly succeeds).
-  const errorTag = <A, E extends { readonly _tag: string }>(
-    program: Effect.Effect<A, E, FileSystemService>,
-  ) =>
-    run(
-      program.pipe(
-        Effect.match({
-          onFailure: (e) => e._tag,
-          onSuccess: () => "no-error",
-        }),
-      ),
-    );
-
-  const readFile = (relPath: string) =>
-    Effect.gen(function* () {
-      const service = yield* FileSystemService;
-      return yield* service.readFileString(cwd, relPath);
+layer(FileSystemServiceLayer.pipe(Layer.provideMerge(NodePlatformLayer)))(
+  "FileSystemService",
+  (it) => {
+    /**
+     * A workspace and a directory outside it, both removed with the test. `link`
+     * points across the boundary — the escape every read has to refuse.
+     */
+    const workspace = Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-fs-" });
+      const outside = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-out-" });
+      yield* fs.writeFileString(path.join(cwd, "a.txt"), "hello\nworld");
+      yield* fs.makeDirectory(path.join(cwd, "sub"), { recursive: true });
+      yield* fs.writeFileString(path.join(outside, "secret.txt"), "top secret");
+      yield* fs.symlink(path.join(outside, "secret.txt"), path.join(cwd, "link"));
+      yield* fs.writeFile(path.join(cwd, "bin"), new Uint8Array([104, 0, 105])); // "h\0i"
+      return { cwd, outside };
     });
 
-  it("reads a file relative to cwd", async () => {
-    expect(await run(readFile("a.txt"))).toBe("hello\nworld");
-  });
+    const readFile = (cwd: string, relPath: string) =>
+      FileSystemService.use((service) => service.readFileString(cwd, relPath));
 
-  it("rejects an absolute path", async () => {
-    expect(await errorTag(readFile(path.join(outside, "secret.txt")))).toBe("WorkspacePathEscape");
-  });
+    /** The `_tag` of the refusal, or a sentinel if the read unexpectedly worked. */
+    const readError = (cwd: string, relPath: string) =>
+      readFile(cwd, relPath).pipe(
+        Effect.match({ onFailure: (error) => error._tag, onSuccess: () => "no-error" }),
+      );
 
-  it("rejects a `..` escape", async () => {
-    expect(await errorTag(readFile("../escape.txt"))).toBe("WorkspacePathEscape");
-  });
+    it.effect("reads a file relative to cwd", () =>
+      Effect.gen(function* () {
+        const { cwd } = yield* workspace;
+        assert.equal(yield* readFile(cwd, "a.txt"), "hello\nworld");
+      }),
+    );
 
-  it("rejects a symlink pointing outside cwd", async () => {
-    expect(await errorTag(readFile("link"))).toBe("WorkspacePathEscape");
-  });
+    it.effect("rejects an absolute path", () =>
+      Effect.gen(function* () {
+        const { cwd, outside } = yield* workspace;
+        assert.equal(
+          yield* readError(cwd, path.join(outside, "secret.txt")),
+          "WorkspacePathEscape",
+        );
+      }),
+    );
 
-  it("rejects a directory read as a file", async () => {
-    expect(await errorTag(readFile("sub"))).toBe("WorkspaceNotFile");
-  });
+    it.effect("rejects a `..` escape", () =>
+      Effect.gen(function* () {
+        const { cwd } = yield* workspace;
+        assert.equal(yield* readError(cwd, "../escape.txt"), "WorkspacePathEscape");
+      }),
+    );
 
-  it("rejects a binary file", async () => {
-    expect(await errorTag(readFile("bin"))).toBe("WorkspaceBinaryFile");
-  });
-});
+    it.effect("rejects a symlink pointing outside cwd", () =>
+      Effect.gen(function* () {
+        const { cwd } = yield* workspace;
+        assert.equal(yield* readError(cwd, "link"), "WorkspacePathEscape");
+      }),
+    );
+
+    it.effect("rejects a directory read as a file", () =>
+      Effect.gen(function* () {
+        const { cwd } = yield* workspace;
+        assert.equal(yield* readError(cwd, "sub"), "WorkspaceNotFile");
+      }),
+    );
+
+    it.effect("rejects a binary file", () =>
+      Effect.gen(function* () {
+        const { cwd } = yield* workspace;
+        assert.equal(yield* readError(cwd, "bin"), "WorkspaceBinaryFile");
+      }),
+    );
+  },
+);

--- a/packages/server/test/fs.test.ts
+++ b/packages/server/test/fs.test.ts
@@ -2,10 +2,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { FileSystemService, FileSystemServiceLayer } from "../src/index";
+import { NodePlatformLayer } from "./platform";
+
+const fsServiceLayer = FileSystemServiceLayer.pipe(Layer.provide(NodePlatformLayer));
 
 describe("FileSystemService", () => {
   let cwd: string;
@@ -25,7 +28,7 @@ describe("FileSystemService", () => {
   });
 
   const run = <A, E>(program: Effect.Effect<A, E, FileSystemService>) =>
-    Effect.runPromise(Effect.provide(program, FileSystemServiceLayer));
+    Effect.runPromise(Effect.provide(program, fsServiceLayer));
 
   // Run a program expected to fail and surface the error's `_tag` (or a sentinel
   // if it unexpectedly succeeds).

--- a/packages/server/test/git.test.ts
+++ b/packages/server/test/git.test.ts
@@ -1,52 +1,50 @@
-import fs from "node:fs/promises";
-import os from "node:os";
+import assert from "node:assert/strict";
 import path from "node:path";
 
-import { Effect } from "effect";
+import { layer } from "@effect/vitest";
+import { Effect, FileSystem } from "effect";
 import { simpleGit } from "simple-git";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { GitService, GitServiceLayer } from "../src/index";
+import { NodePlatformLayer } from "./platform";
 
-describe("GitService", () => {
-  let dir: string;
-  beforeEach(async () => {
-    dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-git-"));
-    const git = simpleGit(dir);
-    await git.raw(["init", "-b", "main"]);
-    await git.addConfig("user.email", "test@example.com");
-    await git.addConfig("user.name", "Test");
-    await fs.writeFile(path.join(dir, "a.txt"), "hi");
-    await git.add(".");
-    await git.commit("init");
-  });
-  afterEach(async () => {
-    await fs.rm(dir, { recursive: true, force: true });
-  });
-
-  const run = <A, E>(program: Effect.Effect<A, E, GitService>) =>
-    Effect.runPromise(Effect.provide(program, GitServiceLayer));
-
-  it("reports working-tree status with untracked files", async () => {
-    await fs.writeFile(path.join(dir, "untracked.txt"), "x");
-    const status = await run(
-      Effect.gen(function* () {
-        const git = yield* GitService;
-        return yield* git.status(dir);
-      }),
-    );
-    expect(status.current).toBe("main");
-    expect(status.not_added).toContain("untracked.txt");
+layer(NodePlatformLayer)("GitService", (it) => {
+  /** A repo with one commit on `main`, removed when the test's scope closes. */
+  const repo = Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const dir = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-git-" });
+    yield* fs.writeFileString(path.join(dir, "a.txt"), "hi");
+    yield* Effect.promise(async () => {
+      const git = simpleGit(dir);
+      await git.raw(["init", "-b", "main"]);
+      await git.addConfig("user.email", "test@example.com");
+      await git.addConfig("user.name", "Test");
+      await git.add(".");
+      await git.commit("init");
+    });
+    return dir;
   });
 
-  it("lists branches", async () => {
-    const branch = await run(
-      Effect.gen(function* () {
-        const git = yield* GitService;
-        return yield* git.branch(dir);
-      }),
-    );
-    expect(branch.current).toBe("main");
-    expect(branch.all).toContain("main");
-  });
+  it.effect("reports working-tree status with untracked files", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const dir = yield* repo;
+      yield* fs.writeFileString(path.join(dir, "untracked.txt"), "x");
+
+      const git = yield* GitService;
+      const status = yield* git.status(dir);
+      assert.equal(status.current, "main");
+      assert.ok(status.not_added.includes("untracked.txt"));
+    }).pipe(Effect.provide(GitServiceLayer)),
+  );
+
+  it.effect("lists branches", () =>
+    Effect.gen(function* () {
+      const dir = yield* repo;
+      const git = yield* GitService;
+      const branch = yield* git.branch(dir);
+      assert.equal(branch.current, "main");
+      assert.ok(branch.all.includes("main"));
+    }).pipe(Effect.provide(GitServiceLayer)),
+  );
 });

--- a/packages/server/test/harness/claude-code/agent.test.ts
+++ b/packages/server/test/harness/claude-code/agent.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, vi } from "vitest";
 
 import { makeClaudeCodeAdapter } from "../../../src/harness/claude-code/adapter";
 import { makeClaudeCodeAgent } from "../../../src/harness/claude-code/agent";
+import { NodePlatformLayer } from "../../platform";
 
 const mockQuery = vi.hoisted(() =>
   vi.fn<
@@ -19,6 +20,11 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: mockQuery,
   getSessionInfo: mockGetSessionInfo,
 }));
+
+// The agent locates the `claude` binary through FileSystem/Path; every test
+// here runs against the real Node platform services.
+const claudeAgent = (options?: Parameters<typeof makeClaudeCodeAgent>[0]) =>
+  makeClaudeCodeAgent(options).pipe(Effect.provide(NodePlatformLayer));
 
 type FakeQuery = sdk.Query & {
   readonly supportedCommands: ReturnType<typeof vi.fn>;
@@ -93,7 +99,7 @@ describe("ClaudeCodeAgent", () => {
 
   it.effect("passes the server environment to the Claude Code process", () =>
     Effect.gen(function* () {
-      const agent = yield* makeClaudeCodeAgent({
+      const agent = yield* claudeAgent({
         env: {
           ...process.env,
           HTTPS_PROXY: "http://desktop-proxy.test:8443",
@@ -108,7 +114,7 @@ describe("ClaudeCodeAgent", () => {
 
   it.effect("leaves the permission mode to the SDK default when none is provided", () =>
     Effect.gen(function* () {
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const { sessionId } = yield* agent.session.create();
 
       assert.equal(lastOptions().permissionMode, undefined);
@@ -121,7 +127,7 @@ describe("ClaudeCodeAgent", () => {
 
   it.effect("forwards bypass permission mode and the required safety flag", () =>
     Effect.gen(function* () {
-      const agent = yield* makeClaudeCodeAgent({ permissionMode: "bypassPermissions" });
+      const agent = yield* claudeAgent({ permissionMode: "bypassPermissions" });
       const { sessionId } = yield* agent.session.create();
 
       assert.equal(lastOptions().permissionMode, "bypassPermissions");
@@ -132,7 +138,7 @@ describe("ClaudeCodeAgent", () => {
 
   it.effect("creates a scoped session and exposes SDK capabilities as Effects", () =>
     Effect.gen(function* () {
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const { sessionId } = yield* agent.session.create();
 
       assert.match(
@@ -160,7 +166,7 @@ describe("ClaudeCodeAgent", () => {
         { type: "system", subtype: "init", session_id: "sdk-session" } as sdk.SDKMessage,
         { type: "result", subtype: "success" } as sdk.SDKMessage,
       ];
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const { sessionId } = yield* agent.session.create();
 
       yield* agent.session.setModel(sessionId, "opus");
@@ -188,7 +194,7 @@ describe("ClaudeCodeAgent", () => {
         queryInstance = makeFakeQuery(prompt, false, reportNativeFailure);
         return queryInstance;
       });
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const session = yield* makeClaudeCodeAdapter(agent).open({ cwd: "/tmp" });
       const crashSeen = yield* Deferred.make<void>();
       yield* Stream.runForEach(session.events, (event) =>
@@ -214,7 +220,7 @@ describe("ClaudeCodeAgent", () => {
         { type: "system", subtype: "init", session_id: "sdk-session" } as sdk.SDKMessage,
         { type: "result", subtype: "success" } as sdk.SDKMessage,
       ];
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const session = yield* makeClaudeCodeAdapter(agent).open({
         cwd: "/tmp",
         model: "opus",
@@ -245,7 +251,7 @@ describe("ClaudeCodeAgent", () => {
   it.effect("rejects a concurrent turn while the previous turn is unfinished", () =>
     Effect.gen(function* () {
       messages = [{ type: "system", subtype: "init" } as sdk.SDKMessage];
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const { sessionId } = yield* agent.session.create();
       const first = yield* agent.session.prompt({
         sessionId,
@@ -273,7 +279,7 @@ describe("ClaudeCodeAgent", () => {
         return queryInstance;
       });
       mockGetSessionInfo.mockResolvedValue({ sessionId: "present" });
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const { sessionId } = yield* agent.session.create();
 
       const first = yield* agent.session.prompt({
@@ -299,7 +305,7 @@ describe("ClaudeCodeAgent", () => {
   it.effect("single-flights concurrent resume and fails when no transcript exists", () =>
     Effect.gen(function* () {
       mockGetSessionInfo.mockResolvedValue({ sessionId: "present" });
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const sessionId = "019f6013-0000-7000-8000-000000000002";
 
       yield* Effect.all(
@@ -315,7 +321,7 @@ describe("ClaudeCodeAgent", () => {
       assert.equal(lastOptions().sessionId, undefined);
 
       mockGetSessionInfo.mockResolvedValue(undefined);
-      const missing = yield* makeClaudeCodeAgent();
+      const missing = yield* claudeAgent();
       const error = yield* missing.session
         .getSupportedCommands("019f6013-0000-7000-8000-000000000003")
         .pipe(Effect.flip);
@@ -325,7 +331,7 @@ describe("ClaudeCodeAgent", () => {
 
   it.effect("denies pending SDK permissions when the session scope closes", () =>
     Effect.gen(function* () {
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const { sessionId } = yield* agent.session.create();
       const requestFiber = yield* Stream.runHead(agent.session.requestPermission(sessionId)).pipe(
         Effect.forkChild,
@@ -359,7 +365,7 @@ describe("ClaudeCodeAgent", () => {
 
   it.effect("bridges SDK permission promises through Deferred", () =>
     Effect.gen(function* () {
-      const agent = yield* makeClaudeCodeAgent();
+      const agent = yield* claudeAgent();
       const { sessionId } = yield* agent.session.create();
       const requestFiber = yield* Stream.runHead(agent.session.requestPermission(sessionId)).pipe(
         Effect.forkChild,

--- a/packages/server/test/harness/claude-code/executable.test.ts
+++ b/packages/server/test/harness/claude-code/executable.test.ts
@@ -1,5 +1,8 @@
+import assert from "node:assert/strict";
+
+import { it } from "@effect/vitest";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
+import { describe, expect } from "vitest";
 
 import {
   type AvailabilityDeps,
@@ -118,66 +121,81 @@ describe("checkClaudeAvailability (version floor)", () => {
 
   /** The check reads the platform only through the resolver; a bare fake will do. */
   const check = (overrides: AvailabilityDeps = {}, ...installed: ReadonlyArray<string>) =>
-    Effect.runPromise(
-      checkClaudeAvailability(availDeps(overrides)).pipe(
-        Effect.provide(fakeExecutables(...installed)),
-      ),
+    checkClaudeAvailability(availDeps(overrides)).pipe(
+      Effect.provide(fakeExecutables(...installed)),
     );
 
   /** Unconditional reason extractor so assertions never sit behind an `if`. */
   const reasonOf = (result: AvailabilityResult): string => (result.available ? "" : result.reason);
 
-  it("is available when the CLI matches the floor", async () => {
-    expect(await check()).toEqual({ available: true });
-  });
+  it.effect("is available when the CLI matches the floor", () =>
+    Effect.gen(function* () {
+      assert.deepEqual(yield* check(), { available: true });
+    }),
+  );
 
-  it("is available when the CLI is newer than the floor", async () => {
-    expect(await check({ readVersion: async () => "2.1.218 (Claude Code)" })).toEqual({
-      available: true,
-    });
-  });
+  it.effect("is available when the CLI is newer than the floor", () =>
+    Effect.gen(function* () {
+      const result = yield* check({ readVersion: async () => "2.1.218 (Claude Code)" });
+      assert.deepEqual(result, { available: true });
+    }),
+  );
 
-  it("is unavailable with an actionable reason when the CLI is too old", async () => {
-    const result = await check({ readVersion: async () => "2.1.215 (Claude Code)" });
-    expect(result.available).toBe(false);
-    expect(reasonOf(result)).toMatch(/2\.1\.215 is too old/);
-    expect(reasonOf(result)).toMatch(/2\.1\.216 or newer/);
-    expect(reasonOf(result)).toContain("claude.com/claude-code");
-  });
+  it.effect("is unavailable with an actionable reason when the CLI is too old", () =>
+    Effect.gen(function* () {
+      const result = yield* check({ readVersion: async () => "2.1.215 (Claude Code)" });
+      assert.equal(result.available, false);
+      assert.match(reasonOf(result), /2\.1\.215 is too old/);
+      assert.match(reasonOf(result), /2\.1\.216 or newer/);
+      assert.ok(reasonOf(result).includes("claude.com/claude-code"));
+    }),
+  );
 
-  it("compares numerically, not lexically (2.1.9 < 2.1.216)", async () => {
-    const result = await check({ readVersion: async () => "2.1.9 (Claude Code)" });
-    expect(result.available).toBe(false);
-  });
+  it.effect("compares numerically, not lexically (2.1.9 < 2.1.216)", () =>
+    Effect.gen(function* () {
+      const result = yield* check({ readVersion: async () => "2.1.9 (Claude Code)" });
+      assert.equal(result.available, false);
+    }),
+  );
 
-  it("fails OPEN when the version cannot be read", async () => {
-    const result = await check({
-      readVersion: async () => {
-        throw new Error("spawn failed");
-      },
-    });
-    expect(result).toEqual({ available: true });
-  });
+  it.effect("fails OPEN when the version cannot be read", () =>
+    Effect.gen(function* () {
+      const result = yield* check({
+        readVersion: async () => {
+          throw new Error("spawn failed");
+        },
+      });
+      assert.deepEqual(result, { available: true });
+    }),
+  );
 
-  it("fails OPEN when the version string is unparseable", async () => {
-    expect(await check({ readVersion: async () => "unknown build" })).toEqual({ available: true });
-  });
+  it.effect("fails OPEN when the version string is unparseable", () =>
+    Effect.gen(function* () {
+      assert.deepEqual(yield* check({ readVersion: async () => "unknown build" }), {
+        available: true,
+      });
+    }),
+  );
 
-  it("fails OPEN when the floor itself cannot be read", async () => {
-    const result = await check({
-      requiredVersion: () => Effect.fail(new Error("manifest missing claudeCodeVersion")),
-      readVersion: async () => "1.0.0 (Claude Code)",
-    });
-    expect(result).toEqual({ available: true });
-  });
+  it.effect("fails OPEN when the floor itself cannot be read", () =>
+    Effect.gen(function* () {
+      const result = yield* check({
+        requiredVersion: () => Effect.fail(new Error("manifest missing claudeCodeVersion")),
+        readVersion: async () => "1.0.0 (Claude Code)",
+      });
+      assert.deepEqual(result, { available: true });
+    }),
+  );
 
-  it("is unavailable with the resolve error when no binary is found", async () => {
-    const result = await check({
-      env: { PATH: "/usr/bin" },
-      home: "/home/din",
-      bundled: () => undefined,
-    });
-    expect(result.available).toBe(false);
-    expect(reasonOf(result)).toMatch(/Claude Code was not found/);
-  });
+  it.effect("is unavailable with the resolve error when no binary is found", () =>
+    Effect.gen(function* () {
+      const result = yield* check({
+        env: { PATH: "/usr/bin" },
+        home: "/home/din",
+        bundled: () => undefined,
+      });
+      assert.equal(result.available, false);
+      assert.match(reasonOf(result), /Claude Code was not found/);
+    }),
+  );
 });

--- a/packages/server/test/harness/claude-code/executable.test.ts
+++ b/packages/server/test/harness/claude-code/executable.test.ts
@@ -1,5 +1,4 @@
-import * as NodePath from "@effect/platform-node/NodePath";
-import { Effect, Layer } from "effect";
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -23,9 +22,7 @@ function deps(overrides: ResolveDeps = {}): ResolveDeps {
 }
 
 const resolve = (overrides: ResolveDeps, ...installed: ReadonlyArray<string>) =>
-  resolveClaudeExecutable(deps(overrides)).pipe(
-    Effect.provide(Layer.merge(fakeExecutables(...installed), NodePath.layer)),
-  );
+  resolveClaudeExecutable(deps(overrides)).pipe(Effect.provide(fakeExecutables(...installed)));
 
 describe("resolveClaudeExecutable", () => {
   it("takes the explicit override ahead of everything else", () => {
@@ -123,7 +120,7 @@ describe("checkClaudeAvailability (version floor)", () => {
   const check = (overrides: AvailabilityDeps = {}, ...installed: ReadonlyArray<string>) =>
     Effect.runPromise(
       checkClaudeAvailability(availDeps(overrides)).pipe(
-        Effect.provide(Layer.merge(fakeExecutables(...installed), NodePath.layer)),
+        Effect.provide(fakeExecutables(...installed)),
       ),
     );
 

--- a/packages/server/test/harness/claude-code/executable.test.ts
+++ b/packages/server/test/harness/claude-code/executable.test.ts
@@ -1,3 +1,5 @@
+import * as NodePath from "@effect/platform-node/NodePath";
+import { Effect, Layer } from "effect";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -7,6 +9,7 @@ import {
   type ResolveDeps,
   resolveClaudeExecutable,
 } from "../../../src/harness/claude-code/executable";
+import { fakeExecutables } from "../../fake-file-system";
 
 /** No SDK binary on disk and nothing executable anywhere, unless a test says so. */
 function deps(overrides: ResolveDeps = {}): ResolveDeps {
@@ -14,28 +17,35 @@ function deps(overrides: ResolveDeps = {}): ResolveDeps {
     env: {},
     home: "/home/din",
     bundled: () => undefined,
-    isExecutable: () => false,
     platform: "darwin",
     ...overrides,
   };
 }
 
+const resolve = (overrides: ResolveDeps, ...installed: ReadonlyArray<string>) =>
+  resolveClaudeExecutable(deps(overrides)).pipe(
+    Effect.provide(Layer.merge(fakeExecutables(...installed), NodePath.layer)),
+  );
+
 describe("resolveClaudeExecutable", () => {
   it("takes the explicit override ahead of everything else", () => {
-    const resolved = resolveClaudeExecutable(
-      deps({
-        env: { VIBEST_CLAUDE_EXECUTABLE: "/custom/claude", PATH: "/usr/bin" },
-        bundled: () => "/node_modules/sdk/claude",
-        isExecutable: () => true,
-      }),
+    const resolved = Effect.runSync(
+      resolve(
+        {
+          env: { VIBEST_CLAUDE_EXECUTABLE: "/custom/claude", PATH: "/usr/bin" },
+          bundled: () => "/node_modules/sdk/claude",
+        },
+        "/node_modules/sdk/claude",
+        "/usr/bin/claude",
+      ),
     );
 
     expect(resolved).toBe("/custom/claude");
   });
 
   it("uses the E2E executable override only in E2E mode", () => {
-    const resolved = resolveClaudeExecutable(
-      deps({
+    const resolved = Effect.runSync(
+      resolve({
         env: {
           VIBEST_E2E: "1",
           VIBEST_E2E_CLAUDE_EXECUTABLE: "/test/fake-claude",
@@ -48,67 +58,53 @@ describe("resolveClaudeExecutable", () => {
   });
 
   it("prefers the SDK's version-matched binary over one on PATH", () => {
-    const resolved = resolveClaudeExecutable(
-      deps({
-        env: { PATH: "/usr/bin" },
-        bundled: () => "/node_modules/sdk/claude",
-        isExecutable: () => true,
-      }),
+    const resolved = Effect.runSync(
+      resolve(
+        { env: { PATH: "/usr/bin" }, bundled: () => "/node_modules/sdk/claude" },
+        "/node_modules/sdk/claude",
+        "/usr/bin/claude",
+      ),
     );
 
     expect(resolved).toBe("/node_modules/sdk/claude");
   });
 
   it("falls back to PATH when the SDK ships no usable binary — the packaged case", () => {
-    const resolved = resolveClaudeExecutable(
-      deps({
-        env: { PATH: "/opt/nope:/usr/bin" },
-        isExecutable: (candidate) => candidate === "/usr/bin/claude",
-      }),
+    const resolved = Effect.runSync(
+      resolve({ env: { PATH: "/opt/nope:/usr/bin" } }, "/usr/bin/claude"),
     );
 
     expect(resolved).toBe("/usr/bin/claude");
   });
 
   it("ignores an SDK binary that resolves but is not executable", () => {
-    const resolved = resolveClaudeExecutable(
-      deps({
-        env: { PATH: "/usr/bin" },
-        bundled: () => "/sealed/claude",
-        isExecutable: (candidate) => candidate === "/usr/bin/claude",
-      }),
+    const resolved = Effect.runSync(
+      resolve({ env: { PATH: "/usr/bin" }, bundled: () => "/sealed/claude" }, "/usr/bin/claude"),
     );
 
     expect(resolved).toBe("/usr/bin/claude");
   });
 
   it("searches the native installer's directory, which is absent from a GUI app's PATH", () => {
-    const resolved = resolveClaudeExecutable(
-      deps({
-        env: { PATH: "/usr/bin:/bin" },
-        isExecutable: (candidate) => candidate === "/home/din/.local/bin/claude",
-      }),
+    const resolved = Effect.runSync(
+      resolve({ env: { PATH: "/usr/bin:/bin" } }, "/home/din/.local/bin/claude"),
     );
 
     expect(resolved).toBe("/home/din/.local/bin/claude");
   });
 
   it("looks for claude.exe on Windows", () => {
-    const resolved = resolveClaudeExecutable(
-      deps({
-        platform: "win32",
-        env: { PATH: "C:\\bin" },
-        isExecutable: (candidate) => candidate.endsWith("claude.exe"),
-      }),
+    const resolved = Effect.runSync(
+      resolve({ platform: "win32", env: { PATH: "C:\\bin" } }, "C:\\bin/claude.exe"),
     );
 
     expect(resolved).toContain("claude.exe");
   });
 
-  it("throws something the user can act on when nothing is installed", () => {
-    expect(() => resolveClaudeExecutable(deps({ env: { PATH: "/usr/bin" } }))).toThrow(
-      /Claude Code was not found.*VIBEST_CLAUDE_EXECUTABLE/s,
-    );
+  it("fails with something the user can act on when nothing is installed", () => {
+    const error = Effect.runSync(Effect.flip(resolve({ env: { PATH: "/usr/bin" } })));
+
+    expect(error.message).toMatch(/Claude Code was not found.*VIBEST_CLAUDE_EXECUTABLE/s);
   });
 });
 
@@ -117,30 +113,35 @@ describe("checkClaudeAvailability (version floor)", () => {
   function availDeps(overrides: AvailabilityDeps = {}): AvailabilityDeps {
     return {
       env: { VIBEST_CLAUDE_EXECUTABLE: "/bin/claude" },
-      requiredVersion: () => "2.1.216",
+      requiredVersion: () => Effect.succeed("2.1.216"),
       readVersion: async () => "2.1.216 (Claude Code)",
       ...overrides,
     };
   }
 
+  /** The check reads the platform only through the resolver; a bare fake will do. */
+  const check = (overrides: AvailabilityDeps = {}, ...installed: ReadonlyArray<string>) =>
+    Effect.runPromise(
+      checkClaudeAvailability(availDeps(overrides)).pipe(
+        Effect.provide(Layer.merge(fakeExecutables(...installed), NodePath.layer)),
+      ),
+    );
+
   /** Unconditional reason extractor so assertions never sit behind an `if`. */
   const reasonOf = (result: AvailabilityResult): string => (result.available ? "" : result.reason);
 
   it("is available when the CLI matches the floor", async () => {
-    expect(await checkClaudeAvailability(availDeps())).toEqual({ available: true });
+    expect(await check()).toEqual({ available: true });
   });
 
   it("is available when the CLI is newer than the floor", async () => {
-    const result = await checkClaudeAvailability(
-      availDeps({ readVersion: async () => "2.1.218 (Claude Code)" }),
-    );
-    expect(result).toEqual({ available: true });
+    expect(await check({ readVersion: async () => "2.1.218 (Claude Code)" })).toEqual({
+      available: true,
+    });
   });
 
   it("is unavailable with an actionable reason when the CLI is too old", async () => {
-    const result = await checkClaudeAvailability(
-      availDeps({ readVersion: async () => "2.1.215 (Claude Code)" }),
-    );
+    const result = await check({ readVersion: async () => "2.1.215 (Claude Code)" });
     expect(result.available).toBe(false);
     expect(reasonOf(result)).toMatch(/2\.1\.215 is too old/);
     expect(reasonOf(result)).toMatch(/2\.1\.216 or newer/);
@@ -148,38 +149,36 @@ describe("checkClaudeAvailability (version floor)", () => {
   });
 
   it("compares numerically, not lexically (2.1.9 < 2.1.216)", async () => {
-    const result = await checkClaudeAvailability(
-      availDeps({ readVersion: async () => "2.1.9 (Claude Code)" }),
-    );
+    const result = await check({ readVersion: async () => "2.1.9 (Claude Code)" });
     expect(result.available).toBe(false);
   });
 
   it("fails OPEN when the version cannot be read", async () => {
-    const result = await checkClaudeAvailability(
-      availDeps({
-        readVersion: async () => {
-          throw new Error("spawn failed");
-        },
-      }),
-    );
+    const result = await check({
+      readVersion: async () => {
+        throw new Error("spawn failed");
+      },
+    });
     expect(result).toEqual({ available: true });
   });
 
   it("fails OPEN when the version string is unparseable", async () => {
-    const result = await checkClaudeAvailability(
-      availDeps({ readVersion: async () => "unknown build" }),
-    );
+    expect(await check({ readVersion: async () => "unknown build" })).toEqual({ available: true });
+  });
+
+  it("fails OPEN when the floor itself cannot be read", async () => {
+    const result = await check({
+      requiredVersion: () => Effect.fail(new Error("manifest missing claudeCodeVersion")),
+      readVersion: async () => "1.0.0 (Claude Code)",
+    });
     expect(result).toEqual({ available: true });
   });
 
   it("is unavailable with the resolve error when no binary is found", async () => {
-    const result = await checkClaudeAvailability({
+    const result = await check({
       env: { PATH: "/usr/bin" },
       home: "/home/din",
       bundled: () => undefined,
-      isExecutable: () => false,
-      requiredVersion: () => "2.1.216",
-      readVersion: async () => "2.1.216 (Claude Code)",
     });
     expect(result.available).toBe(false);
     expect(reasonOf(result)).toMatch(/Claude Code was not found/);

--- a/packages/server/test/harness/claude-code/sdk-executable.test.ts
+++ b/packages/server/test/harness/claude-code/sdk-executable.test.ts
@@ -5,6 +5,7 @@ import { it } from "@effect/vitest";
 import { Effect, Stream } from "effect";
 
 import { makeClaudeCodeAgent } from "../../../src/harness/claude-code/agent";
+import { NodePlatformLayer } from "../../platform";
 
 const fakeClaude = path.resolve(
   import.meta.dirname,
@@ -19,7 +20,7 @@ it.effect("communicates with Claude Agent SDK through a fake Claude executable",
         VIBEST_E2E: "1",
         VIBEST_E2E_CLAUDE_EXECUTABLE: fakeClaude,
       },
-    });
+    }).pipe(Effect.provide(NodePlatformLayer));
     const { sessionId } = yield* agent.session.create();
 
     assert.deepEqual(yield* agent.session.getSupportedModels(sessionId), [

--- a/packages/server/test/harness/executable.test.ts
+++ b/packages/server/test/harness/executable.test.ts
@@ -1,5 +1,4 @@
-import * as NodePath from "@effect/platform-node/NodePath";
-import { Effect, Layer } from "effect";
+import { Effect } from "effect";
 import { expect, it } from "vitest";
 
 import { findExecutable, type FindExecutableDeps } from "../../src/harness/executable";
@@ -14,11 +13,7 @@ const resolve = (
   deps: FindExecutableDeps,
   ...installed: ReadonlyArray<string>
 ): string | undefined =>
-  Effect.runSync(
-    findExecutable(command, deps).pipe(
-      Effect.provide(Layer.merge(fakeExecutables(...installed), NodePath.layer)),
-    ),
-  );
+  Effect.runSync(findExecutable(command, deps).pipe(Effect.provide(fakeExecutables(...installed))));
 
 it("resolves a bare command against PATH, in PATH order", () => {
   const resolved = resolve(
@@ -49,8 +44,8 @@ it("takes an absolute command as an override and only checks it is runnable", ()
   expect(resolve("/opt/missing", deps, "/opt/codex")).toBeUndefined();
 });
 
-// Paths stay posix-shaped because the `Path` service follows the host running
-// the test, not the `platform` we pass in; only the extension probing is under
+// Paths stay posix-shaped because `node:path` follows the host running the
+// test, not the `platform` we pass in; only the extension probing is under
 // test here, and that is the part `platform` actually drives.
 it("finds the .cmd shim npm installs on Windows, not just .exe", () => {
   const resolved = resolve("codex", { env: { PATH: "/bin" }, platform: "win32" }, "/bin/codex.cmd");
@@ -67,9 +62,7 @@ it("reports a missing command as undefined rather than guessing a path", () => {
 it("ignores a directory that shares the command's name", () => {
   const resolved = Effect.runSync(
     findExecutable("codex", { env: { PATH: "/bin" }, platform: "darwin" }).pipe(
-      Effect.provide(
-        Layer.merge(fakeStats({ "/bin/codex": fileInfo("Directory", 0o755) }), NodePath.layer),
-      ),
+      Effect.provide(fakeStats({ "/bin/codex": fileInfo("Directory", 0o755) })),
     ),
   );
 

--- a/packages/server/test/harness/executable.test.ts
+++ b/packages/server/test/harness/executable.test.ts
@@ -1,67 +1,77 @@
+import * as NodePath from "@effect/platform-node/NodePath";
+import { Effect, Layer } from "effect";
 import { expect, it } from "vitest";
 
-import { findExecutable } from "../../src/harness/executable";
+import { findExecutable, type FindExecutableDeps } from "../../src/harness/executable";
+import { fakeExecutables, fakeStats, fileInfo } from "../fake-file-system";
 
 // The whole point of this resolver is to answer the same question the OS will
 // answer when a transport calls `spawn("codex")`. Every test here is about that
 // agreement: anything it finds that spawn wouldn't turns a clear "not found on
 // PATH" into an opaque ENOENT once the user picks the harness.
-const found = (...paths: string[]) => {
-  const set = new Set(paths);
-  return (candidate: string) => set.has(candidate);
-};
+const resolve = (
+  command: string,
+  deps: FindExecutableDeps,
+  ...installed: ReadonlyArray<string>
+): string | undefined =>
+  Effect.runSync(
+    findExecutable(command, deps).pipe(
+      Effect.provide(Layer.merge(fakeExecutables(...installed), NodePath.layer)),
+    ),
+  );
 
 it("resolves a bare command against PATH, in PATH order", () => {
-  const resolved = findExecutable("codex", {
-    env: { PATH: "/first:/second" },
-    isExecutable: found("/first/codex", "/second/codex"),
-    platform: "darwin",
-  });
+  const resolved = resolve(
+    "codex",
+    { env: { PATH: "/first:/second" }, platform: "darwin" },
+    "/first/codex",
+    "/second/codex",
+  );
 
   expect(resolved).toBe("/first/codex");
 });
 
 it("does not look outside PATH, because spawn will not either", () => {
-  const resolved = findExecutable("codex", {
-    env: { PATH: "/usr/bin" },
+  const resolved = resolve(
+    "codex",
+    { env: { PATH: "/usr/bin" }, platform: "darwin" },
     // Installed, but somewhere this process's PATH does not mention.
-    isExecutable: found("/Users/someone/.local/bin/codex"),
-    platform: "darwin",
-  });
+    "/Users/someone/.local/bin/codex",
+  );
 
   expect(resolved).toBeUndefined();
 });
 
 it("takes an absolute command as an override and only checks it is runnable", () => {
-  const deps = {
-    env: { PATH: "" },
-    isExecutable: found("/opt/codex"),
-    platform: "darwin" as const,
-  };
+  const deps = { env: { PATH: "" }, platform: "darwin" as const };
 
-  expect(findExecutable("/opt/codex", deps)).toBe("/opt/codex");
-  expect(findExecutable("/opt/missing", deps)).toBeUndefined();
+  expect(resolve("/opt/codex", deps, "/opt/codex")).toBe("/opt/codex");
+  expect(resolve("/opt/missing", deps, "/opt/codex")).toBeUndefined();
 });
 
-// Paths stay posix-shaped because `node:path` follows the host running the
-// test, not the `platform` we pass in; only the extension probing is under test
-// here, and that is the part `platform` actually drives.
+// Paths stay posix-shaped because the `Path` service follows the host running
+// the test, not the `platform` we pass in; only the extension probing is under
+// test here, and that is the part `platform` actually drives.
 it("finds the .cmd shim npm installs on Windows, not just .exe", () => {
-  const resolved = findExecutable("codex", {
-    env: { PATH: "/bin" },
-    isExecutable: found("/bin/codex.cmd"),
-    platform: "win32",
-  });
+  const resolved = resolve("codex", { env: { PATH: "/bin" }, platform: "win32" }, "/bin/codex.cmd");
 
   expect(resolved).toBe("/bin/codex.cmd");
 });
 
 it("reports a missing command as undefined rather than guessing a path", () => {
-  expect(
-    findExecutable("pi", {
-      env: { PATH: "/usr/bin:/bin" },
-      isExecutable: () => false,
-      platform: "darwin",
-    }),
-  ).toBeUndefined();
+  expect(resolve("pi", { env: { PATH: "/usr/bin:/bin" }, platform: "darwin" })).toBeUndefined();
+});
+
+// A directory carries the same execute bits a binary does, and `spawn` cannot
+// run one — so the mode check alone would report a false hit.
+it("ignores a directory that shares the command's name", () => {
+  const resolved = Effect.runSync(
+    findExecutable("codex", { env: { PATH: "/bin" }, platform: "darwin" }).pipe(
+      Effect.provide(
+        Layer.merge(fakeStats({ "/bin/codex": fileInfo("Directory", 0o755) }), NodePath.layer),
+      ),
+    ),
+  );
+
+  expect(resolved).toBeUndefined();
 });

--- a/packages/server/test/harness/list.test.ts
+++ b/packages/server/test/harness/list.test.ts
@@ -6,6 +6,7 @@ import { Effect } from "effect";
 import type { HarnessAgentAdapter } from "../../src/harness/adapter";
 import { makeHarnessList } from "../../src/harness/list";
 import { makeHarnessAgentRegistry } from "../../src/harness/registry";
+import { NodePlatformLayer } from "../platform";
 
 const adapter = (over: {
   id: HarnessAgentAdapter["id"];
@@ -33,7 +34,9 @@ it.effect("declares each harness's availability and permission subset", () =>
   Effect.gen(function* () {
     const registry = makeHarnessAgentRegistry([adapter({ id: "claude-code" })]);
 
-    const { harnessAgents } = yield* makeHarnessList(registry).list;
+    const { harnessAgents } = yield* makeHarnessList(registry).list.pipe(
+      Effect.provide(NodePlatformLayer),
+    );
 
     assert.deepEqual(harnessAgents[0], {
       id: "claude-code",
@@ -51,7 +54,9 @@ it.effect("keeps declaring settings for a harness whose CLI is missing", () =>
       adapter({ id: "codex", available: false, reason: "Codex was not found on PATH." }),
     ]);
 
-    const { harnessAgents } = yield* makeHarnessList(registry).list;
+    const { harnessAgents } = yield* makeHarnessList(registry).list.pipe(
+      Effect.provide(NodePlatformLayer),
+    );
 
     // The picker greys it out and shows the reason — but what it *would* be
     // able to do has nothing to do with whether it is installed right now.
@@ -69,7 +74,9 @@ it.effect("reports every registered harness, in registration order", () =>
       adapter({ id: "pi" }),
     ]);
 
-    const { harnessAgents } = yield* makeHarnessList(registry).list;
+    const { harnessAgents } = yield* makeHarnessList(registry).list.pipe(
+      Effect.provide(NodePlatformLayer),
+    );
 
     assert.deepEqual(
       harnessAgents.map((harnessAgent) => harnessAgent.id),

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -16,6 +16,7 @@ import type { SessionEnvelopeDraft, SessionEvent } from "../../src/harness/event
 import { streamFromQueueOne } from "../../src/harness/queue-stream";
 import { makeHarnessAgentRegistry } from "../../src/harness/registry";
 import { makeHarnessAgentSessionService } from "../../src/harness/session-service";
+import { NodePlatformLayer } from "../platform";
 
 const makeFixture = Effect.gen(function* () {
   const resumeGate = yield* Deferred.make<void>();
@@ -106,7 +107,9 @@ const makeFixture = Effect.gen(function* () {
     getSessionInfo: () => Effect.succeed<SessionInfoResult>({ _tag: "unsupported" }),
   } satisfies HarnessAgentAdapter;
 
-  const service = yield* makeHarnessAgentSessionService(makeHarnessAgentRegistry([adapter]));
+  const service = yield* makeHarnessAgentSessionService(makeHarnessAgentRegistry([adapter])).pipe(
+    Effect.provide(NodePlatformLayer),
+  );
 
   return {
     service,

--- a/packages/server/test/json-store.test.ts
+++ b/packages/server/test/json-store.test.ts
@@ -1,0 +1,110 @@
+import { Effect, FileSystem, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { StoreReadError, StoreWriteError } from "../src/errors";
+import { readJson, writeJsonAtomic } from "../src/infra/json-store";
+import { fakeFileSystem, permissionDenied } from "./fake-file-system";
+import { NodePlatformLayer } from "./platform";
+
+/**
+ * The repositories' real-fs tests cover the happy path. These pin the error
+ * mapping layer instead: which platform failures become which domain error,
+ * and which one is silently absorbed into a fallback. A real disk can't be
+ * made to deny permission on demand, so the FileSystem is faked here.
+ */
+
+const run = <A, E>(
+  program: Effect.Effect<A, E, FileSystem.FileSystem>,
+  fs: Layer.Layer<FileSystem.FileSystem>,
+) => Effect.runPromise(Effect.provide(program, fs));
+
+describe("readJson", () => {
+  it("falls back when the file does not exist", async () => {
+    const value = await run(readJson("/store/projects.json", ["fallback"]), fakeFileSystem({}));
+    expect(value).toEqual(["fallback"]);
+  });
+
+  it("fails with StoreReadError when the file exists but cannot be read", async () => {
+    const error = await run(
+      Effect.flip(readJson("/store/projects.json", ["fallback"])),
+      fakeFileSystem({
+        readFileString: (path) => Effect.fail(permissionDenied("readFileString", String(path))),
+      }),
+    );
+    expect(error).toBeInstanceOf(StoreReadError);
+    expect(error.file).toBe("/store/projects.json");
+  });
+
+  it("fails with StoreReadError when the file holds malformed JSON", async () => {
+    const error = await run(
+      Effect.flip(readJson("/store/projects.json", ["fallback"])),
+      fakeFileSystem({ readFileString: () => Effect.succeed("{ not json") }),
+    );
+    expect(error).toBeInstanceOf(StoreReadError);
+  });
+});
+
+describe("writeJsonAtomic", () => {
+  const withFailure = (overrides: Partial<FileSystem.FileSystem>) =>
+    Layer.provideMerge(fakeFileSystem(overrides), NodePlatformLayer);
+
+  /** The failure `writeJsonAtomic` ends with on a FileSystem that misbehaves. */
+  const writeWith = (overrides: Partial<FileSystem.FileSystem>) =>
+    Effect.runPromise(
+      Effect.provide(
+        Effect.flip(writeJsonAtomic("/store/projects.json", [{ id: "p1" }])),
+        withFailure(overrides),
+      ),
+    );
+
+  it("fails with StoreWriteError when the parent directory cannot be created", async () => {
+    const error = await writeWith({
+      makeDirectory: (path) => Effect.fail(permissionDenied("makeDirectory", path)),
+    });
+    expect(error).toBeInstanceOf(StoreWriteError);
+    expect(error.file).toBe("/store/projects.json");
+  });
+
+  it("fails with StoreWriteError when the temp file cannot be written", async () => {
+    const error = await writeWith({
+      makeDirectory: () => Effect.void,
+      writeFileString: (path) => Effect.fail(permissionDenied("writeFileString", path)),
+    });
+    expect(error).toBeInstanceOf(StoreWriteError);
+    // The error names the target, never the temp path the failure happened on.
+    expect(error.file).toBe("/store/projects.json");
+  });
+
+  it("fails with StoreWriteError when the rename onto the target fails", async () => {
+    const error = await writeWith({
+      makeDirectory: () => Effect.void,
+      writeFileString: () => Effect.void,
+      rename: (_, to) => Effect.fail(permissionDenied("rename", to)),
+    });
+    expect(error).toBeInstanceOf(StoreWriteError);
+    expect(error.file).toBe("/store/projects.json");
+  });
+
+  it("writes a temp sibling first and renames it onto the target", async () => {
+    const calls: Array<string> = [];
+    const recording = fakeFileSystem({
+      makeDirectory: (path) => Effect.sync(() => void calls.push(`mkdir ${path}`)),
+      writeFileString: (path) => Effect.sync(() => void calls.push(`write ${path}`)),
+      rename: (from, to) => Effect.sync(() => void calls.push(`rename ${from} -> ${to}`)),
+    });
+
+    await Effect.runPromise(
+      Effect.provide(
+        writeJsonAtomic("/store/projects.json", [{ id: "p1" }]),
+        Layer.provideMerge(recording, NodePlatformLayer),
+      ),
+    );
+
+    expect(calls[0]).toBe("mkdir /store");
+    // The temp name carries a fresh uuid, so match the shape rather than the id.
+    expect(calls[1]).toMatch(/^write \/store\/projects\.json\..+\.tmp$/);
+    expect(calls[2]).toMatch(
+      /^rename \/store\/projects\.json\..+\.tmp -> \/store\/projects\.json$/,
+    );
+  });
+});

--- a/packages/server/test/json-store.test.ts
+++ b/packages/server/test/json-store.test.ts
@@ -1,5 +1,8 @@
+import assert from "node:assert/strict";
+
+import { it } from "@effect/vitest";
 import { Effect, FileSystem, Layer } from "effect";
-import { describe, expect, it } from "vitest";
+import { describe } from "vitest";
 
 import { StoreReadError, StoreWriteError } from "../src/errors";
 import { readJson, writeJsonAtomic } from "../src/infra/json-store";
@@ -11,100 +14,104 @@ import { NodePlatformLayer } from "./platform";
  * mapping layer instead: which platform failures become which domain error,
  * and which one is silently absorbed into a fallback. A real disk can't be
  * made to deny permission on demand, so the FileSystem is faked here.
+ *
+ * Every test wants a *different* fake, so there is no block-wide `layer(...)`
+ * to bind: the fake is provided inside the body instead.
  */
 
-const run = <A, E>(
-  program: Effect.Effect<A, E, FileSystem.FileSystem>,
-  fs: Layer.Layer<FileSystem.FileSystem>,
-) => Effect.runPromise(Effect.provide(program, fs));
-
 describe("readJson", () => {
-  it("falls back when the file does not exist", async () => {
-    const value = await run(readJson("/store/projects.json", ["fallback"]), fakeFileSystem({}));
-    expect(value).toEqual(["fallback"]);
-  });
+  it.effect("falls back when the file does not exist", () =>
+    Effect.gen(function* () {
+      const value = yield* readJson("/store/projects.json", ["fallback"]).pipe(
+        Effect.provide(fakeFileSystem({})),
+      );
+      assert.deepEqual(value, ["fallback"]);
+    }),
+  );
 
-  it("fails with StoreReadError when the file exists but cannot be read", async () => {
-    const error = await run(
-      Effect.flip(readJson("/store/projects.json", ["fallback"])),
-      fakeFileSystem({
-        readFileString: (path) => Effect.fail(permissionDenied("readFileString", String(path))),
-      }),
-    );
-    expect(error).toBeInstanceOf(StoreReadError);
-    expect(error.file).toBe("/store/projects.json");
-  });
+  it.effect("fails with StoreReadError when the file exists but cannot be read", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(readJson("/store/projects.json", ["fallback"])).pipe(
+        Effect.provide(
+          fakeFileSystem({
+            readFileString: (path) => Effect.fail(permissionDenied("readFileString", String(path))),
+          }),
+        ),
+      );
+      assert.ok(error instanceof StoreReadError);
+      assert.equal(error.file, "/store/projects.json");
+    }),
+  );
 
-  it("fails with StoreReadError when the file holds malformed JSON", async () => {
-    const error = await run(
-      Effect.flip(readJson("/store/projects.json", ["fallback"])),
-      fakeFileSystem({ readFileString: () => Effect.succeed("{ not json") }),
-    );
-    expect(error).toBeInstanceOf(StoreReadError);
-  });
+  it.effect("fails with StoreReadError when the file holds malformed JSON", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(readJson("/store/projects.json", ["fallback"])).pipe(
+        Effect.provide(fakeFileSystem({ readFileString: () => Effect.succeed("{ not json") })),
+      );
+      assert.ok(error instanceof StoreReadError);
+    }),
+  );
 });
 
 describe("writeJsonAtomic", () => {
-  const withFailure = (overrides: Partial<FileSystem.FileSystem>) =>
-    Layer.provideMerge(fakeFileSystem(overrides), NodePlatformLayer);
+  const write = (overrides: Partial<FileSystem.FileSystem>) =>
+    writeJsonAtomic("/store/projects.json", [{ id: "p1" }]).pipe(
+      Effect.provide(Layer.provideMerge(fakeFileSystem(overrides), NodePlatformLayer)),
+    );
 
   /** The failure `writeJsonAtomic` ends with on a FileSystem that misbehaves. */
-  const writeWith = (overrides: Partial<FileSystem.FileSystem>) =>
-    Effect.runPromise(
-      Effect.provide(
-        Effect.flip(writeJsonAtomic("/store/projects.json", [{ id: "p1" }])),
-        withFailure(overrides),
-      ),
-    );
+  const writeWith = (overrides: Partial<FileSystem.FileSystem>) => Effect.flip(write(overrides));
 
-  it("fails with StoreWriteError when the parent directory cannot be created", async () => {
-    const error = await writeWith({
-      makeDirectory: (path) => Effect.fail(permissionDenied("makeDirectory", path)),
-    });
-    expect(error).toBeInstanceOf(StoreWriteError);
-    expect(error.file).toBe("/store/projects.json");
-  });
+  it.effect("fails with StoreWriteError when the parent directory cannot be created", () =>
+    Effect.gen(function* () {
+      const error = yield* writeWith({
+        makeDirectory: (path) => Effect.fail(permissionDenied("makeDirectory", path)),
+      });
+      assert.ok(error instanceof StoreWriteError);
+      assert.equal(error.file, "/store/projects.json");
+    }),
+  );
 
-  it("fails with StoreWriteError when the temp file cannot be written", async () => {
-    const error = await writeWith({
-      makeDirectory: () => Effect.void,
-      writeFileString: (path) => Effect.fail(permissionDenied("writeFileString", path)),
-    });
-    expect(error).toBeInstanceOf(StoreWriteError);
-    // The error names the target, never the temp path the failure happened on.
-    expect(error.file).toBe("/store/projects.json");
-  });
+  it.effect("fails with StoreWriteError when the temp file cannot be written", () =>
+    Effect.gen(function* () {
+      const error = yield* writeWith({
+        makeDirectory: () => Effect.void,
+        writeFileString: (path) => Effect.fail(permissionDenied("writeFileString", path)),
+      });
+      assert.ok(error instanceof StoreWriteError);
+      // The error names the target, never the temp path the failure happened on.
+      assert.equal(error.file, "/store/projects.json");
+    }),
+  );
 
-  it("fails with StoreWriteError when the rename onto the target fails", async () => {
-    const error = await writeWith({
-      makeDirectory: () => Effect.void,
-      writeFileString: () => Effect.void,
-      rename: (_, to) => Effect.fail(permissionDenied("rename", to)),
-    });
-    expect(error).toBeInstanceOf(StoreWriteError);
-    expect(error.file).toBe("/store/projects.json");
-  });
+  it.effect("fails with StoreWriteError when the rename onto the target fails", () =>
+    Effect.gen(function* () {
+      const error = yield* writeWith({
+        makeDirectory: () => Effect.void,
+        writeFileString: () => Effect.void,
+        rename: (_, to) => Effect.fail(permissionDenied("rename", to)),
+      });
+      assert.ok(error instanceof StoreWriteError);
+      assert.equal(error.file, "/store/projects.json");
+    }),
+  );
 
-  it("writes a temp sibling first and renames it onto the target", async () => {
-    const calls: Array<string> = [];
-    const recording = fakeFileSystem({
-      makeDirectory: (path) => Effect.sync(() => void calls.push(`mkdir ${path}`)),
-      writeFileString: (path) => Effect.sync(() => void calls.push(`write ${path}`)),
-      rename: (from, to) => Effect.sync(() => void calls.push(`rename ${from} -> ${to}`)),
-    });
+  it.effect("writes a temp sibling first and renames it onto the target", () =>
+    Effect.gen(function* () {
+      const calls: Array<string> = [];
+      yield* write({
+        makeDirectory: (path) => Effect.sync(() => void calls.push(`mkdir ${path}`)),
+        writeFileString: (path) => Effect.sync(() => void calls.push(`write ${path}`)),
+        rename: (from, to) => Effect.sync(() => void calls.push(`rename ${from} -> ${to}`)),
+      });
 
-    await Effect.runPromise(
-      Effect.provide(
-        writeJsonAtomic("/store/projects.json", [{ id: "p1" }]),
-        Layer.provideMerge(recording, NodePlatformLayer),
-      ),
-    );
-
-    expect(calls[0]).toBe("mkdir /store");
-    // The temp name carries a fresh uuid, so match the shape rather than the id.
-    expect(calls[1]).toMatch(/^write \/store\/projects\.json\..+\.tmp$/);
-    expect(calls[2]).toMatch(
-      /^rename \/store\/projects\.json\..+\.tmp -> \/store\/projects\.json$/,
-    );
-  });
+      assert.equal(calls[0], "mkdir /store");
+      // The temp name carries a fresh uuid, so match the shape rather than the id.
+      assert.match(calls[1] ?? "", /^write \/store\/projects\.json\..+\.tmp$/);
+      assert.match(
+        calls[2] ?? "",
+        /^rename \/store\/projects\.json\..+\.tmp -> \/store\/projects\.json$/,
+      );
+    }),
+  );
 });

--- a/packages/server/test/mcp.test.ts
+++ b/packages/server/test/mcp.test.ts
@@ -24,7 +24,7 @@ const stdioServer: McpServerConfig = {
 };
 
 const makeLayer = (home: string) => {
-  const paths = Layer.merge(layerPaths(home), NodePlatformLayer);
+  const paths = Layer.provideMerge(layerPaths(home), NodePlatformLayer);
   const mcpRepo = McpRepositoryLayer.pipe(Layer.provide(paths));
   const provRepo = ProviderRepositoryLayer.pipe(Layer.provide(paths));
   return Layer.mergeAll(provRepo, McpServiceLayer.pipe(Layer.provide(mcpRepo)));

--- a/packages/server/test/mcp.test.ts
+++ b/packages/server/test/mcp.test.ts
@@ -14,6 +14,7 @@ import {
   ProviderRepository,
   ProviderRepositoryLayer,
 } from "../src/index";
+import { NodePlatformLayer } from "./platform";
 
 const stdioServer: McpServerConfig = {
   id: "fs",
@@ -23,7 +24,7 @@ const stdioServer: McpServerConfig = {
 };
 
 const makeLayer = (home: string) => {
-  const paths = layerPaths(home);
+  const paths = Layer.merge(layerPaths(home), NodePlatformLayer);
   const mcpRepo = McpRepositoryLayer.pipe(Layer.provide(paths));
   const provRepo = ProviderRepositoryLayer.pipe(Layer.provide(paths));
   return Layer.mergeAll(provRepo, McpServiceLayer.pipe(Layer.provide(mcpRepo)));

--- a/packages/server/test/mcp.test.ts
+++ b/packages/server/test/mcp.test.ts
@@ -1,9 +1,7 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+import assert from "node:assert/strict";
 
-import { Effect, Layer } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { layer } from "@effect/vitest";
+import { Context, Effect, FileSystem, Layer } from "effect";
 
 import {
   layerPaths,
@@ -23,80 +21,66 @@ const stdioServer: McpServerConfig = {
   args: ["--root", "/tmp"],
 };
 
-const makeLayer = (home: string) => {
-  const paths = Layer.provideMerge(layerPaths(home), NodePlatformLayer);
-  const mcpRepo = McpRepositoryLayer.pipe(Layer.provide(paths));
-  const provRepo = ProviderRepositoryLayer.pipe(Layer.provide(paths));
-  return Layer.mergeAll(provRepo, McpServiceLayer.pipe(Layer.provide(mcpRepo)));
-};
-
-describe("McpService", () => {
-  let home: string;
-  beforeEach(async () => {
-    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-mcp-"));
-  });
-  afterEach(async () => {
-    await fs.rm(home, { recursive: true, force: true });
-  });
-
-  const run = <A, E>(program: Effect.Effect<A, E, McpService | ProviderRepository>) =>
-    Effect.runPromise(Effect.provide(program, makeLayer(home)));
-
-  it("creates and lists an MCP server", async () => {
-    const list = await run(
-      Effect.gen(function* () {
-        const svc = yield* McpService;
-        yield* svc.create(stdioServer);
-        return yield* svc.list();
-      }),
-    );
-    expect(list).toHaveLength(1);
-    expect(list[0]?.id).toBe("fs");
-  });
-
-  it("enable/disable toggles enabledFor", async () => {
-    const result = await run(
-      Effect.gen(function* () {
-        const svc = yield* McpService;
-        yield* svc.create(stdioServer);
-        yield* svc.enable("fs", "claude-code");
-        yield* svc.enable("fs", "claude-code"); // idempotent
-        const afterEnable = yield* svc.list();
-        yield* svc.disable("fs", "claude-code");
-        const afterDisable = yield* svc.list();
-        return {
-          enabled: afterEnable[0]?.enabledFor ?? [],
-          disabled: afterDisable[0]?.enabledFor ?? [],
-        };
-      }),
-    );
-    expect(result.enabled).toEqual(["claude-code"]);
-    expect(result.disabled).toEqual([]);
-  });
-
-  it("enable fails with McpServerNotFound for unknown id", async () => {
-    const err = await run(
-      Effect.flip(
-        Effect.gen(function* () {
-          const svc = yield* McpService;
-          return yield* svc.enable("ghost", "codex");
-        }),
+layer(NodePlatformLayer)("McpService", (it) => {
+  /** Both services over one fresh `$VIBEST_HOME`, so they share its config.json. */
+  const services = Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const home = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-mcp-" });
+    const paths = Layer.provideMerge(layerPaths(home), NodePlatformLayer);
+    const context = yield* Layer.build(
+      Layer.mergeAll(
+        ProviderRepositoryLayer.pipe(Layer.provide(paths)),
+        McpServiceLayer.pipe(Layer.provide(McpRepositoryLayer.pipe(Layer.provide(paths)))),
       ),
     );
-    expect(err._tag).toBe("McpServerNotFound");
+    return {
+      mcp: Context.get(context, McpService),
+      providers: Context.get(context, ProviderRepository),
+    };
   });
 
-  it("writing mcp does not clobber the provider field in config.json", async () => {
-    const providers = await run(
-      Effect.gen(function* () {
-        const provRepo = yield* ProviderRepository;
-        yield* provRepo.save([{ id: "openai", enabled: true }]);
-        const svc = yield* McpService;
-        yield* svc.create(stdioServer); // rewrites config.json
-        return yield* provRepo.list();
-      }),
-    );
-    expect(providers).toHaveLength(1);
-    expect(providers[0]?.id).toBe("openai");
-  });
+  it.effect("creates and lists an MCP server", () =>
+    Effect.gen(function* () {
+      const { mcp } = yield* services;
+      yield* mcp.create(stdioServer);
+
+      const list = yield* mcp.list();
+      assert.equal(list.length, 1);
+      assert.equal(list[0]?.id, "fs");
+    }),
+  );
+
+  it.effect("enable/disable toggles enabledFor", () =>
+    Effect.gen(function* () {
+      const { mcp } = yield* services;
+      yield* mcp.create(stdioServer);
+
+      yield* mcp.enable("fs", "claude-code");
+      yield* mcp.enable("fs", "claude-code"); // idempotent
+      assert.deepEqual((yield* mcp.list())[0]?.enabledFor ?? [], ["claude-code"]);
+
+      yield* mcp.disable("fs", "claude-code");
+      assert.deepEqual((yield* mcp.list())[0]?.enabledFor ?? [], []);
+    }),
+  );
+
+  it.effect("enable fails with McpServerNotFound for unknown id", () =>
+    Effect.gen(function* () {
+      const { mcp } = yield* services;
+      const error = yield* Effect.flip(mcp.enable("ghost", "codex"));
+      assert.equal(error._tag, "McpServerNotFound");
+    }),
+  );
+
+  it.effect("writing mcp does not clobber the provider field in config.json", () =>
+    Effect.gen(function* () {
+      const { mcp, providers } = yield* services;
+      yield* providers.save([{ id: "openai", enabled: true }]);
+      yield* mcp.create(stdioServer); // rewrites config.json
+
+      const list = yield* providers.list();
+      assert.equal(list.length, 1);
+      assert.equal(list[0]?.id, "openai");
+    }),
+  );
 });

--- a/packages/server/test/platform.ts
+++ b/packages/server/test/platform.ts
@@ -1,0 +1,17 @@
+import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { Layer } from "effect";
+
+import type { JsonStorePlatform } from "../src/infra/json-store";
+
+/**
+ * The real Node platform services, mirroring what `rpc/runtime.ts` provides.
+ * Tests that exercise a repository against a temp `$VIBEST_HOME` provide this
+ * so the JSON store's `FileSystem | Path | Crypto` requirement is satisfied.
+ */
+export const NodePlatformLayer: Layer.Layer<JsonStorePlatform> = Layer.mergeAll(
+  NodeFileSystem.layer,
+  NodePath.layer,
+  NodeCrypto.layer,
+);

--- a/packages/server/test/platform.ts
+++ b/packages/server/test/platform.ts
@@ -1,7 +1,6 @@
 import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
-import * as NodeServices from "@effect/platform-node/NodeServices";
-import { Effect, Layer, type Scope } from "effect";
+import { Layer } from "effect";
 
 import type { JsonStorePlatform } from "../src/infra/json-store";
 
@@ -14,17 +13,3 @@ export const NodePlatformLayer: Layer.Layer<JsonStorePlatform> = Layer.mergeAll(
   NodeFileSystem.layer,
   NodeCrypto.layer,
 );
-
-/**
- * Run one effect on the full Node platform, exactly as the CLI and the desktop
- * provide it. For Promise-shaped tests (`vitest`'s plain `it` plus
- * `beforeEach`/`afterEach`); a test file whose bodies are all effects should
- * reach for `@effect/vitest`'s `layer(...)` and its scoped `it.effect` instead
- * — see `harness/child-process.test.ts`.
- *
- * Lives here rather than in each test file so "provide the real platform" has
- * one spelling.
- */
-export const runNode = <A, E>(
-  effect: Effect.Effect<A, E, NodeServices.NodeServices | Scope.Scope>,
-): Promise<A> => Effect.runPromise(effect.pipe(Effect.scoped, Effect.provide(NodeServices.layer)));

--- a/packages/server/test/platform.ts
+++ b/packages/server/test/platform.ts
@@ -8,7 +8,7 @@ import type { JsonStorePlatform } from "../src/infra/json-store";
 /**
  * The real Node platform services, mirroring what `rpc/runtime.ts` provides.
  * Tests that exercise a repository against a temp `$VIBEST_HOME` provide this
- * so the JSON store's `FileSystem | Path | Crypto` requirement is satisfied.
+ * so the JSON store's `FileSystem | Crypto` requirement is satisfied.
  */
 export const NodePlatformLayer: Layer.Layer<JsonStorePlatform> = Layer.mergeAll(
   NodeFileSystem.layer,

--- a/packages/server/test/platform.ts
+++ b/packages/server/test/platform.ts
@@ -1,6 +1,7 @@
 import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
-import { Layer } from "effect";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect, Layer, type Scope } from "effect";
 
 import type { JsonStorePlatform } from "../src/infra/json-store";
 
@@ -13,3 +14,17 @@ export const NodePlatformLayer: Layer.Layer<JsonStorePlatform> = Layer.mergeAll(
   NodeFileSystem.layer,
   NodeCrypto.layer,
 );
+
+/**
+ * Run one effect on the full Node platform, exactly as the CLI and the desktop
+ * provide it. For Promise-shaped tests (`vitest`'s plain `it` plus
+ * `beforeEach`/`afterEach`); a test file whose bodies are all effects should
+ * reach for `@effect/vitest`'s `layer(...)` and its scoped `it.effect` instead
+ * — see `harness/child-process.test.ts`.
+ *
+ * Lives here rather than in each test file so "provide the real platform" has
+ * one spelling.
+ */
+export const runNode = <A, E>(
+  effect: Effect.Effect<A, E, NodeServices.NodeServices | Scope.Scope>,
+): Promise<A> => Effect.runPromise(effect.pipe(Effect.scoped, Effect.provide(NodeServices.layer)));

--- a/packages/server/test/platform.ts
+++ b/packages/server/test/platform.ts
@@ -1,6 +1,5 @@
 import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
-import * as NodePath from "@effect/platform-node/NodePath";
 import { Layer } from "effect";
 
 import type { JsonStorePlatform } from "../src/infra/json-store";
@@ -12,6 +11,5 @@ import type { JsonStorePlatform } from "../src/infra/json-store";
  */
 export const NodePlatformLayer: Layer.Layer<JsonStorePlatform> = Layer.mergeAll(
   NodeFileSystem.layer,
-  NodePath.layer,
   NodeCrypto.layer,
 );

--- a/packages/server/test/project.test.ts
+++ b/packages/server/test/project.test.ts
@@ -11,9 +11,14 @@ import {
   ProjectService,
   ProjectServiceLayer,
 } from "../src/index";
+import { NodePlatformLayer } from "./platform";
 
 const makeLayer = (home: string) =>
-  ProjectServiceLayer.pipe(Layer.provide(ProjectRepositoryLayer), Layer.provide(layerPaths(home)));
+  ProjectServiceLayer.pipe(
+    Layer.provide(ProjectRepositoryLayer),
+    Layer.provide(layerPaths(home)),
+    Layer.provide(NodePlatformLayer),
+  );
 
 describe("ProjectService", () => {
   let home: string;

--- a/packages/server/test/project.test.ts
+++ b/packages/server/test/project.test.ts
@@ -1,9 +1,8 @@
-import fs from "node:fs/promises";
-import os from "node:os";
+import assert from "node:assert/strict";
 import path from "node:path";
 
-import { Effect, Layer } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { layer } from "@effect/vitest";
+import { Context, Effect, FileSystem, Layer } from "effect";
 
 import {
   layerPaths,
@@ -13,125 +12,113 @@ import {
 } from "../src/index";
 import { NodePlatformLayer } from "./platform";
 
-const makeLayer = (home: string) =>
-  ProjectServiceLayer.pipe(
-    Layer.provide(ProjectRepositoryLayer),
-    Layer.provide(layerPaths(home)),
-    Layer.provide(NodePlatformLayer),
+layer(NodePlatformLayer)("ProjectService", (it) => {
+  const tempHome = FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.makeTempDirectoryScoped({ prefix: "vibest-proj-" })),
   );
 
-describe("ProjectService", () => {
-  let home: string;
-  beforeEach(async () => {
-    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-proj-"));
-  });
-  afterEach(async () => {
-    await fs.rm(home, { recursive: true, force: true });
-  });
-
-  const run = <A, E>(program: Effect.Effect<A, E, ProjectService>) =>
-    Effect.runPromise(Effect.provide(program, makeLayer(home)));
-
-  it("creates and persists a project, then lists it", async () => {
-    const result = await run(
-      Effect.gen(function* () {
-        const svc = yield* ProjectService;
-        const created = yield* svc.create({ name: "app", path: "/tmp/app" });
-        const listed = yield* svc.list();
-        return { created, listed };
-      }),
-    );
-    expect(result.created.name).toBe("app");
-    expect(result.listed).toHaveLength(1);
-    expect(result.listed[0]?.id).toBe(result.created.id);
-  });
-
-  it("dedupes by resolved path (create twice returns same project)", async () => {
-    const result = await run(
-      Effect.gen(function* () {
-        const svc = yield* ProjectService;
-        const a = yield* svc.create({ name: "app", path: "/tmp/app" });
-        const b = yield* svc.create({ name: "again", path: "/tmp/app/" });
-        const listed = yield* svc.list();
-        return { a, b, count: listed.length };
-      }),
-    );
-    expect(result.b.id).toBe(result.a.id);
-    expect(result.count).toBe(1);
-  });
-
-  it("findById fails with ProjectNotFound for an unknown id", async () => {
-    const err = await run(
-      Effect.flip(
-        Effect.gen(function* () {
-          const svc = yield* ProjectService;
-          return yield* svc.findById("nope");
-        }),
+  // Kept separate from `tempHome` so the two tests that seed a projects.json can
+  // write it before the service is built, as a real cold start would.
+  const serviceIn = (home: string) =>
+    Layer.build(
+      ProjectServiceLayer.pipe(
+        Layer.provide(ProjectRepositoryLayer),
+        Layer.provide(layerPaths(home)),
+        Layer.provide(NodePlatformLayer),
       ),
-    );
-    expect(err._tag).toBe("ProjectNotFound");
-  });
+    ).pipe(Effect.map((context) => Context.get(context, ProjectService)));
 
-  it("removes a project", async () => {
-    const remaining = await run(
+  const projects = Effect.flatMap(tempHome, serviceIn);
+
+  it.effect("creates and persists a project, then lists it", () =>
+    Effect.gen(function* () {
+      const svc = yield* projects;
+      const created = yield* svc.create({ name: "app", path: "/tmp/app" });
+
+      const listed = yield* svc.list();
+      assert.equal(created.name, "app");
+      assert.equal(listed.length, 1);
+      assert.equal(listed[0]?.id, created.id);
+    }),
+  );
+
+  it.effect("dedupes by resolved path (create twice returns same project)", () =>
+    Effect.gen(function* () {
+      const svc = yield* projects;
+      const a = yield* svc.create({ name: "app", path: "/tmp/app" });
+      const b = yield* svc.create({ name: "again", path: "/tmp/app/" });
+
+      assert.equal(b.id, a.id);
+      assert.equal((yield* svc.list()).length, 1);
+    }),
+  );
+
+  it.effect("findById fails with ProjectNotFound for an unknown id", () =>
+    Effect.gen(function* () {
+      const svc = yield* projects;
+      const error = yield* Effect.flip(svc.findById("nope"));
+      assert.equal(error._tag, "ProjectNotFound");
+    }),
+  );
+
+  it.effect("removes a project", () =>
+    Effect.gen(function* () {
+      const svc = yield* projects;
+      const project = yield* svc.create({ name: "app", path: "/tmp/app" });
+      yield* svc.remove(project.id);
+      assert.equal((yield* svc.list()).length, 0);
+    }),
+  );
+
+  it.effect("reads a pre-envelope projects.json and adopts it into envelope form", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
+      const file = path.join(home, "storage", "projects.json");
+      const project = {
+        id: "p1",
+        name: "app",
+        path: "/tmp/app",
+        createdAt: "2026-07-16T00:00:00Z",
+      };
+      yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+      yield* fs.writeFileString(file, JSON.stringify([project]));
+
+      const svc = yield* serviceIn(home);
+      assert.deepEqual(yield* svc.list(), [project]);
+
+      const raw = JSON.parse(yield* fs.readFileString(file));
+      assert.equal(raw.version, 1);
+      assert.deepEqual(raw.data, [project]);
+    }),
+  );
+
+  it.effect(
+    "a corrupt projects.json fails per call with StoreReadError and recovers once fixed",
+    () =>
       Effect.gen(function* () {
-        const svc = yield* ProjectService;
-        const p = yield* svc.create({ name: "app", path: "/tmp/app" });
-        yield* svc.remove(p.id);
-        return yield* svc.list();
-      }),
-    );
-    expect(remaining).toHaveLength(0);
-  });
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* tempHome;
+        const file = path.join(home, "storage", "projects.json");
+        yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+        yield* fs.writeFileString(file, "{ not json");
 
-  it("reads a pre-envelope projects.json and adopts it into envelope form", async () => {
-    const file = path.join(home, "storage", "projects.json");
-    const project = { id: "p1", name: "app", path: "/tmp/app", createdAt: "2026-07-16T00:00:00Z" };
-    await fs.mkdir(path.dirname(file), { recursive: true });
-    await fs.writeFile(file, JSON.stringify([project]), "utf8");
-
-    const listed = await run(
-      Effect.gen(function* () {
-        const svc = yield* ProjectService;
-        return yield* svc.list();
-      }),
-    );
-    expect(listed).toEqual([project]);
-
-    const raw = JSON.parse(await fs.readFile(file, "utf8"));
-    expect(raw.version).toBe(1);
-    expect(raw.data).toEqual([project]);
-  });
-
-  it("a corrupt projects.json fails per call with StoreReadError and recovers once fixed", async () => {
-    const file = path.join(home, "storage", "projects.json");
-    await fs.mkdir(path.dirname(file), { recursive: true });
-    await fs.writeFile(file, "{ not json", "utf8");
-
-    // The layer must still build (no startup defect); the error is per call.
-    const result = await run(
-      Effect.gen(function* () {
-        const svc = yield* ProjectService;
+        // The layer must still build (no startup defect); the error is per call.
+        const svc = yield* serviceIn(home);
         const error = yield* Effect.flip(svc.list());
-        // Fix the file on disk; the next call retries the open and recovers.
-        yield* Effect.promise(() => fs.writeFile(file, "[]", "utf8"));
-        const listed = yield* svc.list();
-        return { error, listed };
-      }),
-    );
-    expect(result.error._tag).toBe("StoreReadError");
-    expect(result.listed).toEqual([]);
-  });
+        assert.equal(error._tag, "StoreReadError");
 
-  it("remove fails with ProjectNotFound for an unknown id", async () => {
-    const err = await run(
-      Effect.flip(
-        Effect.gen(function* () {
-          const svc = yield* ProjectService;
-          return yield* svc.remove("nope");
-        }),
-      ),
-    );
-    expect(err._tag).toBe("ProjectNotFound");
-  });
+        // Fix the file on disk; the next call retries the open and recovers.
+        yield* fs.writeFileString(file, "[]");
+        assert.deepEqual(yield* svc.list(), []);
+      }),
+  );
+
+  it.effect("remove fails with ProjectNotFound for an unknown id", () =>
+    Effect.gen(function* () {
+      const svc = yield* projects;
+      const error = yield* Effect.flip(svc.remove("nope"));
+      assert.equal(error._tag, "ProjectNotFound");
+    }),
+  );
 });

--- a/packages/server/test/provider.test.ts
+++ b/packages/server/test/provider.test.ts
@@ -1,9 +1,7 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+import assert from "node:assert/strict";
 
-import { Effect, Layer } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { layer } from "@effect/vitest";
+import { Context, Effect, FileSystem, Layer } from "effect";
 
 import {
   layerPaths,
@@ -14,13 +12,6 @@ import {
 } from "../src/index";
 import { NodePlatformLayer } from "./platform";
 
-const makeLayer = (home: string) =>
-  ProviderServiceLayer.pipe(
-    Layer.provide(ProviderRepositoryLayer),
-    Layer.provide(layerPaths(home)),
-    Layer.provide(NodePlatformLayer),
-  );
-
 const openai: ProviderConfig = {
   id: "openai",
   enabled: true,
@@ -28,42 +19,44 @@ const openai: ProviderConfig = {
   models: [{ id: "gpt-5" }, { id: "gpt-5-mini" }],
 };
 
-describe("ProviderService", () => {
-  let home: string;
-  beforeEach(async () => {
-    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-prov-"));
-  });
-  afterEach(async () => {
-    await fs.rm(home, { recursive: true, force: true });
-  });
-
-  const run = <A, E>(program: Effect.Effect<A, E, ProviderService>) =>
-    Effect.runPromise(Effect.provide(program, makeLayer(home)));
-
-  it("configures (upsert) and lists providers", async () => {
-    const result = await run(
-      Effect.gen(function* () {
-        const svc = yield* ProviderService;
-        yield* svc.configure(openai);
-        yield* svc.configure({ ...openai, apiKey: "sk-updated" });
-        return yield* svc.list();
-      }),
+layer(NodePlatformLayer)("ProviderService", (it) => {
+  /**
+   * A service over its own `$VIBEST_HOME`. Built inside the test, so each one
+   * gets a fresh instance and a fresh temp dir, and the test's scope removes
+   * both — no `beforeEach`, no mutable `home` for a wrapper to close over.
+   */
+  const providers = Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const home = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-prov-" });
+    const context = yield* Layer.build(
+      ProviderServiceLayer.pipe(
+        Layer.provide(ProviderRepositoryLayer),
+        Layer.provide(layerPaths(home)),
+        Layer.provide(NodePlatformLayer),
+      ),
     );
-    expect(result).toHaveLength(1);
-    expect(result[0]?.apiKey).toBe("sk-updated");
+    return Context.get(context, ProviderService);
   });
 
-  it("lists models across / within providers", async () => {
-    const result = await run(
-      Effect.gen(function* () {
-        const svc = yield* ProviderService;
-        yield* svc.configure(openai);
-        const all = yield* svc.listModels();
-        const scoped = yield* svc.listModels("openai");
-        return { all: all.length, scoped: scoped.length };
-      }),
-    );
-    expect(result.all).toBe(2);
-    expect(result.scoped).toBe(2);
-  });
+  it.effect("configures (upsert) and lists providers", () =>
+    Effect.gen(function* () {
+      const svc = yield* providers;
+      yield* svc.configure(openai);
+      yield* svc.configure({ ...openai, apiKey: "sk-updated" });
+
+      const list = yield* svc.list();
+      assert.equal(list.length, 1);
+      assert.equal(list[0]?.apiKey, "sk-updated");
+    }),
+  );
+
+  it.effect("lists models across / within providers", () =>
+    Effect.gen(function* () {
+      const svc = yield* providers;
+      yield* svc.configure(openai);
+
+      assert.equal((yield* svc.listModels()).length, 2);
+      assert.equal((yield* svc.listModels("openai")).length, 2);
+    }),
+  );
 });

--- a/packages/server/test/provider.test.ts
+++ b/packages/server/test/provider.test.ts
@@ -12,11 +12,13 @@ import {
   ProviderService,
   ProviderServiceLayer,
 } from "../src/index";
+import { NodePlatformLayer } from "./platform";
 
 const makeLayer = (home: string) =>
   ProviderServiceLayer.pipe(
     Layer.provide(ProviderRepositoryLayer),
     Layer.provide(layerPaths(home)),
+    Layer.provide(NodePlatformLayer),
   );
 
 const openai: ProviderConfig = {

--- a/packages/server/test/rpc-harness.ts
+++ b/packages/server/test/rpc-harness.ts
@@ -63,7 +63,7 @@ export async function makeRpcTestHarness(
       registryLayer,
       listLayer,
       probeLayer,
-      FileSystemServiceLayer,
+      FileSystemServiceLayer.pipe(Layer.provide(NodePlatformLayer)),
       NodePlatformLayer,
     ),
   );

--- a/packages/server/test/rpc-harness.ts
+++ b/packages/server/test/rpc-harness.ts
@@ -1,4 +1,3 @@
-import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import { createRouterClient } from "@orpc/server";
 import { Layer, ManagedRuntime } from "effect";
 
@@ -34,7 +33,7 @@ export async function makeRpcTestHarness(
   adapters: ReadonlyArray<HarnessAgentAdapter> = [],
 ) {
   // Paths plus the platform services the repositories' JSON store runs on.
-  const paths = Layer.merge(layerPaths(home), NodePlatformLayer);
+  const paths = Layer.provideMerge(layerPaths(home), NodePlatformLayer);
   const registryLayer = Layer.sync(HarnessAgentRegistry, () => makeHarnessAgentRegistry(adapters));
   const harnessSessionLayer = HarnessAgentSessionServiceLayer.pipe(
     Layer.provide(registryLayer),
@@ -65,7 +64,7 @@ export async function makeRpcTestHarness(
       listLayer,
       probeLayer,
       FileSystemServiceLayer,
-      NodeFileSystem.layer,
+      NodePlatformLayer,
     ),
   );
   // Layer construction does file I/O now (the project document loads eagerly),

--- a/packages/server/test/rpc-harness.ts
+++ b/packages/server/test/rpc-harness.ts
@@ -36,8 +36,14 @@ export async function makeRpcTestHarness(
   // Paths plus the platform services the repositories' JSON store runs on.
   const paths = Layer.merge(layerPaths(home), NodePlatformLayer);
   const registryLayer = Layer.sync(HarnessAgentRegistry, () => makeHarnessAgentRegistry(adapters));
-  const harnessSessionLayer = HarnessAgentSessionServiceLayer.pipe(Layer.provide(registryLayer));
-  const listLayer = HarnessListLayer.pipe(Layer.provide(registryLayer));
+  const harnessSessionLayer = HarnessAgentSessionServiceLayer.pipe(
+    Layer.provide(registryLayer),
+    Layer.provide(NodePlatformLayer),
+  );
+  const listLayer = HarnessListLayer.pipe(
+    Layer.provide(registryLayer),
+    Layer.provide(NodePlatformLayer),
+  );
   const probeLayer = HarnessProbeLayer.pipe(Layer.provide(registryLayer));
   const projectLayer = ProjectModuleLayer.pipe(Layer.provide(paths));
   const sessionServiceLayer = SessionServiceLayer.pipe(

--- a/packages/server/test/rpc-harness.ts
+++ b/packages/server/test/rpc-harness.ts
@@ -22,6 +22,7 @@ import {
   SessionRepositoryLayer,
   SessionServiceLayer,
 } from "../src/session";
+import { NodePlatformLayer } from "./platform";
 
 /**
  * A router client backed by the full `RpcContext`, with an adapterless session
@@ -32,7 +33,8 @@ export async function makeRpcTestHarness(
   home: string,
   adapters: ReadonlyArray<HarnessAgentAdapter> = [],
 ) {
-  const paths = layerPaths(home);
+  // Paths plus the platform services the repositories' JSON store runs on.
+  const paths = Layer.merge(layerPaths(home), NodePlatformLayer);
   const registryLayer = Layer.sync(HarnessAgentRegistry, () => makeHarnessAgentRegistry(adapters));
   const harnessSessionLayer = HarnessAgentSessionServiceLayer.pipe(Layer.provide(registryLayer));
   const listLayer = HarnessListLayer.pipe(Layer.provide(registryLayer));

--- a/packages/server/test/rpc-harness.ts
+++ b/packages/server/test/rpc-harness.ts
@@ -46,6 +46,7 @@ export async function makeRpcTestHarness(
     Layer.provide(HarnessAgentSessionPortLayer.pipe(Layer.provide(harnessSessionLayer))),
     Layer.provide(SessionManagerLayer.pipe(Layer.provide(EventBusLayer))),
     Layer.provide(EventBusLayer),
+    Layer.provide(NodePlatformLayer),
   );
   // registryLayer is merged in as well as provided into the session service;
   // Layer memoization (same reference) keeps it one registry instance.

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -79,7 +79,10 @@ async function setup() {
     }),
   ).pipe(Layer.provide(codexLayer));
 
-  const harnessSessionLayer = HarnessAgentSessionServiceLayer.pipe(Layer.provide(registryLayer));
+  const harnessSessionLayer = HarnessAgentSessionServiceLayer.pipe(
+    Layer.provide(registryLayer),
+    Layer.provide(NodeServices.layer),
+  );
   const projectServiceLayer = ProjectServiceLayer.pipe(
     Layer.provide(ProjectRepositoryLayer),
     Layer.provide(pathsLayer),
@@ -101,7 +104,7 @@ async function setup() {
     sessionServiceLayer,
     projectServiceLayer,
     registryLayer,
-    HarnessListLayer.pipe(Layer.provide(registryLayer)),
+    HarnessListLayer.pipe(Layer.provide(registryLayer), Layer.provide(NodeServices.layer)),
     HarnessProbeLayer.pipe(Layer.provide(registryLayer)),
     FileSystemServiceLayer,
     NodeServices.layer,

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -93,6 +93,7 @@ async function setup() {
     Layer.provide(portLayer),
     Layer.provide(managerLayer),
     Layer.provide(EventBusLayer),
+    Layer.provide(NodeServices.layer),
   );
 
   const appLayer = Layer.mergeAll(

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -62,7 +62,7 @@ async function setup() {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-home-"));
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-ws-"));
   // Paths plus the platform services the repositories' JSON store runs on.
-  const pathsLayer = Layer.merge(layerPaths(home), NodeServices.layer);
+  const pathsLayer = Layer.provideMerge(layerPaths(home), NodeServices.layer);
 
   // The fake path goes to the adapter too: `session.create` gates on
   // checkAvailability, which is a PATH lookup — without the override the test

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -106,7 +106,7 @@ async function setup() {
     registryLayer,
     HarnessListLayer.pipe(Layer.provide(registryLayer), Layer.provide(NodeServices.layer)),
     HarnessProbeLayer.pipe(Layer.provide(registryLayer)),
-    FileSystemServiceLayer,
+    FileSystemServiceLayer.pipe(Layer.provide(NodeServices.layer)),
     NodeServices.layer,
   );
   const runtime = ManagedRuntime.make(appLayer);

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -61,7 +61,8 @@ function makeFake(): string {
 async function setup() {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-home-"));
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-ws-"));
-  const pathsLayer = layerPaths(home);
+  // Paths plus the platform services the repositories' JSON store runs on.
+  const pathsLayer = Layer.merge(layerPaths(home), NodeServices.layer);
 
   // The fake path goes to the adapter too: `session.create` gates on
   // checkAvailability, which is a PATH lookup — without the override the test

--- a/packages/server/test/session-repository.test.ts
+++ b/packages/server/test/session-repository.test.ts
@@ -8,8 +8,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { layerPaths } from "../src/config/paths";
 import { SessionRepository, SessionRepositoryLayer } from "../src/session/repository";
 import type { Session } from "../src/types";
+import { NodePlatformLayer } from "./platform";
 
-const makeLayer = (home: string) => SessionRepositoryLayer.pipe(Layer.provide(layerPaths(home)));
+const makeLayer = (home: string) =>
+  SessionRepositoryLayer.pipe(Layer.provide(layerPaths(home)), Layer.provide(NodePlatformLayer));
 
 const meta = (sessionId: string, projectId: string, harnessSessionId: string): Session => ({
   version: 1,

--- a/packages/server/test/session-repository.test.ts
+++ b/packages/server/test/session-repository.test.ts
@@ -1,17 +1,13 @@
-import fs from "node:fs/promises";
-import os from "node:os";
+import assert from "node:assert/strict";
 import path from "node:path";
 
-import { Effect, Layer } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { layer } from "@effect/vitest";
+import { Context, Effect, FileSystem, Layer } from "effect";
 
 import { layerPaths } from "../src/config/paths";
 import { SessionRepository, SessionRepositoryLayer } from "../src/session/repository";
 import type { Session } from "../src/types";
 import { NodePlatformLayer } from "./platform";
-
-const makeLayer = (home: string) =>
-  SessionRepositoryLayer.pipe(Layer.provide(layerPaths(home)), Layer.provide(NodePlatformLayer));
 
 const meta = (sessionId: string, projectId: string, harnessSessionId: string): Session => ({
   version: 1,
@@ -22,171 +18,159 @@ const meta = (sessionId: string, projectId: string, harnessSessionId: string): S
   createdAt: "2026-07-16T00:00:00.000Z",
 });
 
-describe("SessionRepository", () => {
-  let home: string;
-  beforeEach(async () => {
-    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-sess-"));
-  });
-  afterEach(async () => {
-    await fs.rm(home, { recursive: true, force: true });
-  });
+const sessionFile = (home: string, projectId: string, sessionId: string) =>
+  path.join(home, "storage", "sessions", projectId, `${sessionId}.json`);
 
-  const run = <A, E>(program: Effect.Effect<A, E, SessionRepository>) =>
-    Effect.runPromise(Effect.provide(program, makeLayer(home)));
+layer(NodePlatformLayer)("SessionRepository", (it) => {
+  const tempHome = FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.makeTempDirectoryScoped({ prefix: "vibest-sess-" })),
+  );
 
-  it("writes then reads back a session's metadata", async () => {
-    const read = await run(
-      Effect.gen(function* () {
-        const repo = yield* SessionRepository;
-        yield* repo.write(meta("sess-1", "proj-a", "claude-uuid-1"));
-        return yield* repo.read("proj-a", "sess-1");
-      }),
-    );
-    expect(read.sessionId).toBe("sess-1");
-    expect(read.harnessSessionId).toBe("claude-uuid-1");
-    expect(read.version).toBe(1);
-  });
-
-  it("persists at storage/sessions/<projectId>/<sessionId>.json, sessionId in the body too", async () => {
-    await run(
-      Effect.gen(function* () {
-        const repo = yield* SessionRepository;
-        yield* repo.write(meta("sess-1", "proj-a", "claude-uuid-1"));
-      }),
-    );
-    const raw = JSON.parse(
-      await fs.readFile(path.join(home, "storage", "sessions", "proj-a", "sess-1.json"), "utf8"),
-    );
-    expect(raw.version).toBe(1);
-    expect(raw.data.sessionId).toBe("sess-1");
-    expect(raw.data.projectId).toBe("proj-a");
-  });
-
-  it("reads a pre-envelope record and adopts it into envelope form", async () => {
-    const file = path.join(home, "storage", "sessions", "proj-a", "sess-1.json");
-    await fs.mkdir(path.dirname(file), { recursive: true });
-    await fs.writeFile(file, JSON.stringify(meta("sess-1", "proj-a", "claude-uuid-1")), "utf8");
-
-    const read = await run(
-      Effect.gen(function* () {
-        const repo = yield* SessionRepository;
-        return yield* repo.read("proj-a", "sess-1");
-      }),
-    );
-    expect(read.harnessSessionId).toBe("claude-uuid-1");
-
-    const raw = JSON.parse(await fs.readFile(file, "utf8"));
-    expect(raw.version).toBe(1);
-    expect(raw.data.sessionId).toBe("sess-1");
-  });
-
-  it("lists all sessions of a project", async () => {
-    const listed = await run(
-      Effect.gen(function* () {
-        const repo = yield* SessionRepository;
-        yield* repo.write(meta("sess-1", "proj-a", "u1"));
-        yield* repo.write(meta("sess-2", "proj-a", "u2"));
-        yield* repo.write(meta("sess-3", "proj-b", "u3"));
-        return yield* repo.list("proj-a");
-      }),
-    );
-    expect(listed.map((session) => session.sessionId).toSorted()).toEqual(["sess-1", "sess-2"]);
-  });
-
-  it("list returns empty for a project with no session dir", async () => {
-    const listed = await run(
-      Effect.gen(function* () {
-        const repo = yield* SessionRepository;
-        return yield* repo.list("never-created");
-      }),
-    );
-    expect(listed).toEqual([]);
-  });
-
-  it("read fails with SessionNotFound for an unknown session", async () => {
-    const err = await run(
-      Effect.flip(
-        Effect.gen(function* () {
-          const repo = yield* SessionRepository;
-          return yield* repo.read("proj-a", "nope");
-        }),
+  // Kept separate from `tempHome` so the tests that seed a record on disk can
+  // write it before the repository is built, as a real cold start would.
+  const repositoryIn = (home: string) =>
+    Layer.build(
+      SessionRepositoryLayer.pipe(
+        Layer.provide(layerPaths(home)),
+        Layer.provide(NodePlatformLayer),
       ),
-    );
-    expect(err._tag).toBe("SessionNotFound");
-  });
+    ).pipe(Effect.map((context) => Context.get(context, SessionRepository)));
 
-  it("remove is idempotent and deletes the file", async () => {
-    const listedAfter = await run(
+  const repository = Effect.flatMap(tempHome, repositoryIn);
+
+  it.effect("writes then reads back a session's metadata", () =>
+    Effect.gen(function* () {
+      const repo = yield* repository;
+      yield* repo.write(meta("sess-1", "proj-a", "claude-uuid-1"));
+
+      const read = yield* repo.read("proj-a", "sess-1");
+      assert.equal(read.sessionId, "sess-1");
+      assert.equal(read.harnessSessionId, "claude-uuid-1");
+      assert.equal(read.version, 1);
+    }),
+  );
+
+  it.effect(
+    "persists at storage/sessions/<projectId>/<sessionId>.json, sessionId in the body too",
+    () =>
       Effect.gen(function* () {
-        const repo = yield* SessionRepository;
-        yield* repo.write(meta("sess-1", "proj-a", "u1"));
-        yield* repo.remove("proj-a", "sess-1");
-        yield* repo.remove("proj-a", "sess-1"); // idempotent: second remove is a no-op
-        return yield* repo.list("proj-a");
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* tempHome;
+        const repo = yield* repositoryIn(home);
+        yield* repo.write(meta("sess-1", "proj-a", "claude-uuid-1"));
+
+        const raw = JSON.parse(yield* fs.readFileString(sessionFile(home, "proj-a", "sess-1")));
+        assert.equal(raw.version, 1);
+        assert.equal(raw.data.sessionId, "sess-1");
+        assert.equal(raw.data.projectId, "proj-a");
       }),
-    );
-    expect(listedAfter).toEqual([]);
-  });
+  );
 
-  it("findBySessionId reverse-looks-up a session across projects", async () => {
-    const hit = await run(
-      Effect.gen(function* () {
-        const repo = yield* SessionRepository;
-        yield* repo.write(meta("sess-1", "proj-a", "u1"));
-        yield* repo.write(meta("sess-2", "proj-b", "u2"));
-        return yield* repo.findBySessionId("sess-2");
-      }),
-    );
-    expect(hit.projectId).toBe("proj-b");
-    expect(hit.sessionId).toBe("sess-2");
-    expect(hit.harnessSessionId).toBe("u2");
-  });
+  it.effect("reads a pre-envelope record and adopts it into envelope form", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
+      const file = sessionFile(home, "proj-a", "sess-1");
+      yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+      yield* fs.writeFileString(file, JSON.stringify(meta("sess-1", "proj-a", "claude-uuid-1")));
 
-  it("a corrupt record in another project does not break this project's list", async () => {
-    const badFile = path.join(home, "storage", "sessions", "proj-b", "bad.json");
-    await fs.mkdir(path.dirname(badFile), { recursive: true });
-    await fs.writeFile(badFile, "{ not json", "utf8");
+      const repo = yield* repositoryIn(home);
+      assert.equal((yield* repo.read("proj-a", "sess-1")).harnessSessionId, "claude-uuid-1");
 
-    const result = await run(
-      Effect.gen(function* () {
-        const repo = yield* SessionRepository;
-        yield* repo.write(meta("sess-1", "proj-a", "u1"));
-        const listedA = yield* repo.list("proj-a");
-        const errorB = yield* Effect.flip(repo.list("proj-b"));
-        return { listedA, errorB };
-      }),
-    );
-    expect(result.listedA.map((session) => session.sessionId)).toEqual(["sess-1"]);
-    expect(result.errorB._tag).toBe("StoreReadError");
-  });
+      const raw = JSON.parse(yield* fs.readFileString(file));
+      assert.equal(raw.version, 1);
+      assert.equal(raw.data.sessionId, "sess-1");
+    }),
+  );
 
-  it("malformed ids yield typed results, never defects", async () => {
-    const result = await run(
-      Effect.gen(function* () {
-        const repo = yield* SessionRepository;
-        yield* repo.write(meta("sess-1", "proj-a", "u1"));
-        const readError = yield* Effect.flip(repo.read("..", "sess-1"));
-        const findError = yield* Effect.flip(repo.findBySessionId("a/../b"));
-        const listed = yield* repo.list("../proj-a");
-        yield* repo.remove("..", ".."); // no-op, must not die
-        return { readError, findError, listed };
-      }),
-    );
-    expect(result.readError._tag).toBe("SessionNotFound");
-    expect(result.findError._tag).toBe("SessionRefNotFound");
-    expect(result.listed).toEqual([]);
-  });
+  it.effect("lists all sessions of a project", () =>
+    Effect.gen(function* () {
+      const repo = yield* repository;
+      yield* repo.write(meta("sess-1", "proj-a", "u1"));
+      yield* repo.write(meta("sess-2", "proj-a", "u2"));
+      yield* repo.write(meta("sess-3", "proj-b", "u3"));
 
-  it("findBySessionId fails with SessionRefNotFound for an unknown session", async () => {
-    const err = await run(
-      Effect.flip(
-        Effect.gen(function* () {
-          const repo = yield* SessionRepository;
-          yield* repo.write(meta("sess-1", "proj-a", "u1"));
-          return yield* repo.findBySessionId("ghost");
-        }),
-      ),
-    );
-    expect(err._tag).toBe("SessionRefNotFound");
-  });
+      const listed = yield* repo.list("proj-a");
+      assert.deepEqual(listed.map((session) => session.sessionId).toSorted(), ["sess-1", "sess-2"]);
+    }),
+  );
+
+  it.effect("list returns empty for a project with no session dir", () =>
+    Effect.gen(function* () {
+      const repo = yield* repository;
+      assert.deepEqual(yield* repo.list("never-created"), []);
+    }),
+  );
+
+  it.effect("read fails with SessionNotFound for an unknown session", () =>
+    Effect.gen(function* () {
+      const repo = yield* repository;
+      const error = yield* Effect.flip(repo.read("proj-a", "nope"));
+      assert.equal(error._tag, "SessionNotFound");
+    }),
+  );
+
+  it.effect("remove is idempotent and deletes the file", () =>
+    Effect.gen(function* () {
+      const repo = yield* repository;
+      yield* repo.write(meta("sess-1", "proj-a", "u1"));
+      yield* repo.remove("proj-a", "sess-1");
+      yield* repo.remove("proj-a", "sess-1"); // idempotent: second remove is a no-op
+      assert.deepEqual(yield* repo.list("proj-a"), []);
+    }),
+  );
+
+  it.effect("findBySessionId reverse-looks-up a session across projects", () =>
+    Effect.gen(function* () {
+      const repo = yield* repository;
+      yield* repo.write(meta("sess-1", "proj-a", "u1"));
+      yield* repo.write(meta("sess-2", "proj-b", "u2"));
+
+      const hit = yield* repo.findBySessionId("sess-2");
+      assert.equal(hit.projectId, "proj-b");
+      assert.equal(hit.sessionId, "sess-2");
+      assert.equal(hit.harnessSessionId, "u2");
+    }),
+  );
+
+  it.effect("a corrupt record in another project does not break this project's list", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
+      const badFile = sessionFile(home, "proj-b", "bad");
+      yield* fs.makeDirectory(path.dirname(badFile), { recursive: true });
+      yield* fs.writeFileString(badFile, "{ not json");
+
+      const repo = yield* repositoryIn(home);
+      yield* repo.write(meta("sess-1", "proj-a", "u1"));
+
+      const listedA = yield* repo.list("proj-a");
+      assert.deepEqual(
+        Array.from(listedA, (session) => session.sessionId),
+        ["sess-1"],
+      );
+      assert.equal((yield* Effect.flip(repo.list("proj-b")))._tag, "StoreReadError");
+    }),
+  );
+
+  it.effect("malformed ids yield typed results, never defects", () =>
+    Effect.gen(function* () {
+      const repo = yield* repository;
+      yield* repo.write(meta("sess-1", "proj-a", "u1"));
+
+      assert.equal((yield* Effect.flip(repo.read("..", "sess-1")))._tag, "SessionNotFound");
+      assert.equal((yield* Effect.flip(repo.findBySessionId("a/../b")))._tag, "SessionRefNotFound");
+      assert.deepEqual(yield* repo.list("../proj-a"), []);
+      yield* repo.remove("..", ".."); // no-op, must not die
+    }),
+  );
+
+  it.effect("findBySessionId fails with SessionRefNotFound for an unknown session", () =>
+    Effect.gen(function* () {
+      const repo = yield* repository;
+      yield* repo.write(meta("sess-1", "proj-a", "u1"));
+      const error = yield* Effect.flip(repo.findBySessionId("ghost"));
+      assert.equal(error._tag, "SessionRefNotFound");
+    }),
+  );
 });

--- a/packages/server/test/session-service.test.ts
+++ b/packages/server/test/session-service.test.ts
@@ -1,10 +1,9 @@
-import fs from "node:fs/promises";
-import os from "node:os";
+import assert from "node:assert/strict";
 import path from "node:path";
 
+import { layer } from "@effect/vitest";
 import { isSessionScopedEvent } from "@vibest/contract";
-import { Effect, Layer, Stream } from "effect";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Context, Effect, FileSystem, Layer, Stream } from "effect";
 
 import { layerPaths } from "../src/config/paths";
 import { AgentUnavailable } from "../src/errors";
@@ -31,7 +30,7 @@ const makeFakePort = (
   // Spy side effects live inside the effects (not at construction): callers
   // may build an effect without running it — e.g. the `onCrash` handed to the
   // runtime — and only executions should be counted.
-  const layer = Layer.succeed(HarnessAgentSessionPort, {
+  const portLayer = Layer.succeed(HarnessAgentSessionPort, {
     create: (harnessAgentId, cwd) =>
       Effect.suspend(() => {
         spy.create.push({ harnessAgentId, cwd });
@@ -59,309 +58,239 @@ const makeFakePort = (
     setPermissionMode: () => Effect.die("setPermissionMode not exercised"),
     respondToAgentRequest: () => Effect.die("respond not exercised"),
   });
-  return { layer, spy };
+  return { portLayer, spy };
 };
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const APP = { name: "app", path: "/tmp/vibest-app" };
+const APP_CWD = path.resolve(APP.path);
 
-describe("SessionService", () => {
-  let home: string;
-  beforeEach(async () => {
-    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-svc-"));
-  });
-  afterEach(async () => {
-    await fs.rm(home, { recursive: true, force: true });
-  });
+layer(NodePlatformLayer)("SessionService", (it) => {
+  /**
+   * A whole session stack over a fresh `$VIBEST_HOME` and a fake harness port,
+   * built inside the test so each one is isolated and the scope tears it down.
+   */
+  const world = (opts: Parameters<typeof makeFakePort>[0] = {}) =>
+    Effect.gen(function* () {
+      const { portLayer, spy } = makeFakePort(opts);
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-svc-" });
 
-  const layers = (port: Layer.Layer<HarnessAgentSessionPort>) => {
-    // Paths plus the platform services the repositories' JSON store runs on;
-    // one reference, so the repositories share the same temp-dir wiring.
-    const paths = Layer.provideMerge(layerPaths(home), NodePlatformLayer);
-    const base = Layer.mergeAll(
-      ProjectServiceLayer.pipe(Layer.provide(ProjectRepositoryLayer), Layer.provide(paths)),
-      SessionRepositoryLayer.pipe(Layer.provide(paths)),
-      SessionManagerLayer.pipe(Layer.provide(EventBusLayer)),
-      EventBusLayer,
-      NodePlatformLayer,
-      port,
-    );
-    // Expose SessionService plus the base services the programs also read from;
-    // `base` is one reference, so its layers build once (shared temp dir).
-    return Layer.mergeAll(SessionServiceLayer.pipe(Layer.provide(base)), base);
-  };
-
-  const run = <A, E>(
-    port: Layer.Layer<HarnessAgentSessionPort>,
-    program: Effect.Effect<A, E, SessionService | ProjectService | SessionRepository | EventBus>,
-  ) => Effect.runPromise(Effect.provide(program, layers(port)));
-
-  it("create resolves projectId to cwd, generates a uuid sessionId, persists metadata", async () => {
-    const { layer, spy } = makeFakePort();
-    const result = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const repo = yield* SessionRepository;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const ref = yield* sessions.create(project.id, "claude-code");
-        const stored = yield* repo.read(ref.projectId, ref.sessionId);
-        return { project, ref, stored };
-      }),
-    );
-
-    expect(result.ref.projectId).toBe(result.project.id);
-    expect(result.ref.harnessAgentId).toBe("claude-code");
-    expect(result.ref.sessionId).toMatch(UUID_RE);
-    // harness saw the resolved cwd, never a projectId
-    expect(spy.create).toEqual([
-      { harnessAgentId: "claude-code", cwd: path.resolve("/tmp/vibest-app") },
-    ]);
-    // metadata stores the native id, keyed by the server sessionId (filename)
-    expect(result.stored.harnessSessionId).toBe("native-1");
-    expect(result.stored.projectId).toBe(result.project.id);
-  });
-
-  it("create fails with ProjectNotFound for an unknown projectId", async () => {
-    const { layer, spy } = makeFakePort();
-    const err = await run(
-      layer,
-      Effect.flip(
-        Effect.gen(function* () {
-          const sessions = yield* SessionService;
-          return yield* sessions.create("00000000-0000-7000-8000-000000000000", "codex");
-        }),
-      ),
-    );
-    expect(err._tag).toBe("ProjectNotFound");
-    expect(spy.create).toHaveLength(0);
-  });
-
-  it("create surfaces AgentUnavailable and writes no metadata", async () => {
-    const { layer } = makeFakePort({
-      failCreate: new AgentUnavailable({ harnessAgentId: "codex", reason: "not installed" }),
+      // Paths plus the platform services the repositories' JSON store runs on;
+      // one reference, so the repositories share the same temp-dir wiring.
+      const paths = Layer.provideMerge(layerPaths(home), NodePlatformLayer);
+      const base = Layer.mergeAll(
+        ProjectServiceLayer.pipe(Layer.provide(ProjectRepositoryLayer), Layer.provide(paths)),
+        SessionRepositoryLayer.pipe(Layer.provide(paths)),
+        SessionManagerLayer.pipe(Layer.provide(EventBusLayer)),
+        EventBusLayer,
+        NodePlatformLayer,
+        portLayer,
+      );
+      // `base` is one reference, so its layers build once (shared temp dir).
+      const context = yield* Layer.build(
+        Layer.mergeAll(SessionServiceLayer.pipe(Layer.provide(base)), base),
+      );
+      return {
+        spy,
+        projects: Context.get(context, ProjectService),
+        sessions: Context.get(context, SessionService),
+        repo: Context.get(context, SessionRepository),
+        bus: Context.get(context, EventBus),
+      };
     });
-    const result = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const repo = yield* SessionRepository;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const err = yield* Effect.flip(sessions.create(project.id, "codex"));
-        const listed = yield* repo.list(project.id);
-        return { err, listed };
-      }),
-    );
-    expect(result.err._tag).toBe("AgentUnavailable");
-    expect(result.listed).toHaveLength(0);
-  });
 
-  it("resume translates the ref to the native id and passes the cwd", async () => {
-    const { layer, spy } = makeFakePort();
-    await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const ref = yield* sessions.create(project.id, "claude-code");
-        yield* sessions.resume(ref);
-      }),
-    );
-    expect(spy.resume).toEqual([
-      {
-        harnessAgentId: "claude-code",
-        harnessSessionId: "native-1",
-        cwd: path.resolve("/tmp/vibest-app"),
-      },
-    ]);
-  });
+  it.effect("create resolves projectId to cwd, generates a uuid sessionId, persists metadata", () =>
+    Effect.gen(function* () {
+      const { projects, sessions, repo, spy } = yield* world();
+      const project = yield* projects.create(APP);
+      const ref = yield* sessions.create(project.id, "claude-code");
 
-  it("resume fails with SessionNotFound for an unknown session", async () => {
-    const { layer } = makeFakePort();
-    const err = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        return yield* Effect.flip(
-          sessions.resume({
-            projectId: project.id,
-            harnessAgentId: "claude-code",
-            sessionId: "missing",
-          }),
-        );
-      }),
-    );
-    expect(err._tag).toBe("SessionNotFound");
-  });
+      assert.equal(ref.projectId, project.id);
+      assert.equal(ref.harnessAgentId, "claude-code");
+      assert.match(ref.sessionId, UUID_RE);
+      // harness saw the resolved cwd, never a projectId
+      assert.deepEqual(spy.create, [{ harnessAgentId: "claude-code", cwd: APP_CWD }]);
 
-  it("resume fails with SessionRefMismatch when the ref's agent disagrees with metadata", async () => {
-    const { layer } = makeFakePort();
-    const err = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const ref = yield* sessions.create(project.id, "claude-code");
-        return yield* Effect.flip(sessions.resume({ ...ref, harnessAgentId: "codex" }));
-      }),
-    );
-    expect(err._tag).toBe("SessionRefMismatch");
-  });
+      // metadata stores the native id, keyed by the server sessionId (filename)
+      const stored = yield* repo.read(ref.projectId, ref.sessionId);
+      assert.equal(stored.harnessSessionId, "native-1");
+      assert.equal(stored.projectId, project.id);
+    }),
+  );
 
-  it("close translates the ref to the native id", async () => {
-    const { layer, spy } = makeFakePort();
-    await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const ref = yield* sessions.create(project.id, "claude-code");
-        yield* sessions.close(ref);
-      }),
-    );
-    expect(spy.close).toEqual(["native-1"]);
-  });
+  it.effect("create fails with ProjectNotFound for an unknown projectId", () =>
+    Effect.gen(function* () {
+      const { sessions, spy } = yield* world();
+      const error = yield* Effect.flip(
+        sessions.create("00000000-0000-7000-8000-000000000000", "codex"),
+      );
+      assert.equal(error._tag, "ProjectNotFound");
+      assert.equal(spy.create.length, 0);
+    }),
+  );
 
-  it("delete closes the native session and removes its metadata", async () => {
-    const { layer, spy } = makeFakePort();
-    const listed = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const ref = yield* sessions.create(project.id, "claude-code");
-        yield* sessions.delete(ref);
-        return yield* sessions.list(project.id);
-      }),
-    );
-    expect(spy.close).toEqual(["native-1"]);
-    expect(listed).toHaveLength(0);
-  });
+  it.effect("create surfaces AgentUnavailable and writes no metadata", () =>
+    Effect.gen(function* () {
+      const { projects, sessions, repo } = yield* world({
+        failCreate: new AgentUnavailable({ harnessAgentId: "codex", reason: "not installed" }),
+      });
+      const project = yield* projects.create(APP);
 
-  it("list returns one summary per session, keyed by server sessionId", async () => {
-    const { layer } = makeFakePort();
-    const result = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const a = yield* sessions.create(project.id, "claude-code");
-        const b = yield* sessions.create(project.id, "codex");
-        const listed = yield* sessions.list(project.id);
-        return { a, b, listed };
-      }),
-    );
-    expect(result.listed).toHaveLength(2);
-    expect(result.listed.map((s) => s.sessionId).toSorted()).toEqual(
-      [result.a.sessionId, result.b.sessionId].toSorted(),
-    );
-    // We own the record, so a session we created reads as history-available.
-    expect(result.listed.every((s) => s.historyAvailable)).toBe(true);
-  });
+      const error = yield* Effect.flip(sessions.create(project.id, "codex"));
+      assert.equal(error._tag, "AgentUnavailable");
+      assert.equal((yield* repo.list(project.id)).length, 0);
+    }),
+  );
 
-  it("titles a session from its first prompt, collapsing whitespace", async () => {
-    const { layer } = makeFakePort();
-    const listed = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const ref = yield* sessions.create(project.id, "claude-code");
-        yield* sessions.prompt({ ref, parts: [{ type: "text", text: "  Fix the  login  bug " }] });
-        return yield* sessions.list(project.id);
-      }),
-    );
-    expect(listed).toHaveLength(1);
-    expect(listed[0]?.title).toBe("Fix the login bug");
-  });
+  it.effect("resume translates the ref to the native id and passes the cwd", () =>
+    Effect.gen(function* () {
+      const { projects, sessions, spy } = yield* world();
+      const project = yield* projects.create(APP);
+      const ref = yield* sessions.create(project.id, "claude-code");
+      yield* sessions.resume(ref);
 
-  it("publishes session.updated with the collapsed title on the first prompt", async () => {
-    const { layer } = makeFakePort();
-    const result = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const bus = yield* EventBus;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const ref = yield* sessions.create(project.id, "claude-code");
-        // Subscribe after create so only the prompt's event is in flight; the
-        // queue buffers it until take(1) pulls it — no forked drain, no race.
-        return yield* Effect.scoped(
-          Effect.gen(function* () {
-            const stream = yield* bus.subscribe({ kind: "global" });
-            yield* sessions.prompt({
-              ref,
-              parts: [{ type: "text", text: "  Fix the  login  bug " }],
-            });
-            const items = yield* Stream.runCollect(Stream.take(stream, 1));
-            return Array.from(items);
-          }),
-        );
-      }),
-    );
-    expect(result).toHaveLength(1);
-    const item = result[0];
-    expect(item?.type).toBe("event");
-    const event = item?.type === "event" ? item.event : undefined;
-    expect(event && !isSessionScopedEvent(event)).toBe(true);
-    expect(event?.type).toBe("session.updated");
-    expect(event?.type === "session.updated" ? event.title : undefined).toBe("Fix the login bug");
-  });
+      assert.deepEqual(spy.resume, [
+        { harnessAgentId: "claude-code", harnessSessionId: "native-1", cwd: APP_CWD },
+      ]);
+    }),
+  );
 
-  it("keeps the first prompt's title; later prompts don't rename", async () => {
-    const { layer } = makeFakePort();
-    const listed = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        const ref = yield* sessions.create(project.id, "claude-code");
-        yield* sessions.prompt({ ref, parts: [{ type: "text", text: "first" }] });
-        yield* sessions.prompt({ ref, parts: [{ type: "text", text: "second" }] });
-        return yield* sessions.list(project.id);
-      }),
-    );
-    expect(listed[0]?.title).toBe("first");
-  });
+  it.effect("resume fails with SessionNotFound for an unknown session", () =>
+    Effect.gen(function* () {
+      const { projects, sessions } = yield* world();
+      const project = yield* projects.create(APP);
 
-  it("lists a session with no title until its first prompt", async () => {
-    const { layer } = makeFakePort();
-    const listed = await run(
-      layer,
-      Effect.gen(function* () {
-        const projects = yield* ProjectService;
-        const sessions = yield* SessionService;
-        const project = yield* projects.create({ name: "app", path: "/tmp/vibest-app" });
-        yield* sessions.create(project.id, "claude-code");
-        return yield* sessions.list(project.id);
-      }),
-    );
-    expect(listed).toHaveLength(1);
-    expect(listed[0]?.title).toBeUndefined();
-  });
-
-  it("list fails with ProjectNotFound for an unknown project", async () => {
-    const { layer } = makeFakePort();
-    const err = await run(
-      layer,
-      Effect.flip(
-        Effect.gen(function* () {
-          const sessions = yield* SessionService;
-          return yield* sessions.list("00000000-0000-7000-8000-000000000000");
+      const error = yield* Effect.flip(
+        sessions.resume({
+          projectId: project.id,
+          harnessAgentId: "claude-code",
+          sessionId: "missing",
         }),
-      ),
-    );
-    expect(err._tag).toBe("ProjectNotFound");
-  });
+      );
+      assert.equal(error._tag, "SessionNotFound");
+    }),
+  );
+
+  it.effect(
+    "resume fails with SessionRefMismatch when the ref's agent disagrees with metadata",
+    () =>
+      Effect.gen(function* () {
+        const { projects, sessions } = yield* world();
+        const project = yield* projects.create(APP);
+        const ref = yield* sessions.create(project.id, "claude-code");
+
+        const error = yield* Effect.flip(sessions.resume({ ...ref, harnessAgentId: "codex" }));
+        assert.equal(error._tag, "SessionRefMismatch");
+      }),
+  );
+
+  it.effect("close translates the ref to the native id", () =>
+    Effect.gen(function* () {
+      const { projects, sessions, spy } = yield* world();
+      const project = yield* projects.create(APP);
+      yield* sessions.close(yield* sessions.create(project.id, "claude-code"));
+
+      assert.deepEqual(spy.close, ["native-1"]);
+    }),
+  );
+
+  it.effect("delete closes the native session and removes its metadata", () =>
+    Effect.gen(function* () {
+      const { projects, sessions, spy } = yield* world();
+      const project = yield* projects.create(APP);
+      yield* sessions.delete(yield* sessions.create(project.id, "claude-code"));
+
+      assert.deepEqual(spy.close, ["native-1"]);
+      assert.equal((yield* sessions.list(project.id)).length, 0);
+    }),
+  );
+
+  it.effect("list returns one summary per session, keyed by server sessionId", () =>
+    Effect.gen(function* () {
+      const { projects, sessions } = yield* world();
+      const project = yield* projects.create(APP);
+      const a = yield* sessions.create(project.id, "claude-code");
+      const b = yield* sessions.create(project.id, "codex");
+
+      const listed = yield* sessions.list(project.id);
+      assert.equal(listed.length, 2);
+      assert.deepEqual(
+        listed.map((session) => session.sessionId).toSorted(),
+        [a.sessionId, b.sessionId].toSorted(),
+      );
+      // We own the record, so a session we created reads as history-available.
+      assert.ok(listed.every((session) => session.historyAvailable));
+    }),
+  );
+
+  it.effect("titles a session from its first prompt, collapsing whitespace", () =>
+    Effect.gen(function* () {
+      const { projects, sessions } = yield* world();
+      const project = yield* projects.create(APP);
+      const ref = yield* sessions.create(project.id, "claude-code");
+      yield* sessions.prompt({ ref, parts: [{ type: "text", text: "  Fix the  login  bug " }] });
+
+      const listed = yield* sessions.list(project.id);
+      assert.equal(listed.length, 1);
+      assert.equal(listed[0]?.title, "Fix the login bug");
+    }),
+  );
+
+  it.effect("publishes session.updated with the collapsed title on the first prompt", () =>
+    Effect.gen(function* () {
+      const { projects, sessions, bus } = yield* world();
+      const project = yield* projects.create(APP);
+      const ref = yield* sessions.create(project.id, "claude-code");
+
+      // Subscribe after create so only the prompt's event is in flight; the
+      // queue buffers it until take(1) pulls it — no forked drain, no race.
+      const stream = yield* bus.subscribe({ kind: "global" });
+      yield* sessions.prompt({ ref, parts: [{ type: "text", text: "  Fix the  login  bug " }] });
+      const items = Array.from(yield* Stream.runCollect(Stream.take(stream, 1)));
+
+      assert.equal(items.length, 1);
+      const item = items[0];
+      assert.equal(item?.type, "event");
+      const event = item?.type === "event" ? item.event : undefined;
+      assert.ok(event && !isSessionScopedEvent(event));
+      assert.equal(event?.type, "session.updated");
+      assert.equal(
+        event?.type === "session.updated" ? event.title : undefined,
+        "Fix the login bug",
+      );
+    }),
+  );
+
+  it.effect("keeps the first prompt's title; later prompts don't rename", () =>
+    Effect.gen(function* () {
+      const { projects, sessions } = yield* world();
+      const project = yield* projects.create(APP);
+      const ref = yield* sessions.create(project.id, "claude-code");
+      yield* sessions.prompt({ ref, parts: [{ type: "text", text: "first" }] });
+      yield* sessions.prompt({ ref, parts: [{ type: "text", text: "second" }] });
+
+      assert.equal((yield* sessions.list(project.id))[0]?.title, "first");
+    }),
+  );
+
+  it.effect("lists a session with no title until its first prompt", () =>
+    Effect.gen(function* () {
+      const { projects, sessions } = yield* world();
+      const project = yield* projects.create(APP);
+      yield* sessions.create(project.id, "claude-code");
+
+      const listed = yield* sessions.list(project.id);
+      assert.equal(listed.length, 1);
+      assert.equal(listed[0]?.title, undefined);
+    }),
+  );
+
+  it.effect("list fails with ProjectNotFound for an unknown project", () =>
+    Effect.gen(function* () {
+      const { sessions } = yield* world();
+      const error = yield* Effect.flip(sessions.list("00000000-0000-7000-8000-000000000000"));
+      assert.equal(error._tag, "ProjectNotFound");
+    }),
+  );
 });

--- a/packages/server/test/session-service.test.ts
+++ b/packages/server/test/session-service.test.ts
@@ -16,6 +16,7 @@ import { type HarnessCreateError, HarnessAgentSessionPort } from "../src/session
 import { SessionRepository, SessionRepositoryLayer } from "../src/session/repository";
 import { SessionManagerLayer } from "../src/session/runtime";
 import { SessionService, SessionServiceLayer } from "../src/session/service";
+import { NodePlatformLayer } from "./platform";
 
 type PortSpy = {
   create: Array<{ harnessAgentId: string; cwd: string }>;
@@ -73,7 +74,9 @@ describe("SessionService", () => {
   });
 
   const layers = (port: Layer.Layer<HarnessAgentSessionPort>) => {
-    const paths = layerPaths(home);
+    // Paths plus the platform services the repositories' JSON store runs on;
+    // one reference, so the repositories share the same temp-dir wiring.
+    const paths = Layer.merge(layerPaths(home), NodePlatformLayer);
     const base = Layer.mergeAll(
       ProjectServiceLayer.pipe(Layer.provide(ProjectRepositoryLayer), Layer.provide(paths)),
       SessionRepositoryLayer.pipe(Layer.provide(paths)),

--- a/packages/server/test/session-service.test.ts
+++ b/packages/server/test/session-service.test.ts
@@ -82,6 +82,7 @@ describe("SessionService", () => {
       SessionRepositoryLayer.pipe(Layer.provide(paths)),
       SessionManagerLayer.pipe(Layer.provide(EventBusLayer)),
       EventBusLayer,
+      NodePlatformLayer,
       port,
     );
     // Expose SessionService plus the base services the programs also read from;

--- a/packages/server/test/session-service.test.ts
+++ b/packages/server/test/session-service.test.ts
@@ -76,7 +76,7 @@ describe("SessionService", () => {
   const layers = (port: Layer.Layer<HarnessAgentSessionPort>) => {
     // Paths plus the platform services the repositories' JSON store runs on;
     // one reference, so the repositories share the same temp-dir wiring.
-    const paths = Layer.merge(layerPaths(home), NodePlatformLayer);
+    const paths = Layer.provideMerge(layerPaths(home), NodePlatformLayer);
     const base = Layer.mergeAll(
       ProjectServiceLayer.pipe(Layer.provide(ProjectRepositoryLayer), Layer.provide(paths)),
       SessionRepositoryLayer.pipe(Layer.provide(paths)),

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -23,7 +23,6 @@
     "@orpc/server": "catalog:orpc",
     "ai": "catalog:",
     "effect": "catalog:",
-    "sirv": "^3.0.2",
     "uuid": "catalog:",
     "ws": "catalog:",
     "zod": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,9 @@ importers:
         specifier: 'catalog:'
         version: 6.1.2(react@19.2.7)
     devDependencies:
+      '@effect/vitest':
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97(effect@4.0.0-beta.97)(vitest@4.1.10)
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
         version: 2.0.0(@types/node@24.13.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,9 +505,6 @@ importers:
       simple-git:
         specifier: 'catalog:'
         version: 3.36.0(supports-color@7.2.0)
-      sirv:
-        specifier: ^3.0.2
-        version: 3.0.2
       uuid:
         specifier: 'catalog:'
         version: 14.0.1
@@ -661,9 +658,6 @@ importers:
       effect:
         specifier: 4.0.0-beta.97
         version: 4.0.0-beta.97
-      sirv:
-        specifier: ^3.0.2
-        version: 3.0.2
       uuid:
         specifier: 'catalog:'
         version: 14.0.1
@@ -10628,7 +10622,8 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
-  '@polka/url@1.0.0-next.29': {}
+  '@polka/url@1.0.0-next.29':
+    optional: true
 
   '@preact/signals-core@1.14.4': {}
 
@@ -15214,7 +15209,8 @@ snapshots:
 
   mri@1.2.0: {}
 
-  mrmime@2.0.1: {}
+  mrmime@2.0.1:
+    optional: true
 
   ms@2.1.3: {}
 
@@ -16509,6 +16505,7 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+    optional: true
 
   sisteransi@1.0.5: {}
 
@@ -16778,7 +16775,8 @@ snapshots:
 
   toml@4.1.2: {}
 
-  totalist@3.0.1: {}
+  totalist@3.0.1:
+    optional: true
 
   tough-cookie@5.1.2:
     dependencies:


### PR DESCRIPTION
`packages/server` was half-migrated: `ChildProcessSpawner` drove every harness
process, but disk, path, and randomness still went through `node:fs` /
`node:path` / `node:crypto` — including `readFileSync` inside otherwise
Effect-shaped code. This finishes the sweep in one branch, per
`docs/2026-07-27-effect-platform-migration.md`, and writes the rule down so the
next file doesn't drift back.

> Rebased onto `main` after #145 / #147 landed `@vibest/effect-json-store`. The
> project and session repositories now sit on that package rather than on
> `infra/json-store.ts`, so this branch no longer migrates them — it only
> **unseals** them (see below). `infra/json-store.ts` itself is still here,
> serving the `mcp` and `provider` repositories, and is what this branch moves
> onto the platform services.

## Shape of the dependency

The requirement rides the `R` channel. A function that touches disk is
`Effect<A, E, FileSystem.FileSystem>` — no layer sealed inside the
module, no new `StorageService` wrapper. Service *shapes* stay `R`-free: the
Layer binds the platform once and hands it to each method.

```ts
export const ProviderRepositoryLayer = Layer.effect(ProviderRepository, Effect.gen(function* () {
  const paths = yield* Paths;
  // Bind once so the methods below stay R-free; the Layer's R carries the
  // requirement to the composition root instead.
  const platform = yield* Effect.context<JsonStorePlatform>();
  const readConfig = () => readJson<RuntimeConfig>(paths.configFile, {});
  return {
    list: () => readConfig().pipe(
      Effect.map((config) => config.provider ?? []),
      Effect.provide(platform),
    ),
    save: (providers) => Effect.gen(function* () {
      const config = yield* readConfig();
      yield* writeJsonAtomic(paths.configFile, { ...config, provider: providers });
    }).pipe(Effect.provide(platform)),
  };
}));
```

`NodeFileSystem.layer` / `NodeCrypto.layer` (and `NodePath.layer`, which only
`HttpStaticServer` asks for) now appear in exactly three places: `rpc/runtime.ts`, `apps/desktop`'s `desktop-runtime.ts`,
and the CLI.

That last point is why the two `@vibest/effect-json-store` repositories are
touched at all: both ended with `.pipe(Layer.provide(NodeFileSystem.layer))`,
sealing the node layer inside the module. Unsealed — their `R` now carries
`FileSystem` like everything else.

## What moved

| area | change |
|---|---|
| `infra/json-store.ts` | the central seam — `readJson` / `writeJsonAtomic` on `FileSystem` + `Crypto`; tmp-file uuid from `crypto.randomUUIDv4` |
| mcp / provider repositories | mechanical `R` propagation off the store |
| project / session repositories | unsealed only — the node layer no longer baked in |
| `node:crypto` sweep | entity ids in `project/service.ts` and `session/service.ts`, the daemon token's `randomBytes(32)` |
| `harness/executable.ts`, `harness/claude-code/executable.ts` | PATH walking, SDK resolution, and the SDK's `claudeCodeVersion` floor are Effects; `deps.isExecutable` injection replaced by injecting the `FileSystem` |
| `daemon/{lock,record,tombstone}.ts` + `launcher.ts` | all file state on `FileSystem`; the launch lock is `writeFileString(flag: "wx", mode: 0o600)`, i.e. the same one `O_EXCL` syscall as before |
| `http/ui.ts`, `rpc/fs.ts` | static asset reads and the fs router on `FileSystem`; their path math stays `node:path` |
| `http/` (#141, merged into this branch) | the request path runs on `NodeHttpServer.makeHandler`; oRPC keeps the raw upgrade |

## Scope: not the Vite split

Migrating `http/ui.ts` surfaced that the dev server was doing two unrelated
jobs — serving built assets, and hosting a Vite middleware in dev — and that
splitting them would shrink `ui.ts` a lot. That work exists (dev topology, dev
ports, deleting `createDevWsRPCHandler`, `.claude/skills/verify`), but it is a
**dev-infrastructure change, not an Effect migration**, so it is deliberately
**not** in this PR. It lives on `refactor/split-vite-dev` and lands separately
on top of this one.

Domain errors are unchanged: `StoreReadError` / `StoreWriteError` still wrap
everything, and "the file isn't there" is now `error.reason._tag === "NotFound"`
instead of an errno string comparison.

## Two Effect API gaps worth knowing

**`FileSystem.access` has no `X_OK`.** The plan assumed `accessSync(X_OK)` →
`fs.access`; the Node implementation only exposes `F_OK|R_OK|W_OK`. Both
executable resolvers now use `stat` + `info.type === "File" && (info.mode &
0o111) !== 0`. This is an approximation in one direction — an owner-only-
executable binary is reported as found and fails later at spawn with `EACCES` —
and strictly better in another: a *directory* named like the command used to
pass `accessSync` and now doesn't.

**`Path` has no `delimiter`.** Moot now that both resolvers are on `node:path`,
but worth knowing before reaching for the service: they derive `";"` / `":"`
from the platform locally rather than from `Path`.

## Async where it used to be sync

`daemon/lock.ts` going async moves nothing: the exclusive create is still one
atomic syscall, so only the winner proceeds to spawn, and every branch below it
already assumed the file state can change underneath (a reclaim can lose its
race; the retry loop is what covers that). Re-derived in a comment in
`spawnLocked` rather than left implicit.

Two call sites changed shape rather than propagating requirements everywhere:

- `HarnessAgentAdapter.checkAvailability` widened its `R` instead of turning the
  three adapter factories into Effects — the latter would have churned ~15
  synchronous `makeXAdapter(agent).open(...)` test call sites for nothing.
- Desktop's `makeDaemonServerProcess` became an Effect factory, so the generic
  `SpawnServer` type stays free of server-specific platform requirements.
- `RpcRuntime` gained `run()`, letting the Promise-shaped (and exempt)
  `http/server.ts` execute the now-Effect-native UI handler on the server's own
  runtime instead of standing up a second composition root.

## Exemptions

Fixed up front and reproduced in `.agents/rules/stack.md` with reasons, so
they're a decision rather than a backlog: `spawnDetached` (detached + unref +
stdio to a log fd is the opposite of supervised spawning), `http/server.ts`
wholesale (node:http, ws, oRPC, and Vite HMR share one server and its upgrade
event) and its synchronous call sites, Electron-bound files in
`apps/desktop/src/main`, node-pty in the dormant `packages/services`,
`node:os.homedir`, `node:module.createRequire`, `daemon/port.ts`, and the
`process.kill` signals. "It's already written" is not on the list.

One child-process call is *deliberately deferred* rather than exempt:
`checkClaudeAvailability` still reads `<executable> --version` through
`node:child_process`. `ChildProcessSpawner` supervises its children through a
`Scope`, and threading one in would push `Scope` onto every harness adapter's
`checkAvailability` for a single short-lived capture. Noted in a comment at the
call site.

## What `node:path` is still doing here — and where this PR overshot

Review asked why `config/paths.ts` still imports `node:path`. Chasing it down
showed the *answer* was right and my *stated reason* was wrong, so both the
comment and this section are corrected here.

The reason I had written — that `resolveVibestHome` is "called before Layer
construction and from exempt Promise-shaped code" — is false. All four call
sites (`cli.ts` ×3, `daemon-server-process.ts`) are already inside an
`Effect.gen`, and both composition roots already provide `Path`
(`NodeServices.layer`; `DaemonPlatform`, provided at `daemon-server-process.ts:90`,
included `Path` at the time). Making it an Effect would have cost nothing.

The right reason is the boundary now written into `.agents/rules/stack.md`:
**don't return `Effect` from a helper that performs no effectful work.** An env
lookup plus a string join is not an effect. The test is "is this an effect?",
not "did it come from `node:`" — so `join`/`dirname`/`relative` stay
`node:path`, while `FileSystem` / `Crypto` / `ChildProcessSpawner` do not.

An earlier revision of this PR overshot that rule — it had ~60 `Path.Path`
references in `packages/server`, most of them pure string math, including a
`contains()` that took `Path.Path` as a parameter to compare two strings. That
is walked back here: **64 references across 15 files → 1**, and the one that
remains (`http/ui.ts`) is not ours, since `HttpStaticServer.make` requires it.
Thirteen files import `node:path` instead. `recordPath` and the `Paths` layers
stopped being Effects, because nothing in them suspends. For calibration,
opencode (also Effect 4.x beta) uses `Path.Path` in 2 files across its core and
server and `Crypto.Crypto` in none.

`spawnDetached` is exempt wholesale, and `harness/probe.ts` normalises a cache
key in a file that holds no platform services at all.

That principle also turned up two things worth fixing here:

- `daemon/launcher.ts` was building one error message with `nodePath.join` while
  sitting inside a gen whose `R` already carried `Path`. Now uses the service.
- `fs/service.ts` — pre-existing, not otherwise touched by this branch — ended
  with `Layer.provide(NodeFileSystem.layer)`, sealing the node layer inside the
  module: exactly what the new rule says not to do, and the reason it couldn't
  reach for `Path` either. Unsealed; its `R` is now `FileSystem` like everything
  else, provided at `rpc/runtime.ts` and in the three test wirings.

## Tests

Every existing real-fs + `mkdtemp` test keeps its assertions untouched — that's
the regression net for a refactor this wide; only the `makeLayer` helpers gained
the Node platform layers. On top of that, `test/json-store.test.ts` adds
fault-injection tests over `FileSystem.makeNoop` for the failures a real disk
won't produce on demand: read denied → `StoreReadError`, each of
`makeDirectory`/`writeFileString`/`rename` failing → `StoreWriteError` naming
the *target* rather than the temp path, `NotFound` → fallback, and a recording
fake that pins the write-tmp-then-rename ordering. The Claude executable tests
gain one case main's version floor didn't have: an unreadable floor fails
**open**, same as an unreadable version.

`turbo run test typecheck` is green (server 249 passed / 2 skipped); `pnpm
check` is clean. Also smoke-tested at runtime: the daemon launches through the
migrated launcher, `daemon.pid` lands 0600 with a 64-hex `effect/Crypto` token,
`/api/health` answers, and the SPA loads and talks to the server over the
Effect-native request path in a real headless Chrome.
