### PR TITLE
refactor(server): move the HTTP request path onto Effect, leave oRPC's upgrade raw

### DIFF
--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -51,6 +51,11 @@ means matching this.
 - **Tests:** real-fs + `mkdtemp` for behaviour, `FileSystem.makeNoop` (see
   `packages/server/test/fake-file-system.ts`) for failures a real disk won't
   produce on demand.
+- **The HTTP seam is `NodeHttpServer.makeHandler`,** not `HttpServer.serve`:
+  `serve` registers its own `upgrade` listener, and that event belongs to oRPC
+  and Vite's HMR socket. `makeHandler` yields a plain node `request` listener,
+  so `http/app.ts` is an ordinary Effect while `http/server.ts` keeps the raw
+  upgrade block.
 
 Exempt, deliberately — these are boundaries Effect doesn't model, and "it's
 already written" is not a reason to add to the list:
@@ -58,7 +63,7 @@ already written" is not a reason to add to the list:
 | Location                                                                  | Why                                                                                                  |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `daemon/launcher.ts`'s `spawnDetached`                                    | detached + unref + stdio to a log fd is the opposite of `ChildProcessSpawner`'s supervised semantics |
-| `http/server.ts` as a whole                                               | node:http, ws, the oRPC WS handler, and Vite HMR share one server and its upgrade event              |
+| `http/server.ts`'s `upgrade` path                                         | oRPC and Vite HMR share that event; Effect's own websocket handler would fight them for the listener |
 | Call sites inside an exempt file                                          | e.g. `http/auth.ts`'s ticket `randomUUID`, called synchronously from Promise-shaped `http/server.ts` |
 | `apps/desktop/src/main`'s Electron-bound files                            | `app-protocol`, `main-window`, `desktop-config`, `lib/utils` are tied to the Electron lifecycle      |
 | `packages/services`' terminal-manager                                     | node-pty has no Effect equivalent (and the package is dormant)                                       |

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,7 +33,6 @@
     "@vibest/harness": "workspace:*",
     "effect": "catalog:",
     "simple-git": "catalog:",
-    "sirv": "^3.0.2",
     "uuid": "catalog:",
     "ws": "catalog:"
   },

--- a/packages/server/src/http/app.ts
+++ b/packages/server/src/http/app.ts
@@ -1,0 +1,96 @@
+import * as NodeHttpServerRequest from "@effect/platform-node/NodeHttpServerRequest";
+import { Effect } from "effect";
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+
+import { bearerToken, type TicketStore, tokensMatch } from "./auth";
+import { corsHeaders, isLoopbackHost } from "./cors";
+import type { UIApp } from "./ui";
+
+export type RequestAppOptions = {
+  /**
+   * When set, every `/api/*` request except `/api/health` must present
+   * `Authorization: Bearer <token>`. Unset (browser mode) disables the check.
+   */
+  readonly authToken: string | undefined;
+  /** Extra cross-origin allowlist entries on top of the built-in trusted set. */
+  readonly corsOrigins: readonly string[];
+  readonly tickets: TicketStore;
+  /** Everything the API routes below do not claim. */
+  readonly ui: UIApp;
+};
+
+const forbidden = HttpServerResponse.text("Forbidden", { status: 403 });
+const unauthorized = HttpServerResponse.text("Unauthorized", { status: 401 });
+const notFound = HttpServerResponse.text("Not Found", { status: 404 });
+
+/**
+ * The request half of the server. The WebSocket upgrade half stays on raw
+ * `node:http` (see `server.ts`) because oRPC owns that event.
+ *
+ * Deliberately a plain sequence rather than an `HttpRouter`: the order here
+ * *is* the security policy — rebinding check, then CORS, then auth, then
+ * routes — and a router's middleware layering would obscure it. There are no
+ * path parameters anywhere, so nothing else is on offer.
+ */
+export const makeRequestApp = (
+  options: RequestAppOptions,
+): Effect.Effect<
+  HttpServerResponse.HttpServerResponse,
+  never,
+  HttpServerRequest.HttpServerRequest
+> =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+
+    // Anti DNS-rebinding: the server binds loopback, so a request whose Host
+    // is not loopback comes from an attacker page whose domain rebound to
+    // 127.0.0.1 — CORS would not stop it, this does. Answered before the CORS
+    // headers are computed, so a rebound request gets none of them.
+    if (!isLoopbackHost(request.headers.host)) {
+      return forbidden;
+    }
+
+    const headers = corsHeaders(request.headers.origin, options.corsOrigins);
+    const withCors = (response: HttpServerResponse.HttpServerResponse) =>
+      headers ? HttpServerResponse.setHeaders(response, headers) : response;
+
+    if (request.method === "OPTIONS") {
+      // A preflight from an origin we don't allow gets no headers, so the
+      // browser blocks the real request that would have followed.
+      return withCors(HttpServerResponse.empty({ status: headers ? 204 : 403 }));
+    }
+
+    const pathname = new URL(request.url, "http://localhost").pathname;
+
+    // Unauthenticated on purpose: the desktop supervisor polls this before
+    // it holds a token, and it discloses nothing.
+    if (request.method === "GET" && pathname === "/api/health") {
+      return withCors(HttpServerResponse.text("ok"));
+    }
+
+    if (options.authToken !== undefined && pathname.startsWith("/api/")) {
+      if (!tokensMatch(options.authToken, bearerToken(request.headers.authorization))) {
+        return withCors(unauthorized);
+      }
+    }
+
+    if (request.method === "POST" && pathname === "/api/ws-ticket") {
+      return withCors(HttpServerResponse.jsonUnsafe({ ticket: options.tickets.issue() }));
+    }
+
+    if (pathname.startsWith("/api/")) {
+      return withCors(notFound);
+    }
+
+    // The dev branch of the UI app writes its own bytes to the raw response, so
+    // a header added to the value it returns would never reach the socket. Set
+    // them on the socket as well; node merges `setHeader` into `writeHead`, so
+    // the static branch below still ends up with exactly one of each.
+    if (headers) {
+      const nodeResponse = NodeHttpServerRequest.toServerResponse(request);
+      for (const [name, value] of Object.entries(headers)) {
+        nodeResponse.setHeader(name, value);
+      }
+    }
+    return withCors(yield* options.ui);
+  });

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -1,13 +1,16 @@
-import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import type { Server } from "node:http";
 import { createServer as createHttpServer } from "node:http";
 
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import { Effect, Exit, Scope } from "effect";
 import type { WebSocket } from "ws";
 import { WebSocketServer } from "ws";
 
 import { createRpcRuntime, createWsRPCHandler } from "../rpc";
-import { bearerToken, createTicketStore, tokensMatch } from "./auth";
-import { corsHeaders, isAllowedOrigin, isLoopbackHost } from "./cors";
-import { createUIHandler, type UIHandler } from "./ui";
+import { makeRequestApp } from "./app";
+import { createTicketStore } from "./auth";
+import { isAllowedOrigin, isLoopbackHost } from "./cors";
+import { createUIHandler } from "./ui";
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -30,11 +33,6 @@ export type CreateServerOptions = {
   corsOrigins?: readonly string[] | undefined;
 };
 
-function notFound(res: ServerResponse) {
-  res.statusCode = 404;
-  res.end("Not Found");
-}
-
 export async function createServer(options: CreateServerOptions = {}): Promise<ManagedServer> {
   const { authToken, corsOrigins = [] } = options;
 
@@ -42,81 +40,21 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
   const wsHandler = createWsRPCHandler(rpcRuntime.context);
   const tickets = createTicketStore();
 
-  let serveUI: UIHandler;
-  let closeUI = async () => {};
+  const server = createHttpServer();
 
-  const server = createHttpServer((req, res) => {
-    void handleRequest(req, res);
-  });
-
-  async function handleRequest(req: IncomingMessage, res: ServerResponse) {
-    try {
-      // Anti DNS-rebinding: the server binds loopback, so a request whose Host
-      // is not loopback comes from an attacker page whose domain rebound to
-      // 127.0.0.1 — CORS would not stop it, this does.
-      if (!isLoopbackHost(req.headers.host)) {
-        res.statusCode = 403;
-        res.end("Forbidden");
-        return;
-      }
-
-      const headers = corsHeaders(req.headers.origin, corsOrigins);
-      if (headers) {
-        for (const [name, value] of Object.entries(headers)) {
-          res.setHeader(name, value);
-        }
-      }
-
-      if (req.method === "OPTIONS") {
-        // A preflight from an origin we don't allow gets no headers, so the
-        // browser blocks the real request that would have followed.
-        res.statusCode = headers ? 204 : 403;
-        res.end();
-        return;
-      }
-
-      const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
-
-      // Unauthenticated on purpose: the desktop supervisor polls this before
-      // it holds a token, and it discloses nothing.
-      if (req.method === "GET" && pathname === "/api/health") {
-        res.setHeader("content-type", "text/plain");
-        res.end("ok");
-        return;
-      }
-
-      if (authToken !== undefined && pathname.startsWith("/api/")) {
-        if (!tokensMatch(authToken, bearerToken(req.headers.authorization))) {
-          res.statusCode = 401;
-          res.end("Unauthorized");
-          return;
-        }
-      }
-
-      if (req.method === "POST" && pathname === "/api/ws-ticket") {
-        res.setHeader("content-type", "application/json");
-        res.end(JSON.stringify({ ticket: tickets.issue() }));
-        return;
-      }
-
-      if (pathname.startsWith("/api/")) {
-        notFound(res);
-        return;
-      }
-
-      serveUI(req, res);
-    } catch (error) {
-      console.error(error);
-      if (!res.headersSent) {
-        res.statusCode = 500;
-      }
-      res.end();
-    }
-  }
-
-  // The UI handler is Effect-native; run it on the RPC runtime rather than
-  // building a second platform layer inside this Promise-shaped module.
-  ({ serveUI, closeUI } = await rpcRuntime.run(createUIHandler(server, isDev)));
+  // The request half is Effect-native and runs on the RPC runtime, which
+  // already carries FileSystem/Path/HttpPlatform. `makeHandler` gives back a
+  // plain node `request` listener, which is the whole point: it leaves the
+  // `upgrade` event below untouched. (`HttpServer.serve` would register its own
+  // upgrade handler and fight oRPC and Vite's HMR socket for it.)
+  const { ui, closeUI } = await rpcRuntime.run(createUIHandler(server, isDev));
+  const requestScope = Scope.makeUnsafe();
+  const handleRequest = await rpcRuntime.run(
+    NodeHttpServer.makeHandler(makeRequestApp({ authToken, corsOrigins, tickets, ui }), {
+      scope: requestScope,
+    }),
+  );
+  server.on("request", handleRequest);
 
   const wss = new WebSocketServer({ noServer: true });
 
@@ -127,7 +65,9 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     console.error(e);
   });
 
-  // Share the same HTTP server between Vite's HMR socket and our custom WebSocketServer.
+  // Share the same HTTP server between Vite's HMR socket and our custom
+  // WebSocketServer. Raw on purpose: oRPC owns this event, so Effect's own
+  // websocket support (`NodeHttpServer.makeUpgradeHandler`) must stay out of it.
   server.on("upgrade", (req, socket, head) => {
     if (isDev) {
       const protocol = req.headers["sec-websocket-protocol"];
@@ -182,6 +122,8 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
       for (const client of wss.clients) client.terminate();
       await new Promise<void>((resolve) => wss.close(() => resolve()));
       await serverClosed;
+      // Interrupts any request fiber still in flight before the runtime goes.
+      await Effect.runPromise(Scope.close(requestScope, Exit.void));
       await closeUI();
       await rpcRuntime.dispose();
     })());

--- a/packages/server/src/http/ui.ts
+++ b/packages/server/src/http/ui.ts
@@ -1,15 +1,27 @@
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import { fileURLToPath } from "node:url";
 
+import * as NodeHttpServerRequest from "@effect/platform-node/NodeHttpServerRequest";
 import { Effect, FileSystem, Path } from "effect";
-import sirv from "sirv";
+import type { HttpPlatform } from "effect/unstable/http";
+import { HttpServerRequest, HttpServerResponse, HttpStaticServer } from "effect/unstable/http";
 
-export type UIHandler = (req: IncomingMessage, res: ServerResponse) => void;
+/**
+ * Answers everything the API routes did not claim. `never` on the error channel
+ * because a UI miss is a response (404 / 503), not a failure.
+ */
+export type UIApp = Effect.Effect<
+  HttpServerResponse.HttpServerResponse,
+  never,
+  HttpServerRequest.HttpServerRequest
+>;
 
-function notFound(res: ServerResponse) {
-  res.statusCode = 404;
-  res.end("Not Found");
-}
+export type UIHandler = {
+  readonly ui: UIApp;
+  readonly closeUI: () => Promise<void>;
+};
+
+const notFound = HttpServerResponse.text("Not Found", { status: 404 });
 
 /** `node:url` has no Effect equivalent; the URLs below are all module-relative. */
 const fromModuleUrl = (relative: string) => fileURLToPath(new URL(relative, import.meta.url));
@@ -42,19 +54,40 @@ const resolveStaticDir = (): Effect.Effect<
     return undefined;
   });
 
+type ConnectMiddleware = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
+
+/**
+ * Hand the request to a connect-style middleware, which writes to the raw node
+ * response itself. `NodeHttpServer`'s `handleResponse` skips a response whose
+ * socket is already ended, so the value resolved here is a placeholder for the
+ * "middleware handled it" case and a real 404 for the "it passed" case.
+ */
+const runMiddleware = (middleware: ConnectMiddleware): UIApp =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const nodeRequest = NodeHttpServerRequest.toIncomingMessage(request);
+    const nodeResponse = NodeHttpServerRequest.toServerResponse(request);
+    return yield* Effect.callback<HttpServerResponse.HttpServerResponse>((resume) => {
+      let settled = false;
+      const done = (response: HttpServerResponse.HttpServerResponse) => {
+        if (settled) return;
+        settled = true;
+        resume(Effect.succeed(response));
+      };
+      nodeResponse.once("finish", () => done(HttpServerResponse.empty()));
+      middleware(nodeRequest, nodeResponse, () => done(notFound));
+    });
+  });
+
 /**
  * The UI-serving half of the server, isolated from auth/CORS/routing: Vite
- * middleware in dev (its HMR socket shares the HTTP server), `sirv` over the
- * built bundle in prod, and a 503 when the bundle has not been built.
+ * middleware in dev (its HMR socket shares the HTTP server), `HttpStaticServer`
+ * over the built bundle in prod, and a 503 when the bundle has not been built.
  */
 export const createUIHandler = (
   server: Server,
   isDev: boolean,
-): Effect.Effect<
-  { readonly serveUI: UIHandler; readonly closeUI: () => Promise<void> },
-  never,
-  FileSystem.FileSystem | Path.Path
-> =>
+): Effect.Effect<UIHandler, never, FileSystem.FileSystem | Path.Path | HttpPlatform.HttpPlatform> =>
   Effect.gen(function* () {
     if (isDev) {
       // Import vite lazily so the production bundle never depends on it
@@ -71,7 +104,7 @@ export const createUIHandler = (
         });
       });
       return {
-        serveUI: (req, res) => vite.middlewares(req, res, () => notFound(res)),
+        ui: runMiddleware(vite.middlewares as ConnectMiddleware),
         closeUI: () => vite.close(),
       };
     }
@@ -79,17 +112,33 @@ export const createUIHandler = (
     const staticDir = yield* resolveStaticDir();
     if (!staticDir) {
       return {
-        serveUI: (_req, res) => {
-          res.statusCode = 503;
-          res.end("Web UI not built. Run the @vibest/app build first.");
-        },
+        ui: Effect.succeed(
+          HttpServerResponse.text("Web UI not built. Run the @vibest/app build first.", {
+            status: 503,
+          }),
+        ),
         closeUI: async () => {},
       };
     }
 
-    const assets = sirv(staticDir, { single: true });
+    // `spa: true` is the old `sirv(dir, { single: true })`: an unknown path
+    // falls back to index.html so the client router owns deep links.
+    const assets = yield* HttpStaticServer.make({ root: staticDir, spa: true }).pipe(Effect.orDie);
     return {
-      serveUI: (req, res) => assets(req, res, () => notFound(res)),
+      // A path that matches no file is a 404; anything else went wrong on our
+      // side. `RouteNotFound` covers both a missing asset and a deep link the
+      // SPA fallback declined (it only rewrites extensionless paths from a
+      // client that accepts HTML — a browser navigation, never a fetch).
+      ui: assets.pipe(
+        Effect.catch((error) =>
+          error.reason._tag === "RouteNotFound"
+            ? Effect.succeed(notFound)
+            : Effect.as(
+                Effect.logError("static asset read failed", error),
+                HttpServerResponse.text("Internal Server Error", { status: 500 }),
+              ),
+        ),
+      ),
       closeUI: async () => {},
     };
   });

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -1,6 +1,7 @@
 import * as NodeChildProcessSpawner from "@effect/platform-node/NodeChildProcessSpawner";
 import * as NodeCrypto from "@effect/platform-node/NodeCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodeHttpPlatform from "@effect/platform-node/NodeHttpPlatform";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { Context, Effect, Layer } from "effect";
 
@@ -126,4 +127,7 @@ export const AgentRuntimeLayer = Layer.mergeAll(
   HarnessProbeProvided,
   FileSystemServiceLayer.pipe(Layer.provide(PlatformLayer)),
   PlatformLayer,
+  // For the HTTP request app: `HttpStaticServer` needs it to turn a file into a
+  // response. Sealed by the vendor layer, hence no `Layer.provide` here.
+  NodeHttpPlatform.layer,
 );

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -23,7 +23,6 @@
     "@orpc/server": "catalog:orpc",
     "ai": "catalog:",
     "effect": "catalog:",
-    "sirv": "^3.0.2",
     "uuid": "catalog:",
     "ws": "catalog:",
     "zod": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,9 +514,6 @@ importers:
       simple-git:
         specifier: 'catalog:'
         version: 3.36.0(supports-color@7.2.0)
-      sirv:
-        specifier: ^3.0.2
-        version: 3.0.2
       uuid:
         specifier: 'catalog:'
         version: 14.0.1
@@ -667,9 +664,6 @@ importers:
       effect:
         specifier: 4.0.0-beta.97
         version: 4.0.0-beta.97
-      sirv:
-        specifier: ^3.0.2
-        version: 3.0.2
       uuid:
         specifier: 'catalog:'
         version: 14.0.1
@@ -3585,6 +3579,10 @@ packages:
     resolution: {integrity: sha512-80toEFD6s+0Le7jrYB6pHWLF703WSg0WyavAWqrBGWG8JkREHgedAxzFYgoY5GlMI756qk6Ea7UzhJTHd2zAXA==}
     engines: {node: '>=18'}
 
+  '@shaderfrog/glsl-parser@7.0.1':
+    resolution: {integrity: sha512-8mpfsoPeRhesY3pOrzNZBL8uG6N5GVX1EHLBYbd4gzKs+c7vaEIqpTNK5VrffU33qQN4cwpP2v3u4aPPBU32sw==}
+    engines: {node: '>=16'}
+
   '@shikijs/core@4.3.1':
     resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
     engines: {node: '>=20'}
@@ -5668,8 +5666,8 @@ packages:
   deslop-js@0.7.8:
     resolution: {integrity: sha512-QMmb3Z/ARvYZmZneudb8cnY/4mVvZTdhUyA9TC2skwOcm7KvY9zyOdn0TApQc4rL0VM2TffFkmo3ky/lJZX7qw==}
 
-  deslop-js@0.9.1:
-    resolution: {integrity: sha512-eo3Tn37bqC1mMS3BwsdwRITYgQQQdT30g8SMY9C/zRbMu6ekNf9o7aGNUEkxWiKd1dTND58Sndi5fBlT9V6UvA==}
+  deslop-js@0.9.2:
+    resolution: {integrity: sha512-rGhQ17gHnmsjG5KFJM4+oN4bOxktHiPGqzJxKqWt0Qw/NLZIsEgLH1wIo1tTXRyN/MNwhchKbfUieFiWyAh0pQ==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -7344,8 +7342,8 @@ packages:
     resolution: {integrity: sha512-3f9/jFLIC/KRLPYqxiXSk20cq47luGy9Oz5Ru7nK7w0EI9B9zuMvAU92bK9jFiwFE7Lc9PA8ER6Y+naYaGFQGw==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
-  oxlint-plugin-react-doctor@0.9.1:
-    resolution: {integrity: sha512-yCW8USbiuszbVsUMN4fL1iU7mRu3Ae3w96+k/xqCyWvW6bF6DzCMtLy5N/w6WLRX78iQsWxVqW/SEgzRBXLfsA==}
+  oxlint-plugin-react-doctor@0.9.2:
+    resolution: {integrity: sha512-fTciSOgAGe/KAgvFDKLz9crjxHyAuu0BvT5sXfSdo2B5QmY5Y/j3nliqX6FaGr7Wud1SYvkAky+/m+58b6K6fQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@0.24.0:
@@ -7730,8 +7728,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
-  react-doctor@0.9.1:
-    resolution: {integrity: sha512-pKCWENXuYZK7UNBHpNLbEBlpy+oVWwPnOxTD2B//gmrQLm+UvIknArzP3IOjNP5Nk1NKCR9uavypFA1QMbYFyg==}
+  react-doctor@0.9.2:
+    resolution: {integrity: sha512-A/e21t0y3j7zUTS8lJyNI2pKMfYLDH+zZwqAC7+MQW1vCD3xqWc2x8XCCWKnrQQwtFd6dwSZw2017x1iSLnGTA==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -11254,7 +11252,8 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
-  '@polka/url@1.0.0-next.29': {}
+  '@polka/url@1.0.0-next.29':
+    optional: true
 
   '@preact/signals-core@1.14.4': {}
 
@@ -11548,6 +11547,8 @@ snapshots:
       magic-string: 0.30.21
     transitivePeerDependencies:
       - supports-color
+
+  '@shaderfrog/glsl-parser@7.0.1': {}
 
   '@shikijs/core@4.3.1':
     dependencies:
@@ -13975,7 +13976,7 @@ snapshots:
       oxc-resolver: 11.23.0
       typescript: 5.9.3
 
-  deslop-js@0.9.1:
+  deslop-js@0.9.2:
     dependencies:
       '@oxc-project/types': 0.141.0
       fast-glob: 3.3.3
@@ -15849,7 +15850,8 @@ snapshots:
 
   mri@1.2.0: {}
 
-  mrmime@2.0.1: {}
+  mrmime@2.0.1:
+    optional: true
 
   ms@2.1.3: {}
 
@@ -16221,8 +16223,9 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       oxc-parser: 0.138.0
 
-  oxlint-plugin-react-doctor@0.9.1:
+  oxlint-plugin-react-doctor@0.9.2:
     dependencies:
+      '@shaderfrog/glsl-parser': 7.0.1
       '@typescript-eslint/types': 8.63.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -16733,22 +16736,23 @@ snapshots:
       - oxlint-tsgolint
       - supports-color
 
-  react-doctor@0.9.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(oxlint-tsgolint@0.24.0)(supports-color@7.2.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
+  react-doctor@0.9.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(oxlint-tsgolint@0.24.0)(supports-color@7.2.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@7.2.0)
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.9.1
+      deslop-js: 0.9.2
       eslint-plugin-react-hooks: 7.1.1(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
       figures: 6.1.0
       ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
       ink-spinner: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5)
       jiti: 2.7.0
       magicast: 0.5.3
+      oxc-resolver: 11.24.2
       oxlint: 1.74.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint-plugin-react-doctor: 0.9.1
+      oxlint-plugin-react-doctor: 0.9.2
       prompts: 2.4.2
       react: 19.2.5
       typescript: 5.9.3
@@ -16811,7 +16815,7 @@ snapshots:
       preact: 10.29.7
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.9.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(oxlint-tsgolint@0.24.0)(supports-color@7.2.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      react-doctor: 0.9.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(oxlint-tsgolint@0.24.0)(supports-color@7.2.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.50(react@19.2.7)
     optionalDependencies:
@@ -17266,6 +17270,7 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+    optional: true
 
   sisteransi@1.0.5: {}
 
@@ -17543,7 +17548,8 @@ snapshots:
 
   toml@4.1.2: {}
 
-  totalist@3.0.1: {}
+  totalist@3.0.1:
+    optional: true
 
   tough-cookie@5.1.2:
     dependencies:


### PR DESCRIPTION
Stacked on #140 — review that one first; this branch is based on it, so the diff
below is only the HTTP work.

`http/server.ts` was exempt from the platform-services sweep because "node:http,
ws, the oRPC WS handler, and Vite HMR share one server and its upgrade event".
That reason turns out to cover the *upgrade* event only. The request path can be
Effect-native without touching it.

## The seam

`HttpServer.serve` registers **both** a `request` and an `upgrade` listener
(`NodeHttpServer.ts:156-157`), so using it would put Effect's websocket handler
in a fight with oRPC and Vite's HMR socket over the same event. But
`NodeHttpServer.makeHandler` is exported separately and hands back a plain
`(req, res) => void`:

```ts
const handleRequest = await rpcRuntime.run(
  NodeHttpServer.makeHandler(makeRequestApp({ authToken, corsOrigins, tickets, ui }), {
    scope: requestScope,
  }),
);
server.on("request", handleRequest);
// server.on("upgrade", …) below is untouched — oRPC owns that event.
```

We still create the `http.Server` ourselves, which Vite's `hmr: { server }`
needs. Nothing about oRPC changes: the contract, router, `createRpcRuntime`,
`createWsRPCHandler`, the ticket consumption, the protocol sniffing that lets
`vite-hmr` through — all byte-identical.

## What the request path became

`http/app.ts` is a new `Effect<HttpServerResponse, never, HttpServerRequest>`
holding the pipeline that used to be an if-chain over raw `req`/`res`: rebinding
check → CORS → health → auth → ws-ticket → UI. Deliberately **not** an
`HttpRouter` — the order here *is* the security policy, and there are no path
parameters anywhere, so a router would only obscure it. That is a judgement
call worth arguing with in review.

One thing arrives for free: `makeHandler` interrupts the request fiber when the
client disconnects mid-response (`nodeResponse.on("close")`). Previously nothing
was cancelled.

## `sirv` → `HttpStaticServer`

The production branch of `http/ui.ts` drops the `sirv` dependency (removed from
both `packages/server` and `packages/vibest`) for `HttpStaticServer.make({ root,
spa: true })`, which also brings byte ranges and conditional `304`s. Its
dependency is `FileSystem | Path | HttpPlatform`; the first two were wired up in
#140, and `NodeHttpPlatform.layer` joins them at the composition root.

**One behaviour change, deliberate:** effect's SPA fallback only rewrites an
extensionless path from a client that accepts HTML, where `sirv`'s fallback is
unconditional (`isSPA && !isMatch(pathname, ignores)` — no extension or `Accept`
test at all). So a browser deep link still gets `index.html`, while a path that
looks like a missing file now gets a real 404. The live example is
`/favicon.ico`, which `apps/app/dist` does not contain: it used to return
`index.html` with `content-type: text/html` and a 200, and now returns 404. That
is the better answer, but it is a change.

The dev branch keeps Vite's connect middleware — supported rather than hacked:
`handleResponse` returns early when `nodeResponse.writableEnded`
(`NodeHttpServer.ts:504`), so the middleware writes its own bytes and the
placeholder response we return is ignored. CORS headers are set on the raw
socket for that branch, since a header on the ignored placeholder would never
reach the client.

## Verification

`test/http/server.test.ts` — 173 lines covering exactly this security boundary
(rebinding 403, preflight 204/403, 401 on a wrong token, ticket issue/replay,
upgrade accept/reject, browser mode) — passes **with zero assertion changes**.
That was the point of doing it this way. Full suite green: 18 turbo tasks,
server 240 passed / 2 skipped; `pnpm check` clean.

Smoke-tested both UI branches against a real server:

| | prod | dev |
|---|---|---|
| `/api/health` | 200 | 200 |
| `/` | 200 html | 200 html (react-refresh injected) |
| `/projects/abc` (browser `Accept`) | 200 html (SPA fallback) | 200 html |
| `/nope.js` | 404 | vite's own answer |
| `Range: bytes=0-10` | 206 | — |
| `ws://…/ws/rpc` upgrade | — | opens |

Then driven in a real (headless) Chrome, which is what actually exercises the
two integration risks:

- **Production.** The app boots and the sidebar lists the four real projects
  with their sessions — data that can only arrive over the oRPC WebSocket, so
  assets → SPA → `POST /api/ws-ticket` → upgrade → RPC all work end to end.
  Every request 200 (document, 6 JS chunks, CSS, font), console empty. Opening
  `/draft` directly — no client-side redirect — also renders, so the server-side
  SPA fallback is real.
- **Dev.** Same page through Vite's middleware, same four projects, and the
  console shows `[vite] connecting…` → **`[vite] connected.`** That is the one
  that mattered: Vite's HMR socket and oRPC's `/ws/rpc` still share the raw
  `upgrade` listener while the request path runs on Effect.

## Not done

`http/serve.ts` still reads `VIBEST_*` straight off `process.env`. `effect/Config`
would fit (and needs no layer — `ConfigProvider` is a `Context.Reference`
defaulting to `fromEnv()`), except `takeAuthToken` deliberately *deletes* the
variable after reading it so agent-spawned shells can't see the credential, and
`Config` has no read-then-scrub semantics. Left for its own PR.

Static serving has no automated test: `resolveStaticDir` resolves module-relative
paths with no injection point, so covering it means changing that shape first.
The table above was checked by hand instead.
