### PR TITLE
refactor(server): stop embedding vite, proxy dev traffic from the app instead

### DIFF
--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -52,10 +52,14 @@ means matching this.
   `packages/server/test/fake-file-system.ts`) for failures a real disk won't
   produce on demand.
 - **The HTTP seam is `NodeHttpServer.makeHandler`,** not `HttpServer.serve`:
-  `serve` registers its own `upgrade` listener, and that event belongs to oRPC
-  and Vite's HMR socket. `makeHandler` yields a plain node `request` listener,
-  so `http/app.ts` is an ordinary Effect while `http/server.ts` keeps the raw
-  upgrade block.
+  `serve` registers its own `upgrade` listener, and that event belongs to oRPC.
+  `makeHandler` yields a plain node `request` listener, so `http/app.ts` is an
+  ordinary Effect while `http/server.ts` keeps the raw upgrade block.
+- **`effect/unstable/socket` cannot replace `ws` here.** Its Node implementation
+  _is_ `ws` (`@effect/platform-node-shared` depends on it and re-exports it as
+  `NodeWS`), and `makeUpgradeHandler` wraps the socket into a `Socket` — while
+  oRPC wants `Pick<WebSocket, "send" | "addEventListener" | "removeEventListener">`.
+  Adopting it would add an adapter to undo the wrapper and save no dependency.
 
 Exempt, deliberately — these are boundaries Effect doesn't model, and "it's
 already written" is not a reason to add to the list:
@@ -63,7 +67,7 @@ already written" is not a reason to add to the list:
 | Location                                                                  | Why                                                                                                  |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `daemon/launcher.ts`'s `spawnDetached`                                    | detached + unref + stdio to a log fd is the opposite of `ChildProcessSpawner`'s supervised semantics |
-| `http/server.ts`'s `upgrade` path                                         | oRPC and Vite HMR share that event; Effect's own websocket handler would fight them for the listener |
+| `http/server.ts`'s `upgrade` path                                         | oRPC owns that event; Effect's own websocket handler would fight it for the listener                 |
 | Call sites inside an exempt file                                          | e.g. `http/auth.ts`'s ticket `randomUUID`, called synchronously from Promise-shaped `http/server.ts` |
 | `apps/desktop/src/main`'s Electron-bound files                            | `app-protocol`, `main-window`, `desktop-config`, `lib/utils` are tied to the Electron lifecycle      |
 | `packages/services`' terminal-manager                                     | node-pty has no Effect equivalent (and the package is dormant)                                       |

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -13,27 +13,27 @@ and Vite proxies `/api` + `/ws/rpc` across so the browser stays same-origin.
 ```bash
 # The API server (run_in_background) — no prebuild needed:
 # @vibest/harness exports src/*.ts directly and tsx resolves it.
-cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4100
+cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4180
 
 # The app (run_in_background), in a second call:
-cd apps/app && pnpm dev                   # vite on 5180 (strict), proxying to 4100
+cd apps/app && pnpm dev                   # vite on 4190 (strict), proxying to 4180
 ```
 
-Open **the Vite URL** (`http://localhost:5180/`), not the server port — the
-server only answers `/api/*`, `/ws/rpc`, and the _built_ bundle (503 until you
-`turbo run build --filter=@vibest/app`). `pnpm dev` at the root runs both through
-turbo.
+Open **the Vite URL** (`http://localhost:4190/`), not the server port — 4180
+answers `/api/*`, `/ws/rpc`, and the _built_ bundle, so it either 503s ("not
+built") or quietly serves a stale build instead of your edits. `pnpm dev` at the
+root runs both through turbo.
 
-Health check: `curl http://127.0.0.1:4100/api/health` → `ok`, and
-`curl http://localhost:5180/api/health` → `ok` proves the proxy.
+Health check: `curl http://127.0.0.1:4180/api/health` → `ok`, and
+`curl http://localhost:4190/api/health` → `ok` proves the proxy.
 
-To move the API off 4100, export `VIBEST_PORT` for **both** processes —
+To move the API off 4180, export `VIBEST_PORT` for **both** processes —
 `vite.config.ts` reads the same variable to pick its proxy target. Don't point
 it at **4000**: that is the daemon's port, which the desktop app spawns and
 guards with an auth token, so the app would load and then fail to connect
 (`/api/health` 200, `/api/ws-ticket` 401) instead of failing loudly. If the app
 loads but shows no data, check which process owns the proxy target first:
-`lsof -nP -iTCP:4100 -sTCP:LISTEN`.
+`lsof -nP -iTCP:4180 -sTCP:LISTEN`.
 
 Restarting the server no longer reloads the browser: Vite keeps the page, the
 client reconnects over the proxied WS.
@@ -46,7 +46,7 @@ Gotchas:
 - **TanStack Router's `routeTree.gen.ts` regenerates only when the Vite router
   plugin runs** — on app load through the Vite dev server, NOT on typecheck.
   After adding/renaming/deleting route files, hit the app root once
-  (`curl -o /dev/null http://localhost:5180/`) before typechecking, or typecheck
+  (`curl -o /dev/null http://localhost:4190/`) before typechecking, or typecheck
   fails against the stale tree.
 
 ## Flows worth driving

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,29 +1,37 @@
 ---
 name: verify
-description: Build/launch/drive recipe for verifying vibest web changes at runtime (tsx dev server, dynamic port)
+description: Build/launch/drive recipe for verifying vibest web changes at runtime (two processes: vite dev + the server)
 ---
 
 # Verifying vibest at runtime
 
 ## Build + launch
 
+Dev is **two processes**: Vite serves the app, the vibest server serves the API,
+and Vite proxies `/api` + `/ws/rpc` across so the browser stays same-origin.
+
 ```bash
-# Start the dev server (run_in_background) — no prebuild needed:
+# The API server (run_in_background) — no prebuild needed:
 # @vibest/harness exports src/*.ts directly and tsx resolves it.
-# Pin the port so the URL is deterministic (dev otherwise picks a random one):
-cd packages/vibest && VIBEST_PORT=4000 pnpm dev
+cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4000
+
+# The app (run_in_background), in a second call:
+cd apps/app && pnpm dev                   # vite on 5173, proxying to 4000
 ```
 
-This runs `NODE_ENV=development tsx src/node/cli.ts`: one server bound to
-`127.0.0.1` with Vite middleware serving **`apps/app`**, oRPC at `/api/rpc`, WS
-at `/ws/rpc`, health at `/api/health`.
+Open **the Vite URL** (`http://localhost:5173/`), not the server port — the
+server only answers `/api/*`, `/ws/rpc`, and the _built_ bundle (503 until you
+`turbo run build --filter=@vibest/app`). `pnpm dev` at the root runs both through
+turbo.
 
-**Port is dynamic in dev.** `readPort()` returns `0` under `NODE_ENV=development`
-(the OS assigns an ephemeral port) unless `VIBEST_PORT` is set. Either pin it
-with `VIBEST_PORT=4000` (recommended), or read the actual port from the dev
-output — the server prints `vibest:ready {"port":<PORT>}` then
-`vibest listening on http://127.0.0.1:<PORT>`. Health check:
-`curl http://127.0.0.1:<PORT>/api/health` → `ok`.
+Health check: `curl http://127.0.0.1:4000/api/health` → `ok`, and
+`curl http://localhost:5173/api/health` → `ok` proves the proxy.
+
+To move the API off 4000, export `VIBEST_PORT` for **both** processes —
+`vite.config.ts` reads the same variable to pick its proxy target.
+
+Restarting the server no longer reloads the browser: Vite keeps the page, the
+client reconnects over the proxied WS.
 
 Gotchas:
 
@@ -31,10 +39,10 @@ Gotchas:
   typecheck; `pnpm run format` to fix formatting. Typecheck one package with
   `turbo run typecheck --filter=@vibest/app`.
 - **TanStack Router's `routeTree.gen.ts` regenerates only when the Vite router
-  plugin runs** — on app load through the dev server, NOT on typecheck. After
-  adding/renaming/deleting route files, hit the app root once
-  (`curl -o /dev/null http://127.0.0.1:<PORT>/`) before typechecking, or
-  typecheck fails against the stale tree.
+  plugin runs** — on app load through the Vite dev server, NOT on typecheck.
+  After adding/renaming/deleting route files, hit the app root once
+  (`curl -o /dev/null http://localhost:5173/`) before typechecking, or typecheck
+  fails against the stale tree.
 
 ## Flows worth driving
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -13,22 +13,27 @@ and Vite proxies `/api` + `/ws/rpc` across so the browser stays same-origin.
 ```bash
 # The API server (run_in_background) — no prebuild needed:
 # @vibest/harness exports src/*.ts directly and tsx resolves it.
-cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4000
+cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4100
 
 # The app (run_in_background), in a second call:
-cd apps/app && pnpm dev                   # vite on 5173, proxying to 4000
+cd apps/app && pnpm dev                   # vite on 5180 (strict), proxying to 4100
 ```
 
-Open **the Vite URL** (`http://localhost:5173/`), not the server port — the
+Open **the Vite URL** (`http://localhost:5180/`), not the server port — the
 server only answers `/api/*`, `/ws/rpc`, and the _built_ bundle (503 until you
 `turbo run build --filter=@vibest/app`). `pnpm dev` at the root runs both through
 turbo.
 
-Health check: `curl http://127.0.0.1:4000/api/health` → `ok`, and
-`curl http://localhost:5173/api/health` → `ok` proves the proxy.
+Health check: `curl http://127.0.0.1:4100/api/health` → `ok`, and
+`curl http://localhost:5180/api/health` → `ok` proves the proxy.
 
-To move the API off 4000, export `VIBEST_PORT` for **both** processes —
-`vite.config.ts` reads the same variable to pick its proxy target.
+To move the API off 4100, export `VIBEST_PORT` for **both** processes —
+`vite.config.ts` reads the same variable to pick its proxy target. Don't point
+it at **4000**: that is the daemon's port, which the desktop app spawns and
+guards with an auth token, so the app would load and then fail to connect
+(`/api/health` 200, `/api/ws-ticket` 401) instead of failing loudly. If the app
+loads but shows no data, check which process owns the proxy target first:
+`lsof -nP -iTCP:4100 -sTCP:LISTEN`.
 
 Restarting the server no longer reloads the browser: Vite keeps the page, the
 client reconnects over the proxied WS.
@@ -41,7 +46,7 @@ Gotchas:
 - **TanStack Router's `routeTree.gen.ts` regenerates only when the Vite router
   plugin runs** — on app load through the Vite dev server, NOT on typecheck.
   After adding/renaming/deleting route files, hit the app root once
-  (`curl -o /dev/null http://localhost:5173/`) before typechecking, or typecheck
+  (`curl -o /dev/null http://localhost:5180/`) before typechecking, or typecheck
   fails against the stale tree.
 
 ## Flows worth driving

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -11,12 +11,23 @@ import { defineConfig } from "vite";
  * so this proxies the two prefixes it owns — which also keeps the app
  * same-origin with the RPC, the way it is when the server serves the built
  * bundle. Add a prefix here whenever the server grows one.
+ *
+ * 4100, not the server's own default of 4000: that port belongs to the daemon,
+ * which the desktop app spawns and which holds an auth token this browser
+ * cannot present. Proxying there answers `/api/health` but 401s the ws-ticket,
+ * so the app loads and never connects. Keep dev on a port nothing else claims.
  */
-const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4000);
+const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4100);
 const serverTarget = `http://127.0.0.1:${SERVER_PORT}`;
 
 export default defineConfig({
   server: {
+    // Pinned, and strict: 5173 is `apps/desktop`'s electron-vite renderer, so
+    // under `pnpm dev` Vite's default would silently land on 5174 — and whoever
+    // opened 5173 would get the desktop renderer, which has no proxy and never
+    // connects. Fail to boot instead of drifting to another port.
+    port: 5180,
+    strictPort: true,
     proxy: {
       "/api": { target: serverTarget, changeOrigin: true },
       "/ws/rpc": { target: serverTarget, changeOrigin: true, ws: true },

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -6,7 +6,22 @@ import react from "@vitejs/plugin-react";
 import { codeInspectorPlugin } from "code-inspector-plugin";
 import { defineConfig } from "vite";
 
+/**
+ * The dev server the browser talks to. The vibest server no longer embeds Vite,
+ * so this proxies the two prefixes it owns — which also keeps the app
+ * same-origin with the RPC, the way it is when the server serves the built
+ * bundle. Add a prefix here whenever the server grows one.
+ */
+const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4000);
+const serverTarget = `http://127.0.0.1:${SERVER_PORT}`;
+
 export default defineConfig({
+  server: {
+    proxy: {
+      "/api": { target: serverTarget, changeOrigin: true },
+      "/ws/rpc": { target: serverTarget, changeOrigin: true, ws: true },
+    },
+  },
   resolve: {
     tsconfigPaths: true,
     alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -12,21 +12,22 @@ import { defineConfig } from "vite";
  * same-origin with the RPC, the way it is when the server serves the built
  * bundle. Add a prefix here whenever the server grows one.
  *
- * 4100, not the server's own default of 4000: that port belongs to the daemon,
- * which the desktop app spawns and which holds an auth token this browser
- * cannot present. Proxying there answers `/api/health` but 401s the ws-ticket,
- * so the app loads and never connects. Keep dev on a port nothing else claims.
+ * 4180/4190 rather than 4000/5173, which are taken: 4000 is the daemon's
+ * default, spawned by the desktop app and guarded by an auth token this browser
+ * cannot present — proxying there answers `/api/health` but 401s the ws-ticket,
+ * so the app loads and silently never connects. 5173 is `apps/desktop`'s
+ * electron-vite renderer. 4180/4190 are claimed by no common dev tool. Open
+ * 4190: 4180 serves the last *built* bundle, so it works but shows stale UI.
  */
-const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4100);
+const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4180);
 const serverTarget = `http://127.0.0.1:${SERVER_PORT}`;
 
 export default defineConfig({
   server: {
-    // Pinned, and strict: 5173 is `apps/desktop`'s electron-vite renderer, so
-    // under `pnpm dev` Vite's default would silently land on 5174 — and whoever
-    // opened 5173 would get the desktop renderer, which has no proxy and never
-    // connects. Fail to boot instead of drifting to another port.
-    port: 5180,
+    // Strict, so a taken port fails the boot instead of silently drifting to
+    // the next one — that drift is how you end up reading someone else's dev
+    // server at the URL you expected to be ours.
+    port: 4190,
     strictPort: true,
     proxy: {
       "/api": { target: serverTarget, changeOrigin: true },

--- a/packages/server/src/http/app.ts
+++ b/packages/server/src/http/app.ts
@@ -1,4 +1,3 @@
-import * as NodeHttpServerRequest from "@effect/platform-node/NodeHttpServerRequest";
 import { Effect } from "effect";
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
@@ -82,15 +81,5 @@ export const makeRequestApp = (
       return withCors(notFound);
     }
 
-    // The dev branch of the UI app writes its own bytes to the raw response, so
-    // a header added to the value it returns would never reach the socket. Set
-    // them on the socket as well; node merges `setHeader` into `writeHead`, so
-    // the static branch below still ends up with exactly one of each.
-    if (headers) {
-      const nodeResponse = NodeHttpServerRequest.toServerResponse(request);
-      for (const [name, value] of Object.entries(headers)) {
-        nodeResponse.setHeader(name, value);
-      }
-    }
     return withCors(yield* options.ui);
   });

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -10,9 +10,7 @@ import { createRpcRuntime, createWsRPCHandler } from "../rpc";
 import { makeRequestApp } from "./app";
 import { createTicketStore } from "./auth";
 import { isAllowedOrigin, isLoopbackHost } from "./cors";
-import { createUIHandler } from "./ui";
-
-const isDev = process.env.NODE_ENV === "development";
+import { createUIApp } from "./ui";
 
 export type ManagedServer = Server & {
   readonly dispose: () => Promise<void>;
@@ -47,7 +45,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
   // plain node `request` listener, which is the whole point: it leaves the
   // `upgrade` event below untouched. (`HttpServer.serve` would register its own
   // upgrade handler and fight oRPC and Vite's HMR socket for it.)
-  const { ui, closeUI } = await rpcRuntime.run(createUIHandler(server, isDev));
+  const ui = await rpcRuntime.run(createUIApp());
   const requestScope = Scope.makeUnsafe();
   const handleRequest = await rpcRuntime.run(
     NodeHttpServer.makeHandler(makeRequestApp({ authToken, corsOrigins, tickets, ui }), {
@@ -65,15 +63,11 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     console.error(e);
   });
 
-  // Share the same HTTP server between Vite's HMR socket and our custom
-  // WebSocketServer. Raw on purpose: oRPC owns this event, so Effect's own
-  // websocket support (`NodeHttpServer.makeUpgradeHandler`) must stay out of it.
+  // Raw on purpose: oRPC owns this event, so Effect's own websocket support
+  // (`NodeHttpServer.makeUpgradeHandler`) must stay out of it — it hands back a
+  // `Socket`, and oRPC wants a WebSocket-shaped object. `/ws/rpc` is the only
+  // upgrade this server answers.
   server.on("upgrade", (req, socket, head) => {
-    if (isDev) {
-      const protocol = req.headers["sec-websocket-protocol"];
-      if (protocol && ["vite-ping", "vite-hmr"].includes(protocol)) return;
-    }
-
     const requestUrl = new URL(req.url ?? "/", "http://localhost");
     if (requestUrl.pathname !== "/ws/rpc") {
       socket.write("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
@@ -124,7 +118,6 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
       await serverClosed;
       // Interrupts any request fiber still in flight before the runtime goes.
       await Effect.runPromise(Scope.close(requestScope, Exit.void));
-      await closeUI();
       await rpcRuntime.dispose();
     })());
 

--- a/packages/server/src/http/ui.ts
+++ b/packages/server/src/http/ui.ts
@@ -1,7 +1,5 @@
-import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import { fileURLToPath } from "node:url";
 
-import * as NodeHttpServerRequest from "@effect/platform-node/NodeHttpServerRequest";
 import { Effect, FileSystem, Path } from "effect";
 import type { HttpPlatform } from "effect/unstable/http";
 import { HttpServerRequest, HttpServerResponse, HttpStaticServer } from "effect/unstable/http";
@@ -15,11 +13,6 @@ export type UIApp = Effect.Effect<
   never,
   HttpServerRequest.HttpServerRequest
 >;
-
-export type UIHandler = {
-  readonly ui: UIApp;
-  readonly closeUI: () => Promise<void>;
-};
 
 const notFound = HttpServerResponse.text("Not Found", { status: 404 });
 
@@ -54,91 +47,43 @@ const resolveStaticDir = (): Effect.Effect<
     return undefined;
   });
 
-type ConnectMiddleware = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
-
 /**
- * Hand the request to a connect-style middleware, which writes to the raw node
- * response itself. `NodeHttpServer`'s `handleResponse` skips a response whose
- * socket is already ended, so the value resolved here is a placeholder for the
- * "middleware handled it" case and a real 404 for the "it passed" case.
+ * The UI-serving half of the server: the built bundle, or a 503 saying it has
+ * not been built. There is no dev branch — `apps/app` runs its own `vite dev`
+ * and proxies `/api` and `/ws/rpc` here, so this server serves files in every
+ * mode and never hosts a bundler.
  */
-const runMiddleware = (middleware: ConnectMiddleware): UIApp =>
+export const createUIApp = (): Effect.Effect<
+  UIApp,
+  never,
+  FileSystem.FileSystem | Path.Path | HttpPlatform.HttpPlatform
+> =>
   Effect.gen(function* () {
-    const request = yield* HttpServerRequest.HttpServerRequest;
-    const nodeRequest = NodeHttpServerRequest.toIncomingMessage(request);
-    const nodeResponse = NodeHttpServerRequest.toServerResponse(request);
-    return yield* Effect.callback<HttpServerResponse.HttpServerResponse>((resume) => {
-      let settled = false;
-      const done = (response: HttpServerResponse.HttpServerResponse) => {
-        if (settled) return;
-        settled = true;
-        resume(Effect.succeed(response));
-      };
-      nodeResponse.once("finish", () => done(HttpServerResponse.empty()));
-      middleware(nodeRequest, nodeResponse, () => done(notFound));
-    });
-  });
-
-/**
- * The UI-serving half of the server, isolated from auth/CORS/routing: Vite
- * middleware in dev (its HMR socket shares the HTTP server), `HttpStaticServer`
- * over the built bundle in prod, and a 503 when the bundle has not been built.
- */
-export const createUIHandler = (
-  server: Server,
-  isDev: boolean,
-): Effect.Effect<UIHandler, never, FileSystem.FileSystem | Path.Path | HttpPlatform.HttpPlatform> =>
-  Effect.gen(function* () {
-    if (isDev) {
-      // Import vite lazily so the production bundle never depends on it
-      // (vite is a devDependency and marked external in tsdown.config.ts).
-      const vite = yield* Effect.promise(async () => {
-        const { createServer: createViteDevServer } = await import("vite");
-        return createViteDevServer({
-          // Serve the standalone web app package (apps/app) through this server.
-          root: fromModuleUrl("../../../../apps/app/"),
-          server: {
-            middlewareMode: true,
-            hmr: { server },
-          },
-        });
-      });
-      return {
-        ui: runMiddleware(vite.middlewares as ConnectMiddleware),
-        closeUI: () => vite.close(),
-      };
-    }
-
     const staticDir = yield* resolveStaticDir();
     if (!staticDir) {
-      return {
-        ui: Effect.succeed(
-          HttpServerResponse.text("Web UI not built. Run the @vibest/app build first.", {
-            status: 503,
-          }),
-        ),
-        closeUI: async () => {},
-      };
+      return Effect.succeed(
+        HttpServerResponse.text("Web UI not built. Run the @vibest/app build first.", {
+          status: 503,
+        }),
+      );
     }
 
     // `spa: true` is the old `sirv(dir, { single: true })`: an unknown path
     // falls back to index.html so the client router owns deep links.
     const assets = yield* HttpStaticServer.make({ root: staticDir, spa: true }).pipe(Effect.orDie);
-    return {
-      // A path that matches no file is a 404; anything else went wrong on our
-      // side. `RouteNotFound` covers both a missing asset and a deep link the
-      // SPA fallback declined (it only rewrites extensionless paths from a
-      // client that accepts HTML — a browser navigation, never a fetch).
-      ui: assets.pipe(
-        Effect.catch((error) =>
-          error.reason._tag === "RouteNotFound"
-            ? Effect.succeed(notFound)
-            : Effect.as(
-                Effect.logError("static asset read failed", error),
-                HttpServerResponse.text("Internal Server Error", { status: 500 }),
-              ),
-        ),
+
+    // A path that matches no file is a 404; anything else went wrong on our
+    // side. `RouteNotFound` covers both a missing asset and a deep link the
+    // SPA fallback declined (it only rewrites extensionless paths from a
+    // client that accepts HTML — a browser navigation, never a fetch).
+    return assets.pipe(
+      Effect.catch((error) =>
+        error.reason._tag === "RouteNotFound"
+          ? Effect.succeed(notFound)
+          : Effect.as(
+              Effect.logError("static asset read failed", error),
+              HttpServerResponse.text("Internal Server Error", { status: 500 }),
+            ),
       ),
-      closeUI: async () => {},
-    };
+    );
   });

--- a/packages/server/src/rpc/handlers.ts
+++ b/packages/server/src/rpc/handlers.ts
@@ -1,11 +1,7 @@
-import type { Buffer } from "node:buffer";
-import type * as http from "node:http";
-import type { Socket } from "node:net";
-
 import { RPCHandler as WsRPCHandler } from "@orpc/server/websocket";
 import type { Effect, Layer } from "effect";
 import { ManagedRuntime } from "effect";
-import { type WebSocket, WebSocketServer } from "ws";
+import type { WebSocket } from "ws";
 
 import type { RpcContext } from "./context";
 import { router } from "./router";
@@ -59,74 +55,5 @@ export function createWsRPCHandler(rpcContext: RpcContext) {
     wsHandler.upgrade(ws, {
       context: rpcContext,
     });
-  };
-}
-
-type DevWsLogger = Pick<Console, "error">;
-
-type DevWsRPCHandlerOptions = {
-  path: string;
-  logger?: DevWsLogger;
-};
-
-export type DevWsRPCHandler = {
-  handleUpgrade(request: http.IncomingMessage, socket: Socket, head: Buffer): boolean;
-  teardown(): void;
-};
-
-export function createDevWsRPCHandler(
-  { path, logger }: DevWsRPCHandlerOptions,
-  rpcContext: RpcContext,
-): DevWsRPCHandler {
-  const webSocketServer = new WebSocketServer({ noServer: true });
-  const upgradeHandler = createWsRPCHandler(rpcContext);
-
-  const connectionListener = (socket: WebSocket) => {
-    upgradeHandler(socket);
-  };
-
-  webSocketServer.on("connection", connectionListener);
-
-  function handleUpgrade(request: http.IncomingMessage, socket: Socket, head: Buffer): boolean {
-    let requestUrl: URL;
-
-    try {
-      requestUrl = new URL(request.url ?? "", "http://localhost");
-    } catch (error) {
-      logger?.error(`Failed to parse ORPC WebSocket request URL: ${(error as Error).message}`);
-      socket.destroy();
-      return false;
-    }
-
-    if (requestUrl.pathname !== path) {
-      return false;
-    }
-
-    try {
-      webSocketServer.handleUpgrade(request, socket, head, (ws) => {
-        connectionListener(ws);
-      });
-    } catch (error) {
-      logger?.error(`Failed to upgrade ORPC WebSocket connection: ${(error as Error).message}`);
-      socket.destroy();
-      return false;
-    }
-
-    return true;
-  }
-
-  function teardown() {
-    webSocketServer.off("connection", connectionListener);
-
-    for (const client of webSocketServer.clients) {
-      client.terminate();
-    }
-
-    webSocketServer.close();
-  }
-
-  return {
-    handleUpgrade,
-    teardown,
   };
 }

--- a/packages/server/src/rpc/index.ts
+++ b/packages/server/src/rpc/index.ts
@@ -1,10 +1,4 @@
 export type { RpcContext } from "./context";
 export { AgentRuntimeLayer, ClaudeCode, ClaudeCodeLayer, Codex, CodexLayer } from "./runtime";
-export {
-  createDevWsRPCHandler,
-  createRpcRuntime,
-  createWsRPCHandler,
-  type DevWsRPCHandler,
-  type RpcRuntime,
-} from "./handlers";
+export { createRpcRuntime, createWsRPCHandler, type RpcRuntime } from "./handlers";
 export { type Router, router } from "./router";

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -9,7 +9,7 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "VIBEST_PORT=4000 tsx src/node/cli.ts serve",
+    "dev": "VIBEST_PORT=4100 tsx src/node/cli.ts serve",
     "build": "tsdown",
     "start": "node dist/cli.mjs",
     "test": "vitest run --passWithNoTests",

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -9,7 +9,7 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "NODE_ENV=development tsx src/node/cli.ts",
+    "dev": "VIBEST_PORT=4000 tsx src/node/cli.ts serve",
     "build": "tsdown",
     "start": "node dist/cli.mjs",
     "test": "vitest run --passWithNoTests",

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -9,7 +9,7 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "VIBEST_PORT=4100 tsx src/node/cli.ts serve",
+    "dev": "VIBEST_PORT=4180 tsx src/node/cli.ts serve",
     "build": "tsdown",
     "start": "node dist/cli.mjs",
     "test": "vitest run --passWithNoTests",

--- a/packages/vibest/tsdown.config.ts
+++ b/packages/vibest/tsdown.config.ts
@@ -1,12 +1,9 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  // Keep `vite` external: server.ts imports it lazily in dev only, and it must
-  // never end up in the production bundle.
   entry: ["src/node/cli.ts"],
   platform: "node",
   deps: {
-    neverBundle: ["vite"],
     // The private server/harness/contract packages are compiled into the CLI.
     // Whitelist their bundled runtime dependencies so additions fail closed.
     onlyBundle: [


### PR DESCRIPTION
Stacked on #140 (which now contains #141).

The server hosted a Vite dev server in `NODE_ENV=development`, so that the SPA
and the RPC were same-origin. That one convenience is what forced three special
cases through the HTTP layer. `apps/app` already has its own `vite dev` script —
it just had no proxy, so nobody could use it. Giving it one lets the server drop
the bundler entirely.

## What that deletes

| | why it existed |
|---|---|
| `runMiddleware` + `ConnectMiddleware` + the `writableEnded` placeholder response | only Vite's connect middleware needed raw-response interop |
| `vite-hmr` / `vite-ping` protocol sniffing in `server.on("upgrade")` | only Vite's HMR socket shared that event |
| the raw `setHeader` CORS block in `http/app.ts` | only the Vite branch wrote its own bytes, so headers on the returned response never reached the socket |
| `createUIHandler(server, isDev)`'s `server` argument, `closeUI`, and the `isDev` flag | only HMR needed the `http.Server`, and only Vite needed closing |
| `neverBundle: ["vite"]` in `tsdown.config.ts` | the production CLI could otherwise swallow a bundler |

`http/ui.ts` goes from 144 lines to 87 and now has one job: serve the built
bundle, or say it isn't built. The upgrade handler answers exactly one path.

Also removed: `createDevWsRPCHandler` (75 lines in `rpc/handlers.ts`) — zero
consumers, a leftover of an earlier "the Vite plugin hosts the RPC" design that
this change makes permanently moot.

## What replaces it

```ts
// apps/app/vite.config.ts
const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4000);
server: {
  proxy: {
    "/api": { target: serverTarget, changeOrigin: true },
    "/ws/rpc": { target: serverTarget, changeOrigin: true, ws: true },
  },
},
```

Both processes read `VIBEST_PORT` and default to 4000, so they stay in sync;
override it for both to move the API. `packages/vibest`'s dev script becomes
`VIBEST_PORT=4000 tsx src/node/cli.ts serve` — a foreground server rather than
the daemon it used to spawn, which also drops the auth token that made browser
dev awkward (the daemon minted one the browser could not present, so
`/api/ws-ticket` answered 401).

The security policy needed no changes: the proxy forwards the browser's
`Origin: http://localhost:5173`, which `cors.ts`'s loopback pattern already
allows, and `changeOrigin` rewrites `Host` to `127.0.0.1:4000`, which
`isLoopbackHost` already accepts.

## The dev experience is better, not just simpler

Verified in a real browser against the split setup:

- **Editing app source hot-updates as before.** Changed a sidebar string, saw it
  in the DOM within seconds, reverted it, saw it revert — no reload.
- **Editing server code no longer nukes the page.** Set a marker on `window`,
  killed the server, restarted it: the marker survived (so the page never
  reloaded) and the project list came back over the reconnected WS. Under the
  old setup Vite died with the server and the page needed a full reload.
- The app renders its four real projects through the proxied WebSocket, so
  assets → `POST /api/ws-ticket` → upgrade → oRPC all work across the proxy.
- `curl localhost:5173/api/health` → `ok` proves the HTTP half.

`.claude/skills/verify` is updated to the two-process flow; it described the
embedded server and would have sent the next agent down a dead path.

## Cost, honestly

The proxy is a new moving part: a server route outside `/api` and `/ws/rpc` will
404 in dev until `vite.config.ts` learns the prefix. Same-origin used to make
that automatic. The comment above the proxy block says so.

`vibest serve` under `NODE_ENV=development` now returns 503 for `/` unless the
app has been built. That seems more honest than shipping a bundler inside the
production CLI, but it is a change in behaviour.

Full suite green: 11 typecheck tasks, 9 test tasks (server 240 passed / 2
skipped), `pnpm check` clean. `test/http/server.test.ts` still passes unchanged
— the upgrade path lost only the Vite branch.
