### PR TITLE
feat: add @vibest/effect-json-store and adopt it for storage/ persistence

### DIFF
--- a/docs/design/effect-json-store-api-rfc.md
+++ b/docs/design/effect-json-store-api-rfc.md
@@ -1,0 +1,316 @@
+# RFC: `effect-json-store` 公开 API
+
+- 状态：已采纳（形态定案：`makeJsonDocument` / `makeJsonCollection` 双入口 + 平铺 `migrations` 数组，实现已对齐；曾短暂采用链式 `defineSchema().to()`，经调研 zod-file 后替换；单入口时代曾名 `makeStore`）
+- 日期：2026-07-28
+- 实现：`packages/effect-json-store`（已按本 RFC 命名落地）
+
+## 1. 背景与动机
+
+调研结论（2026-07-28 深度调研，25 条声明对抗验证）：
+
+- **conf** 是"JSON 文件读写 + schema 校验 + 迁移"一体化的事实标准，但迁移功能被作者本人声明**不提供支持、有已知 bug、无修复计划**；其 semver key 联动宿主 `package.json` version 的设计是主要坑源。
+- **verzod / json-up** 证明了"每版本一个 schema + `up()` 转换"的类型化迁移链是正确设计，但二者都不做文件 I/O。
+- **electron-conf** 证明了整数版本号 + 构造时逐级执行的迁移引擎足够简单可靠。
+
+本库综合三者：**整数版本链 + 每版本 Effect Schema + up() 转换 + 原子文件读写**，Effect v4 原生。
+
+### 目标
+
+1. `up()` 的入参类型自动从上一版本 schema 推导，零手写标注。
+2. 旧版本数据先经其所属版本的 schema 校验，再进入迁移函数（垃圾数据不被"成功迁移"）。
+3. 版本号不可能跳号、重号（隐式编号）。
+4. 迁移原子性：唯一落盘点是最后的 tmp+rename，中途任何失败磁盘上仍是完整旧文件。
+5. 错误全部 tagged，corrupt 文件 fail loud、绝不自动重置。
+
+### 非目标
+
+- 文件 watch（跨进程变更感知）、变更钩子/生命周期 hooks（曾实现 beforeMigration/onChange 后删除——需要通知时在消费方包装层做）、加密（conf 的包袱：密钥在代码里只是混淆）。
+- ~~dot-notation~~ 后续已加入（类型安全版 `getKey`/`setKey`，见 §2）。
+- 多进程写协调（单进程内用信号量串行化；跨进程是消费方的问题）。
+
+## 2. 核心概念
+
+两个入口，共享同一套信封/校验/迁移/原子写引擎（内部 `codec.ts`），语义借用 Firestore 的 document/collection 词汇：
+
+- **`makeJsonDocument`** — 单例文件（settings.json、projects.json 这类）：`defaults` 必填、构造时急加载、内存缓存、信号量串行化写。
+- **`makeJsonCollection`** — 目录里的键控记录（`<dir>/<id>.json`，如 sessions）：不存在是 `Option.none` 而非错误、绝不种子化、无缓存、有 `list`/`remove`。
+
+`schema` 都是当前（最新版）的 Effect Schema，历史版本放在平铺的 `migrations` 数组里。形态借鉴 zod-file（见 §6），关键在于**每个迁移条目和它自己版本的 schema 配对**，使 `migrate` 入参的类型推导是局部的（同一对象字面量内），不需要链式调用也不需要跨数组元素的类型体操。
+
+```ts
+import { makeJsonDocument } from "effect-json-store";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { Effect, Schema } from "effect";
+
+const SettingsV1 = Schema.Struct({ theme: Schema.String });
+const SettingsV2 = Schema.Struct({
+  theme: Schema.Literals(["light", "dark"]),
+  fontSize: Schema.Number,
+});
+const SettingsV3 = Schema.Struct({ appearance: SettingsV2 });
+
+const program = Effect.gen(function* () {
+  const store = yield* makeJsonDocument({
+    path: "/Users/me/.myapp/settings.json",
+    schema: SettingsV3, // 当前 schema；document 的值类型 = SettingsV3.Type
+    migrations: [
+      // 下标 i 的条目就是版本 i+1；当前 schema 是版本 migrations.length + 1
+      {
+        schema: SettingsV1,
+        migrate: (v1) => ({
+          // v1 类型自动从同条目的 schema 推出，无需标注
+          theme: v1.theme === "dark" ? "dark" : "light",
+          fontSize: 14,
+        }),
+      },
+      { schema: SettingsV2, migrate: (v2) => ({ appearance: v2 }) },
+    ],
+    defaults: { appearance: { theme: "light", fontSize: 14 } },
+  });
+
+  const current = yield* store.get; // 读内存缓存，永不失败
+  yield* store.set({ appearance: { theme: "dark", fontSize: 16 } });
+  const next = yield* store.update((s) => ({
+    appearance: { ...s.appearance, fontSize: s.appearance.fontSize + 2 },
+  }));
+  yield* store.load; // 外部改了文件后重读（含迁移）
+});
+
+Effect.runPromise(program.pipe(Effect.provide(NodeFileSystem.layer)));
+```
+
+设计要点：
+
+- **版本号仍然隐式**：数组下标 + 1 = 该条目的版本，当前 schema = `migrations.length + 1`。跳号、重号在构造上不可能。首版 store 直接省略 `migrations`。
+- **`migrate` 入参编译期自动推导**（mapped tuple + 同条目配对，已在 TS 7 native compiler 上验证）；**`migrate` 返回值在运行时校验**——引擎每执行一步迁移，就用下一版 schema（Type 侧，经 `encodeEffect`）校验输出，失败即 `JsonStoreMigrationError{fromVersion, toVersion}`。这比链式的编译期返回值检查晚，但校验每个中间结果反而更严格，且错误带精确版本号。
+- 迁移条目是纯数据对象，可读性对 conf/redux-persist 用户零门槛。
+
+签名：
+
+```ts
+/** schema 的最宽约束：decode/encode 不需要任何服务 */
+type AnySchema = Schema.Codec<unknown, unknown, never, never>;
+
+/** 一个被取代的版本：它的 schema + 从它迁出的函数（入参由同条目 schema 推导） */
+interface MigrationStep<S extends AnySchema> {
+  readonly schema: S;
+  readonly migrate: (data: S["Type"]) => unknown;
+}
+
+interface JsonDocumentOptions<Latest extends AnySchema, Steps extends ReadonlyArray<AnySchema>> {
+  /** 绝对路径 */
+  readonly path: string;
+  /** 当前 schema；document 的值类型 = Latest["Type"] */
+  readonly schema: Latest;
+  /** 被取代的历史版本，从旧到新；省略表示从未变过形状 */
+  readonly migrations?: { readonly [K in keyof Steps]: MigrationStep<Steps[K]> };
+  /**
+   * 无信封旧文件的收编路径：信封 decode 不过的文件改用此 schema 解码，
+   * `migrate` 到 v1 形状后走正常迁移链，写回时带上信封。不配置则报
+   * `JsonStoreFormatError`。（document 与 collection 都支持）
+   */
+  readonly legacy?: MigrationStep<Legacy>;
+  /** 文件不存在时的种子值（视为不可变） */
+  readonly defaults: Latest["Type"];
+}
+
+const makeJsonDocument: <
+  Latest extends AnySchema,
+  const Steps extends ReadonlyArray<AnySchema> = readonly [],
+>(
+  options: JsonDocumentOptions<Latest, Steps>,
+) => Effect.Effect<JsonDocument<Latest["Type"]>, JsonStoreLoadError, FileSystem.FileSystem>;
+
+interface JsonDocument<A> {
+  /** 内存缓存的当前值；makeJsonDocument 时已完成加载/迁移/种子化 */
+  readonly get: Effect.Effect<A>;
+  /** 整份替换：当前 schema encode（兼作写前校验）→ 原子写 → 更新缓存 */
+  readonly set: (value: A) => Effect.Effect<void, JsonStoreEncodeError | JsonStoreWriteError>;
+  /** 串行化的 read-modify-write；f 必须纯函数，返回新值 */
+  readonly update: (
+    f: (current: A) => A,
+  ) => Effect.Effect<A, JsonStoreEncodeError | JsonStoreWriteError>;
+  /** 类型安全 dot-notation 单键读，如 getKey("appearance.fontSize") */
+  readonly getKey: <P extends KeyPath<A>>(path: P) => Effect.Effect<KeyPathValue<A, P>>;
+  /** 类型安全 dot-notation 单键写；整值持久化 */
+  readonly setKey: <P extends KeyPath<A>>(
+    path: P,
+    value: KeyPathValue<A, P>,
+  ) => Effect.Effect<void, JsonStoreEncodeError | JsonStoreWriteError>;
+  /** 重读磁盘（含迁移），刷新缓存 */
+  readonly load: Effect.Effect<A, JsonStoreLoadError>;
+}
+```
+
+dot-notation 的路径类型（`KeyPath<A>` / `KeyPathValue<A, P>`）只穿透**必选的普通对象**：primitive、数组、可选字段都是叶子（可选对象在它自己的 key 上整体读写），因此路径在运行时不可能中途踩到 `undefined`；未知路径和值类型错误都在编译期拒绝。
+
+- `makeJsonDocument` 内部捕获一次 `FileSystem.FileSystem`，document 各方法的 R 通道为 `never`——消费方只在构造时 provide 一次。
+- 库**不内置 Context tag**：document 是泛型的，单一库级 tag 无法服务多个不同类型的配置文件。消费方按具体配置包一层（见 §4）。
+
+### 2.1 Collection
+
+对齐 Astro（`defineCollection({loader, schema})` + `getCollection`/`getEntry` → `{id, data}`）与 Fumadocs（`defineCollections({type, dir, schema})`）的 collection 概念，但面向读写而非静态构建：
+
+```ts
+const makeJsonCollection: <
+  Latest extends AnySchema,
+  const Steps extends ReadonlyArray<AnySchema> = readonly [],
+>(options: {
+  /** collection 目录的绝对路径；条目位于 `<dir>/<id>.json` */
+  readonly dir: string;
+  readonly schema: Latest;
+  /** 与 makeJsonDocument 同一契约 */
+  readonly migrations?: { readonly [K in keyof Steps]: MigrationStep<Steps[K]> };
+}) => Effect.Effect<JsonCollection<Latest["Type"]>, never, FileSystem.FileSystem>;
+
+interface JsonCollectionEntry<A> {
+  readonly id: string;
+  readonly data: A;
+}
+
+interface JsonCollection<A> {
+  /** 缺失是 Option.none（不是错误，绝不种子化）；旧版本条目迁移后写回 */
+  readonly get: (id: string) => Effect.Effect<Option.Option<A>, JsonStoreLoadError>;
+  /** 新建或整份替换：当前 schema encode → 原子写 */
+  readonly put: (
+    id: string,
+    value: A,
+  ) => Effect.Effect<void, JsonStoreEncodeError | JsonStoreWriteError>;
+  /** 删除；缺失是 no-op */
+  readonly remove: (id: string) => Effect.Effect<void, JsonStoreWriteError>;
+  /** 全部条目按 id 排序；目录不存在 = 空表；损坏条目 fail loud；有界并发（16） */
+  readonly list: (
+    filter?: (entry: JsonCollectionEntry<A>) => boolean,
+  ) => Effect.Effect<ReadonlyArray<JsonCollectionEntry<A>>, JsonStoreLoadError>;
+}
+```
+
+与 document 的语义分野：
+
+| 维度         | document                       | collection                                        |
+| ------------ | ------------------------------ | ------------------------------------------------- |
+| 寻址         | 一个固定文件                   | `<dir>/<id>.json`，id 可含 `/` 嵌套（如 `p1/s1`） |
+| 缺失         | `defaults` 种子化写盘          | `Option.none`，绝不创建文件                       |
+| 加载时机     | 构造时急加载 + 缓存            | 每次 `get`/`list` 读盘，无缓存                    |
+| 写序         | Semaphore(1) 串行化            | 无（不同 id 天然无冲突；同 id 并发是消费方问题）  |
+| 构造失败通道 | `JsonStoreLoadError`（急加载） | `never`（构造纯粹，错误推迟到操作）               |
+
+id 校验：空串、绝对路径、`.`/`..` 段一律 `Effect.die`（这是调用方 bug，不是可恢复错误）。迁移写回发生在 `get`（含 `list` 内部的 get），与 document 一致走原子写。
+
+- 命名取自 Firestore 的 document/collection 对偶；错误类型保留 `JsonStore*` 前缀作为包级伞名。
+
+## 3. 语义
+
+### 3.1 磁盘格式：信封
+
+```json
+{
+  "version": 2,
+  "data": { "theme": "dark", "fontSize": 14 }
+}
+```
+
+版本号不占用用户字段命名空间（对照：conf 的 `__internal__` 魔法键）；信封 schema 与业务 schema 解耦，先读版本、再选 schema。
+
+### 3.2 行为表
+
+| 场景                        | 行为                                                                                                                                                                                                        |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 文件不存在                  | 用 `defaults` **立即** encode + 原子写盘（目录不可写这类错误在启动时暴露，而非首次 set 时）                                                                                                                 |
+| 文件版本 > 代码已知最新     | fail `JsonStoreVersionTooNewError`，**绝不写盘**（防应用回退后静默丢数据）                                                                                                                                  |
+| JSON 损坏                   | fail `JsonStoreParseError`，**不自动重置**（对照 configstore 的 `clearInvalidConfig` 直接清空文件）；想"损坏即重置"的消费方自行 catch 后删文件重开                                                          |
+| 信封形状不对 / 版本非正整数 | fail `JsonStoreFormatError`；配置了 `legacy` 时按 legacy schema 解码（失败 → `JsonStoreDecodeError{version: 0}`）→ `migrate` 到 v1（失败 → `JsonStoreMigrationError{0,1}`）→ 走正常链并**总是写回信封格式** |
+| 文件版本 < 最新             | 旧版 schema decode（失败 → `JsonStoreDecodeError{version}`）→ 内存中逐级 `up()`（抛错 → `JsonStoreMigrationError{fromVersion,toVersion}`）→ latest encode → 原子写回新版本                                  |
+| 文件版本 == 最新            | decode 校验后直接用，**不写回**（不碰 mtime）                                                                                                                                                               |
+| 迁移原子性                  | 全程内存中，唯一落盘点是最后的 tmp+rename；任何一步失败磁盘仍是完整旧文件，下次启动重新迁移                                                                                                                 |
+| 并发 read-modify-write      | per-store `Semaphore(1)` 串行化 `set` / `update` / `load`；`get` 裸读缓存                                                                                                                                   |
+| 原子写                      | mkdir -p → 写 `<path>.<uuid>.tmp` → rename                                                                                                                                                                  |
+
+### 3.3 错误类型
+
+全部 `Data.TaggedError`，可 `Effect.catchTag` 精确处理：
+
+```
+JsonStoreReadError          读文件失败（非 not-found）
+JsonStoreWriteError         mkdir / 写 tmp / rename 失败
+JsonStoreParseError         文件存在但不是合法 JSON
+JsonStoreFormatError        JSON 合法但信封形状不对
+JsonStoreVersionTooNewError 文件版本超前 { fileVersion, latestVersion }
+JsonStoreDecodeError        data 不满足其声明版本的 schema { version }
+JsonStoreEncodeError        写盘前 latest encode 失败
+JsonStoreMigrationError     某步 migrate() 抛出或输出不过下一版 schema { fromVersion, toVersion }
+
+JsonStoreLoadError = 以上全部的联合（makeJsonDocument / load / collection get / list 的错误通道）
+```
+
+## 4. 消费方惯例（Effect 应用）
+
+```ts
+class SettingsStore extends Context.Service<SettingsStore, JsonDocument<Settings>>()(
+  "SettingsStore",
+) {}
+
+const SettingsStoreLayer: Layer.Layer<SettingsStore, JsonStoreLoadError> = Layer.effect(
+  SettingsStore,
+  makeJsonDocument({ path: settingsPath, schema: SettingsV3, migrations, defaults }),
+).pipe(Layer.provide(NodeFileSystem.layer));
+```
+
+## 5. 面向非 Effect 用户：`/promise` 门面（后续，独立 RFC 不阻塞本篇）
+
+公开发布时增加子路径导出，内部用 `ManagedRuntime` 吞掉 Effect：
+
+```ts
+import { makeJsonDocument } from "effect-json-store/promise";
+
+const store = await makeJsonDocument({ path, schema: SettingsV3, migrations, defaults });
+store.get(); // 同步读缓存
+await store.update((s) => ({ ...s, fontSize: 16 }));
+await store.close(); // dispose runtime
+```
+
+错误以异常抛出，`_tag` 保留供 `catch` 后判别。迁移条目是纯数据，两个入口共用。
+
+## 6. 已否决的替代方案
+
+| 方案                                       | 否决理由                                                                                                                                                                                                            |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 链式 builder `defineSchema(V1).to(V2, up)` | 类型安全等价（且返回值多一层编译期检查），但评审认为链式形态别扭；对照真实世界（redux-persist/zustand/RxDB/Dexie/verzod/zod-file）链式确属少数派，仅 json-up 采用。被平铺数组取代后，返回值检查由逐步运行时校验补偿 | \n  | 独立声明式 `const v2 = version(SettingsV2, v1, up)` | 类型机制与链式相同，但多出无信息量的中间变量名；引入"引用错上一版"这一新错误类别（类型碰巧兼容时静默跳版本），链式每步只能接链尾、构造上无此问题；且链式 builder 不可变、本就可拆成多个常量续写，声明式的灵活性优势不成立 |
+| 数组字面量 `versions: [{schema, up}, ...]` | TS 上下文类型化不能跨数组元素：`prev` 需手写标注且标注本身不被校验（标错版本要到运行时才炸）；强行用递归条件类型校验则报错不可读、tsgo 下推断稳定性存疑；数组顺序即版本号，merge 挪位会静默重编号                   |
+| conf 式迁移 map `migrations: { 2: fn }`    | `prev: unknown`，类型化迁移链卖点归零；旧数据不经逐版校验直接进迁移函数；显式版本号带回跳号/重号一整类错误                                                                                                          |
+| semver 版本键（conf 原版）                 | 联动宿主 package.json version 是 conf 迁移被作者弃保的坑源；调研已确认                                                                                                                                              |
+| 库内置 Context tag                         | store 泛型，单一 tag 无法服务多个配置文件；tag 属于应用层                                                                                                                                                           |
+
+## 7. 开放问题
+
+1. **npm 包名与 effect 依赖形态**：`effect-json-store` 直接依赖 effect（Effect 生态惯例），还是 peer dependency？Effect v4 仍在 beta，公开发布前需钉版本策略。
+2. **"损坏即重置"是否提供官方糖**：`onCorrupt: "fail" | "reset"` 选项，还是坚持让消费方自己 catch？当前立场：不提供，库不替用户做丢数据的决定。
+
+## 8. 从现有实现迁移
+
+已完成。相对链式版本的改动：
+
+- 删除 `defineSchema` / `VersionedSchema`（`src/schema.ts` 整个移除），`MigrationStep` / `AnySchema` 移入 `store.ts`。
+- `JsonDocumentOptions` 变为 `{ path, schema, migrations?, defaults }` 双泛型（`Latest` + mapped tuple `Steps`）。
+- 迁移引擎新增逐步运行时校验（`encodeEffect(下一版 schema)`）。
+- 测试：`typing.test.ts` 验证入参推导与无迁移形态；`migration.test.ts` 新增"迁移输出不过下一版 schema → MigrationError"用例。
+
+collection 引入后的重构（2026-07-28）：
+
+- `makeStore`/`JsonStore` 更名 `makeJsonDocument`/`JsonDocument`（`src/store.ts` → `src/document.ts`）。
+- 信封/校验/迁移/原子写引擎抽入内部 `src/codec.ts`（`makeFileCodec` → `{load, save}`），document 与 collection 共用。
+- 新增 `src/collection.ts`（`makeJsonCollection`）与 `test/collection.test.ts`。
+
+server `storage/` 接入（2026-07-28）：
+
+- 新增 `legacy` 选项（见 §2/§3.2）收编无信封存量文件。检测依据是信封 decode 失败——
+  session 旧记录体内自带 `version: 1` 但没有 `data` 键，仍会正确走 legacy 路径（有测试钉住）。
+- `packages/server/src/session/repository.ts` 改走 `makeJsonCollection`（id = `<projectId>/<sessionId>`，
+  `SessionSchema` 与 `Session` 接口的一致性由 `write`/`read` 的双向赋值在编译期兜底）；
+  `packages/server/src/project/repository.ts` 改走 `makeJsonDocument`（`Schema.Array(ProjectSchema)`，
+  defaults `[]`，构造时急加载 `Effect.orDie`——projects.json 损坏改为启动即失败，而非每次 list 报错）。
+- 对外错误面不变：`JsonStore*` 在 repository 层映射回 `StoreReadError`/`StoreWriteError`。
+- `infra/json-store.ts` 删掉无消费方的 `readJsonDir`/`removeFile`；`readJson`/`writeJsonAtomic`
+  留给 config.json（provider/mcp，本次范围外）。
+- 层构造现在含文件 I/O：测试 harness 的 `runtime.runSync(contextEffect)` 改为 `runPromise`
+  （生产路径 `createRpcRuntime` 本就是 async，不受影响）。

--- a/packages/effect-json-store/package.json
+++ b/packages/effect-json-store/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@vibest/effect-json-store",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Effect-native JSON file store with schema validation and integer-versioned migrations",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "git clean -xdf node_modules dist .turbo"
+  },
+  "dependencies": {
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@effect/platform-node": "catalog:",
+    "@effect/vitest": "catalog:",
+    "@vibest/typescript": "workspace:*"
+  },
+  "engines": {
+    "node": ">=24 <25"
+  }
+}

--- a/packages/effect-json-store/src/codec.ts
+++ b/packages/effect-json-store/src/codec.ts
@@ -1,0 +1,194 @@
+import path from "node:path";
+
+import { Effect, type FileSystem, Option, Schema } from "effect";
+
+import {
+  JsonStoreDecodeError,
+  JsonStoreEncodeError,
+  JsonStoreFormatError,
+  type JsonStoreLoadError,
+  JsonStoreMigrationError,
+  JsonStoreParseError,
+  JsonStoreReadError,
+  JsonStoreVersionTooNewError,
+  JsonStoreWriteError,
+} from "./errors";
+
+/**
+ * Any schema whose decode/encode needs no services. Documents and collections
+ * require this so their methods never leak a requirements channel.
+ */
+export type AnySchema = Schema.Codec<unknown, unknown, never, never>;
+
+/**
+ * One superseded version: its schema, plus the migration out of it. `migrate`
+ * receives data valid under this entry's own schema — pairing the two in one
+ * object is what lets TypeScript infer `data` without annotations — and
+ * returns the next version's shape, which is validated at runtime against the
+ * next schema before continuing.
+ */
+export interface MigrationStep<S extends AnySchema> {
+  readonly schema: S;
+  readonly migrate: (data: S["Type"]) => unknown;
+}
+
+/**
+ * On-disk shape: `{ "version": n, "data": { ... } }`. The envelope keeps the
+ * version outside user data (no reserved field names) and lets the engine pick
+ * the right version schema before touching `data`.
+ */
+const Envelope = Schema.Struct({
+  version: Schema.Int,
+  data: Schema.Unknown,
+});
+
+/** @internal Per-file engine shared by documents and collections. */
+export interface FileCodec {
+  /**
+   * Read, validate, and migrate one file. Returns `undefined` when the file
+   * does not exist (`JSON.parse` can never produce `undefined`, so the signal
+   * is unambiguous). A file at an older version is migrated in memory and
+   * written back atomically before returning.
+   */
+  readonly load: (file: string) => Effect.Effect<unknown | undefined, JsonStoreLoadError>;
+  /** Encode with the current schema (doubles as validation) and write atomically. */
+  readonly save: (
+    file: string,
+    value: unknown,
+  ) => Effect.Effect<void, JsonStoreEncodeError | JsonStoreWriteError>;
+}
+
+/** @internal */
+export const makeFileCodec = (
+  fs: FileSystem.FileSystem,
+  schema: AnySchema,
+  migrations: ReadonlyArray<MigrationStep<AnySchema>>,
+  legacy?: MigrationStep<AnySchema>,
+): FileCodec => {
+  const latestVersion = migrations.length + 1;
+
+  const versionSchema = (version: number): AnySchema | undefined =>
+    version === latestVersion ? schema : migrations[version - 1]?.schema;
+
+  const writeAtomic = (
+    file: string,
+    envelope: { readonly version: number; readonly data: unknown },
+  ): Effect.Effect<void, JsonStoreWriteError> =>
+    Effect.gen(function* () {
+      yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+      const tmp = `${file}.${crypto.randomUUID()}.tmp`;
+      yield* fs.writeFileString(tmp, `${JSON.stringify(envelope, null, 2)}\n`);
+      yield* fs.rename(tmp, file);
+    }).pipe(Effect.mapError((cause) => new JsonStoreWriteError({ file, cause })));
+
+  const save: FileCodec["save"] = (file, value) =>
+    Schema.encodeEffect(schema)(value).pipe(
+      Effect.mapError((cause) => new JsonStoreEncodeError({ file, cause })),
+      Effect.flatMap((data) => writeAtomic(file, { version: latestVersion, data })),
+    );
+
+  const readRaw = (file: string): Effect.Effect<string | undefined, JsonStoreReadError> =>
+    fs.readFileString(file).pipe(
+      Effect.map((raw): string | undefined => raw),
+      Effect.catch((error) =>
+        error.reason._tag === "NotFound"
+          ? Effect.succeed(undefined)
+          : Effect.fail(new JsonStoreReadError({ file, cause: error })),
+      ),
+    );
+
+  const migrateStep = (
+    file: string,
+    step: MigrationStep<AnySchema>,
+    input: unknown,
+    fromVersion: number,
+  ): Effect.Effect<unknown, JsonStoreMigrationError> =>
+    Effect.gen(function* () {
+      const toVersion = fromVersion + 1;
+      const next = versionSchema(toVersion);
+      if (next === undefined) {
+        return yield* Effect.die(new Error(`missing schema for v${toVersion}`));
+      }
+      const output = yield* Effect.try({
+        try: () => step.migrate(input),
+        catch: (cause) => new JsonStoreMigrationError({ file, fromVersion, toVersion, cause }),
+      });
+      // A migration must produce a value valid under the next version's schema;
+      // encoding validates the Type side without touching disk.
+      yield* Schema.encodeEffect(next)(output).pipe(
+        Effect.mapError(
+          (cause) => new JsonStoreMigrationError({ file, fromVersion, toVersion, cause }),
+        ),
+      );
+      return output;
+    });
+
+  const load: FileCodec["load"] = (file) =>
+    Effect.gen(function* () {
+      const raw = yield* readRaw(file);
+      if (raw === undefined) {
+        return undefined;
+      }
+      const parsed = yield* Effect.try({
+        try: () => JSON.parse(raw) as unknown,
+        catch: (cause) => new JsonStoreParseError({ file, cause }),
+      });
+      // A file that fails the envelope decode is a pre-envelope (legacy) file
+      // when `legacy` is configured, and a format error otherwise.
+      const envelope = yield* Schema.decodeUnknownEffect(Envelope)(parsed).pipe(
+        Effect.map(Option.some),
+        Effect.catch((cause) =>
+          legacy === undefined
+            ? Effect.fail(new JsonStoreFormatError({ file, cause }))
+            : Effect.succeed(Option.none<typeof Envelope.Type>()),
+        ),
+      );
+
+      // The version the on-disk bytes were decoded at; 0 marks a legacy file.
+      let version: number;
+      let value: unknown;
+      if (Option.isSome(envelope)) {
+        version = envelope.value.version;
+        if (version > latestVersion) {
+          return yield* Effect.fail(
+            new JsonStoreVersionTooNewError({ file, fileVersion: version, latestVersion }),
+          );
+        }
+        const fileSchema = versionSchema(version);
+        if (fileSchema === undefined) {
+          return yield* Effect.fail(
+            new JsonStoreFormatError({
+              file,
+              cause: `version must be a positive integer, got ${version}`,
+            }),
+          );
+        }
+        value = yield* Schema.decodeUnknownEffect(fileSchema)(envelope.value.data).pipe(
+          Effect.mapError((cause) => new JsonStoreDecodeError({ file, version, cause })),
+        );
+      } else if (legacy !== undefined) {
+        version = 0;
+        const legacyValue = yield* Schema.decodeUnknownEffect(legacy.schema)(parsed).pipe(
+          Effect.mapError((cause) => new JsonStoreDecodeError({ file, version: 0, cause })),
+        );
+        value = yield* migrateStep(file, legacy, legacyValue, 0);
+      } else {
+        return yield* Effect.die(new Error("unreachable: none implies legacy"));
+      }
+
+      for (let from = Math.max(version, 1); from < latestVersion; from++) {
+        const step = migrations[from - 1];
+        if (step === undefined) {
+          return yield* Effect.die(new Error(`missing migration for v${from}`));
+        }
+        value = yield* migrateStep(file, step, value, from);
+      }
+      // Legacy adoption (version 0) always writes back, even at a chain of one.
+      if (version < latestVersion) {
+        yield* save(file, value);
+      }
+      return value;
+    });
+
+  return { load, save };
+};

--- a/packages/effect-json-store/src/collection.ts
+++ b/packages/effect-json-store/src/collection.ts
@@ -1,0 +1,155 @@
+import path from "node:path";
+
+import { Effect, FileSystem, Option } from "effect";
+
+import { type AnySchema, makeFileCodec, type MigrationStep } from "./codec";
+import {
+  type JsonStoreEncodeError,
+  type JsonStoreLoadError,
+  JsonStoreReadError,
+  JsonStoreWriteError,
+} from "./errors";
+
+export interface JsonCollectionEntry<A> {
+  readonly id: string;
+  readonly data: A;
+}
+
+export interface JsonCollection<A> {
+  /**
+   * Read one entry. Missing is `Option.none` — never an error, and never
+   * seeded. An entry at an older version is migrated and written back.
+   */
+  readonly get: (id: string) => Effect.Effect<Option.Option<A>, JsonStoreLoadError>;
+  /** Create or replace one entry: encode with the current schema, write atomically. */
+  readonly put: (
+    id: string,
+    value: A,
+  ) => Effect.Effect<void, JsonStoreEncodeError | JsonStoreWriteError>;
+  /** Delete one entry; missing is a no-op. */
+  readonly remove: (id: string) => Effect.Effect<void, JsonStoreWriteError>;
+  /**
+   * All entries, sorted by id. Files that vanish between listing and reading
+   * are skipped; a corrupt entry fails the whole list (catch by tag to
+   * handle). A missing collection directory is an empty list.
+   */
+  readonly list: (
+    filter?: (entry: JsonCollectionEntry<A>) => boolean,
+  ) => Effect.Effect<ReadonlyArray<JsonCollectionEntry<A>>, JsonStoreLoadError>;
+}
+
+export interface JsonCollectionOptions<
+  Latest extends AnySchema,
+  Steps extends ReadonlyArray<AnySchema>,
+  Legacy extends AnySchema,
+> {
+  /** Absolute path of the collection directory; entries live at `<dir>/<id>.json`. */
+  readonly dir: string;
+  /** The current schema; the collection's entry type is `Latest["Type"]`. */
+  readonly schema: Latest;
+  /** Superseded versions, oldest first — same contract as `makeJsonDocument`. */
+  readonly migrations?: { readonly [K in keyof Steps]: MigrationStep<Steps[K]> };
+  /**
+   * Adoption path for pre-envelope entries — same contract as
+   * `makeJsonDocument`: an entry failing the envelope decode is decoded with
+   * this schema, `migrate`d into the version-1 shape, and written back in
+   * envelope form on first read.
+   */
+  readonly legacy?: MigrationStep<Legacy>;
+}
+
+/** Bounded fan-out for `list` so huge collections don't exhaust file handles. */
+const LIST_CONCURRENCY = 16;
+
+/**
+ * Open a JSON collection — a directory of keyed entries (`<dir>/<id>.json`),
+ * sharing the document engine's envelope format, schema validation, versioned
+ * migrations, and atomic writes, but with record semantics: no eager load, no
+ * cache, no defaults. Ids may contain `/` to nest entries in subdirectories
+ * (e.g. `"<projectId>/<sessionId>"`).
+ */
+export const makeJsonCollection = <
+  Latest extends AnySchema,
+  const Steps extends ReadonlyArray<AnySchema> = readonly [],
+  Legacy extends AnySchema = AnySchema,
+>(
+  options: JsonCollectionOptions<Latest, Steps, Legacy>,
+): Effect.Effect<JsonCollection<Latest["Type"]>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    type A = Latest["Type"];
+    const { dir, schema } = options;
+    const migrations = (options.migrations ?? []) as ReadonlyArray<MigrationStep<AnySchema>>;
+    const fs = yield* FileSystem.FileSystem;
+    const codec = makeFileCodec(
+      fs,
+      schema,
+      migrations,
+      options.legacy as MigrationStep<AnySchema> | undefined,
+    );
+
+    const isValidId = (id: string): boolean =>
+      id.length > 0 &&
+      !path.isAbsolute(id) &&
+      id.split("/").every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
+
+    const fileOf = (id: string): Effect.Effect<string> =>
+      isValidId(id)
+        ? Effect.succeed(path.join(dir, `${id}.json`))
+        : Effect.die(new Error(`invalid collection id: ${JSON.stringify(id)}`));
+
+    const get = (id: string): Effect.Effect<Option.Option<A>, JsonStoreLoadError> =>
+      fileOf(id).pipe(
+        Effect.flatMap((file) => codec.load(file)),
+        Effect.map((value) => (value === undefined ? Option.none<A>() : Option.some(value as A))),
+      );
+
+    const listIds: Effect.Effect<ReadonlyArray<string>, JsonStoreReadError> = fs
+      .readDirectory(dir, { recursive: true })
+      .pipe(
+        Effect.map((entries) =>
+          entries
+            .map((entry) => entry.replaceAll("\\", "/"))
+            .filter((entry) => entry.endsWith(".json"))
+            .map((entry) => entry.slice(0, -".json".length)),
+        ),
+        Effect.catch((error) =>
+          error.reason._tag === "NotFound"
+            ? Effect.succeed([])
+            : Effect.fail(new JsonStoreReadError({ file: dir, cause: error })),
+        ),
+      );
+
+    return {
+      get,
+      put: (id, value) => fileOf(id).pipe(Effect.flatMap((file) => codec.save(file, value))),
+      remove: (id) =>
+        fileOf(id).pipe(
+          Effect.flatMap((file) =>
+            fs
+              .remove(file)
+              .pipe(
+                Effect.catch((error) =>
+                  error.reason._tag === "NotFound"
+                    ? Effect.void
+                    : Effect.fail(new JsonStoreWriteError({ file, cause: error })),
+                ),
+              ),
+          ),
+        ),
+      list: (filter) =>
+        Effect.gen(function* () {
+          const ids = yield* listIds;
+          const loaded = yield* Effect.all(
+            ids.map((id) =>
+              get(id).pipe(
+                Effect.map(Option.map((data): JsonCollectionEntry<A> => ({ id, data }))),
+              ),
+            ),
+            { concurrency: LIST_CONCURRENCY },
+          );
+          const entries = loaded.flatMap((entry) => (Option.isSome(entry) ? [entry.value] : []));
+          entries.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+          return filter === undefined ? entries : entries.filter(filter);
+        }),
+    };
+  });

--- a/packages/effect-json-store/src/document.ts
+++ b/packages/effect-json-store/src/document.ts
@@ -1,0 +1,136 @@
+import { Effect, FileSystem, Ref, Semaphore } from "effect";
+
+import { type AnySchema, makeFileCodec, type MigrationStep } from "./codec";
+import type { JsonStoreEncodeError, JsonStoreLoadError, JsonStoreWriteError } from "./errors";
+import { getAtPath, type KeyPath, type KeyPathValue, setAtPath } from "./path";
+
+export interface JsonDocument<A> {
+  /** Current value from the in-memory cache; never fails. */
+  readonly get: Effect.Effect<A>;
+  /** Replace the whole value: encode with the current schema, write atomically, update the cache. */
+  readonly set: (value: A) => Effect.Effect<void, JsonStoreEncodeError | JsonStoreWriteError>;
+  /** Serialized read-modify-write; returns the new value. `f` must be pure. */
+  readonly update: (
+    f: (current: A) => A,
+  ) => Effect.Effect<A, JsonStoreEncodeError | JsonStoreWriteError>;
+  /** Read one field by typed dot-notation path, e.g. `getKey("appearance.fontSize")`. */
+  readonly getKey: <P extends KeyPath<A>>(path: P) => Effect.Effect<KeyPathValue<A, P>>;
+  /** Replace one field by typed dot-notation path; persists the whole value. */
+  readonly setKey: <P extends KeyPath<A>>(
+    path: P,
+    value: KeyPathValue<A, P>,
+  ) => Effect.Effect<void, JsonStoreEncodeError | JsonStoreWriteError>;
+  /** Re-read the file (running migrations if needed) and refresh the cache. */
+  readonly load: Effect.Effect<A, JsonStoreLoadError>;
+}
+
+export interface JsonDocumentOptions<
+  Latest extends AnySchema,
+  Steps extends ReadonlyArray<AnySchema>,
+  Legacy extends AnySchema,
+> {
+  /** Absolute path of the JSON file. */
+  readonly path: string;
+  /** The current schema; the document's value type is `Latest["Type"]`. */
+  readonly schema: Latest;
+  /**
+   * Superseded versions, oldest first: the entry at index i is version i+1,
+   * and the current `schema` is version `migrations.length + 1`. Versions are
+   * implicit in the order, so gaps and duplicates cannot exist. Omit for a
+   * document that has never changed shape.
+   */
+  readonly migrations?: { readonly [K in keyof Steps]: MigrationStep<Steps[K]> };
+  /**
+   * Adoption path for a pre-envelope file: a file whose JSON fails the
+   * `{ version, data }` envelope decode is decoded with this schema instead,
+   * `migrate`d into the version-1 shape, run through the normal chain, and
+   * written back in envelope form. Without it such a file is a
+   * {@link JsonStoreFormatError}.
+   */
+  readonly legacy?: MigrationStep<Legacy>;
+  /** Seed value written when the file does not exist yet. Treated as immutable. */
+  readonly defaults: Latest["Type"];
+}
+
+/**
+ * Open a single versioned JSON document — a standalone file with a seed value,
+ * loaded eagerly: a missing file is seeded with `defaults` immediately, an
+ * outdated file is migrated step by step in memory (each step's output is
+ * validated against the next version's schema) and written back once, and a
+ * file from a newer version fails with {@link JsonStoreVersionTooNewError}
+ * without ever being touched. Corrupt files fail loudly and are never reset.
+ *
+ * For dynamic sets of keyed records, use `makeJsonCollection` instead.
+ *
+ * The document is generic, so it ships no Context tag — wrap it in one per
+ * concrete config:
+ *
+ * ```ts
+ * class SettingsStore extends Context.Service<SettingsStore, JsonDocument<Settings>>()(
+ *   "SettingsStore",
+ * ) {}
+ *
+ * const SettingsStoreLayer = Layer.effect(
+ *   SettingsStore,
+ *   makeJsonDocument({ path: settingsPath, schema: SettingsV2, migrations: [...], defaults }),
+ * ).pipe(Layer.provide(NodeFileSystem.layer));
+ * ```
+ */
+export const makeJsonDocument = <
+  Latest extends AnySchema,
+  const Steps extends ReadonlyArray<AnySchema> = readonly [],
+  Legacy extends AnySchema = AnySchema,
+>(
+  options: JsonDocumentOptions<Latest, Steps, Legacy>,
+): Effect.Effect<JsonDocument<Latest["Type"]>, JsonStoreLoadError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    type A = Latest["Type"];
+    const { defaults, path: file, schema } = options;
+    const migrations = (options.migrations ?? []) as ReadonlyArray<MigrationStep<AnySchema>>;
+    const fs = yield* FileSystem.FileSystem;
+    const codec = makeFileCodec(
+      fs,
+      schema,
+      migrations,
+      options.legacy as MigrationStep<AnySchema> | undefined,
+    );
+
+    const loadFromDisk: Effect.Effect<A, JsonStoreLoadError> = codec
+      .load(file)
+      .pipe(
+        Effect.flatMap((value) =>
+          value === undefined
+            ? codec.save(file, defaults).pipe(Effect.as(defaults))
+            : Effect.succeed(value as A),
+        ),
+      );
+
+    const initial = yield* loadFromDisk;
+    const ref = yield* Ref.make(initial);
+    const semaphore = yield* Semaphore.make(1);
+
+    const update = (
+      f: (current: A) => A,
+    ): Effect.Effect<A, JsonStoreEncodeError | JsonStoreWriteError> =>
+      semaphore.withPermit(
+        Effect.gen(function* () {
+          const next = f(yield* Ref.get(ref));
+          yield* codec.save(file, next);
+          yield* Ref.set(ref, next);
+          return next;
+        }),
+      );
+
+    return {
+      get: Ref.get(ref),
+      set: (value) => Effect.asVoid(update(() => value)),
+      update,
+      getKey: (key) =>
+        Ref.get(ref).pipe(
+          Effect.map((value) => getAtPath(value, key) as KeyPathValue<A, typeof key>),
+        ),
+      setKey: (key, leaf) =>
+        Effect.asVoid(update((current) => setAtPath(current, key.split("."), leaf) as A)),
+      load: semaphore.withPermit(loadFromDisk.pipe(Effect.tap((value) => Ref.set(ref, value)))),
+    };
+  });

--- a/packages/effect-json-store/src/errors.ts
+++ b/packages/effect-json-store/src/errors.ts
@@ -1,0 +1,70 @@
+import { Data } from "effect";
+
+/** Reading the file failed for a reason other than it not existing. */
+export class JsonStoreReadError extends Data.TaggedError("JsonStoreReadError")<{
+  readonly file: string;
+  readonly cause: unknown;
+}> {}
+
+/** Creating the parent directory, writing the temp file, or renaming it failed. */
+export class JsonStoreWriteError extends Data.TaggedError("JsonStoreWriteError")<{
+  readonly file: string;
+  readonly cause: unknown;
+}> {}
+
+/** The file exists but is not valid JSON. Never auto-reset; the caller decides. */
+export class JsonStoreParseError extends Data.TaggedError("JsonStoreParseError")<{
+  readonly file: string;
+  readonly cause: unknown;
+}> {}
+
+/** The JSON is valid but not a `{ version, data }` envelope with a positive integer version. */
+export class JsonStoreFormatError extends Data.TaggedError("JsonStoreFormatError")<{
+  readonly file: string;
+  readonly cause: unknown;
+}> {}
+
+/**
+ * The file was written by a newer version chain than this code knows.
+ * Typical cause: the app was downgraded after an upgrade wrote the file.
+ * The store never touches the file in this state.
+ */
+export class JsonStoreVersionTooNewError extends Data.TaggedError("JsonStoreVersionTooNewError")<{
+  readonly file: string;
+  readonly fileVersion: number;
+  readonly latestVersion: number;
+}> {}
+
+/** The data does not satisfy the schema of the version the file declares. */
+export class JsonStoreDecodeError extends Data.TaggedError("JsonStoreDecodeError")<{
+  readonly file: string;
+  readonly version: number;
+  readonly cause: unknown;
+}> {}
+
+/** Encoding a value with the latest schema failed before writing to disk. */
+export class JsonStoreEncodeError extends Data.TaggedError("JsonStoreEncodeError")<{
+  readonly file: string;
+  readonly cause: unknown;
+}> {}
+
+/** A `migrate()` step threw, or produced a value that fails the next version's schema. */
+export class JsonStoreMigrationError extends Data.TaggedError("JsonStoreMigrationError")<{
+  readonly file: string;
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly cause: unknown;
+}> {}
+
+/** Everything `make`/`load` can fail with. */
+export type JsonStoreLoadError =
+  | JsonStoreReadError
+  | JsonStoreParseError
+  | JsonStoreFormatError
+  | JsonStoreVersionTooNewError
+  | JsonStoreDecodeError
+  | JsonStoreMigrationError
+  | JsonStoreEncodeError
+  | JsonStoreWriteError;
+
+export type JsonStoreError = JsonStoreLoadError;

--- a/packages/effect-json-store/src/index.ts
+++ b/packages/effect-json-store/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Effect-native JSON file storage with schema validation and integer-versioned
+ * migrations (a flat `migrations` array, one schema and one `migrate()` per
+ * superseded version, current version persisted in each file).
+ *
+ * Two shapes share one engine:
+ * - `makeJsonDocument` — a standalone file: seeded defaults, eager load, cache.
+ * - `makeJsonCollection` — a directory of keyed entries: get/put/remove/list.
+ */
+export type { AnySchema, MigrationStep } from "./codec";
+export {
+  type JsonCollection,
+  type JsonCollectionEntry,
+  type JsonCollectionOptions,
+  makeJsonCollection,
+} from "./collection";
+export { type JsonDocument, type JsonDocumentOptions, makeJsonDocument } from "./document";
+export * from "./errors";
+export type { KeyPath, KeyPathValue } from "./path";

--- a/packages/effect-json-store/src/path.ts
+++ b/packages/effect-json-store/src/path.ts
@@ -1,0 +1,53 @@
+/**
+ * Typed dot-notation paths. Traversal recurses through required plain objects
+ * only: primitives, arrays, and optional fields are leaves (an optional object
+ * is read/written as a whole at its own key), so a path can never hit
+ * `undefined` mid-way at runtime.
+ */
+type Leaf =
+  | string
+  | number
+  | boolean
+  | bigint
+  | null
+  | undefined
+  | ReadonlyArray<unknown>
+  | ((...args: never) => unknown);
+
+/** All dot-notation paths of `T`, e.g. `"appearance" | "appearance.fontSize"`. */
+export type KeyPath<T> = T extends Leaf
+  ? never
+  : {
+      [K in keyof T & string]: [NonNullable<T[K]>] extends [Leaf]
+        ? K
+        : undefined extends T[K]
+          ? K
+          : K | `${K}.${KeyPath<T[K]>}`;
+    }[keyof T & string];
+
+/** The value type at path `P` in `T`. */
+export type KeyPathValue<T, P extends string> = P extends `${infer Head}.${infer Rest}`
+  ? Head extends keyof T
+    ? KeyPathValue<T[Head], Rest>
+    : never
+  : P extends keyof T
+    ? T[P]
+    : never;
+
+/** @internal Runtime walk; the path is compile-time validated, so no guards. */
+export const getAtPath = (value: unknown, path: string): unknown =>
+  path.split(".").reduce<unknown>((acc, key) => (acc as Record<string, unknown>)[key], value);
+
+/** @internal Immutably rebuild the spine along `segments`, replacing the leaf. */
+export const setAtPath = (
+  value: unknown,
+  segments: ReadonlyArray<string>,
+  leaf: unknown,
+): unknown => {
+  const [head, ...rest] = segments;
+  if (head === undefined) {
+    return leaf;
+  }
+  const record = value as Record<string, unknown>;
+  return { ...record, [head]: setAtPath(record[head], rest, leaf) };
+};

--- a/packages/effect-json-store/test/collection.test.ts
+++ b/packages/effect-json-store/test/collection.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { it } from "@effect/vitest";
+import { Effect, FileSystem, Option, Schema } from "effect";
+
+import { makeJsonCollection } from "../src";
+import { withTmp } from "./helpers";
+
+const V1 = Schema.Struct({ title: Schema.String });
+const V2 = Schema.Struct({ title: Schema.String, starred: Schema.Boolean });
+
+it.effect("put/get round-trips, including nested ids", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const sessions = yield* makeJsonCollection({ dir: path.join(dir, "sessions"), schema: V2 });
+
+      yield* sessions.put("p1/s1", { title: "hello", starred: false });
+      assert.deepEqual(
+        yield* sessions.get("p1/s1"),
+        Option.some({ title: "hello", starred: false }),
+      );
+
+      // put replaces
+      yield* sessions.put("p1/s1", { title: "hello", starred: true });
+      assert.deepEqual(
+        yield* sessions.get("p1/s1"),
+        Option.some({ title: "hello", starred: true }),
+      );
+    }),
+  ),
+);
+
+it.effect("get of a missing entry is none and never creates a file", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const collectionDir = path.join(dir, "sessions");
+      const sessions = yield* makeJsonCollection({ dir: collectionDir, schema: V2 });
+
+      assert.deepEqual(yield* sessions.get("p1/nope"), Option.none());
+      assert.equal(yield* fs.exists(path.join(collectionDir, "p1", "nope.json")), false);
+    }),
+  ),
+);
+
+it.effect("remove deletes an entry and is a no-op when missing", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const sessions = yield* makeJsonCollection({ dir: path.join(dir, "sessions"), schema: V2 });
+      yield* sessions.put("p1/s1", { title: "x", starred: false });
+      yield* sessions.remove("p1/s1");
+      assert.deepEqual(yield* sessions.get("p1/s1"), Option.none());
+      yield* sessions.remove("p1/s1"); // idempotent
+    }),
+  ),
+);
+
+it.effect("list returns entries sorted by id, supports filter, and an absent dir is empty", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const sessions = yield* makeJsonCollection({ dir: path.join(dir, "sessions"), schema: V2 });
+
+      assert.deepEqual(yield* sessions.list(), []); // dir not created yet
+
+      yield* sessions.put("p2/s1", { title: "b", starred: false });
+      yield* sessions.put("p1/s2", { title: "a", starred: true });
+      yield* sessions.put("p1/s1", { title: "c", starred: false });
+
+      const all = yield* sessions.list();
+      assert.deepEqual(
+        all.map((entry) => entry.id),
+        ["p1/s1", "p1/s2", "p2/s1"],
+      );
+
+      const starred = yield* sessions.list((entry) => entry.data.starred);
+      assert.deepEqual(
+        starred.map((entry) => entry.id),
+        ["p1/s2"],
+      );
+    }),
+  ),
+);
+
+it.effect("get migrates an old entry and writes the new version back", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const collectionDir = path.join(dir, "sessions");
+      const file = path.join(collectionDir, "p1", "s1.json");
+      yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+      yield* fs.writeFileString(file, JSON.stringify({ version: 1, data: { title: "old" } }));
+
+      const sessions = yield* makeJsonCollection({
+        dir: collectionDir,
+        schema: V2,
+        migrations: [{ schema: V1, migrate: (v1) => ({ ...v1, starred: false }) }],
+      });
+
+      assert.deepEqual(yield* sessions.get("p1/s1"), Option.some({ title: "old", starred: false }));
+      const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
+      assert.deepEqual(parsed, { version: 2, data: { title: "old", starred: false } });
+    }),
+  ),
+);
+
+it.effect("a corrupt entry fails get and list loudly", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const collectionDir = path.join(dir, "sessions");
+      yield* fs.makeDirectory(collectionDir, { recursive: true });
+      yield* fs.writeFileString(path.join(collectionDir, "bad.json"), "{ not json");
+
+      const sessions = yield* makeJsonCollection({ dir: collectionDir, schema: V2 });
+
+      const getError = yield* Effect.flip(sessions.get("bad"));
+      assert.equal(getError._tag, "JsonStoreParseError");
+      const listError = yield* Effect.flip(sessions.list());
+      assert.equal(listError._tag, "JsonStoreParseError");
+    }),
+  ),
+);

--- a/packages/effect-json-store/test/concurrency.test.ts
+++ b/packages/effect-json-store/test/concurrency.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { it } from "@effect/vitest";
+import { Effect, FileSystem, Schema } from "effect";
+
+import { makeJsonDocument } from "../src";
+import { withTmp } from "./helpers";
+
+const V1 = Schema.Struct({ count: Schema.Number });
+
+it.effect("serializes concurrent updates so none are lost", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      const store = yield* makeJsonDocument({
+        path: file,
+        schema: V1,
+        defaults: { count: 0 },
+      });
+
+      yield* Effect.all(
+        Array.from({ length: 20 }, () => store.update((current) => ({ count: current.count + 1 }))),
+        { concurrency: "unbounded" },
+      );
+
+      assert.deepEqual(yield* store.get, { count: 20 });
+      const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
+      assert.deepEqual(parsed, { version: 1, data: { count: 20 } });
+    }),
+  ),
+);

--- a/packages/effect-json-store/test/document.test.ts
+++ b/packages/effect-json-store/test/document.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { it } from "@effect/vitest";
+import { Effect, FileSystem, Schema } from "effect";
+
+import { makeJsonDocument } from "../src";
+import { withTmp } from "./helpers";
+
+const schema = Schema.Struct({ theme: Schema.String, count: Schema.Number });
+const defaults = { theme: "light", count: 0 };
+
+it.effect("seeds a missing file with defaults immediately, creating parent directories", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "nested", "config.json");
+      const store = yield* makeJsonDocument({ path: file, schema, defaults });
+      assert.deepEqual(yield* store.get, defaults);
+      const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
+      assert.deepEqual(parsed, { version: 1, data: defaults });
+    }),
+  ),
+);
+
+it.effect("set persists atomically and a reopened store reads the value back", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      const store = yield* makeJsonDocument({ path: file, schema, defaults });
+      yield* store.set({ theme: "dark", count: 2 });
+      assert.deepEqual(yield* store.get, { theme: "dark", count: 2 });
+
+      const reopened = yield* makeJsonDocument({ path: file, schema, defaults });
+      assert.deepEqual(yield* reopened.get, { theme: "dark", count: 2 });
+
+      const leftovers = (yield* fs.readDirectory(dir)).filter((name) => name.endsWith(".tmp"));
+      assert.deepEqual(leftovers, []);
+    }),
+  ),
+);
+
+it.effect("update applies the function and returns the new value", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const file = path.join(dir, "config.json");
+      const store = yield* makeJsonDocument({ path: file, schema, defaults });
+      const next = yield* store.update((current) => ({ ...current, count: current.count + 1 }));
+      assert.equal(next.count, 1);
+      assert.deepEqual(yield* store.get, next);
+    }),
+  ),
+);
+
+it.effect("load re-reads the file after an external change", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      const store = yield* makeJsonDocument({ path: file, schema, defaults });
+      yield* fs.writeFileString(
+        file,
+        JSON.stringify({ version: 1, data: { theme: "external", count: 9 } }),
+      );
+      assert.deepEqual(yield* store.load, { theme: "external", count: 9 });
+      assert.deepEqual(yield* store.get, { theme: "external", count: 9 });
+    }),
+  ),
+);

--- a/packages/effect-json-store/test/errors.test.ts
+++ b/packages/effect-json-store/test/errors.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { it } from "@effect/vitest";
+import { Effect, FileSystem, Layer, PlatformError, Schema } from "effect";
+
+import { makeJsonDocument } from "../src";
+import { withTmp } from "./helpers";
+
+const schema = Schema.Struct({ theme: Schema.String });
+const defaults = { theme: "light" };
+
+const openWithFileContent = (content: string) =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      yield* fs.writeFileString(file, content);
+      return yield* Effect.flip(makeJsonDocument({ path: file, schema, defaults }));
+    }),
+  );
+
+it.effect("fails with JsonStoreParseError on invalid JSON and never resets the file", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      yield* fs.writeFileString(file, "{ not json");
+      const error = yield* Effect.flip(makeJsonDocument({ path: file, schema, defaults }));
+      assert.equal(error._tag, "JsonStoreParseError");
+      assert.equal(yield* fs.readFileString(file), "{ not json");
+    }),
+  ),
+);
+
+it.effect("fails with JsonStoreFormatError when the envelope has no version", () =>
+  Effect.gen(function* () {
+    const error = yield* openWithFileContent(JSON.stringify({ theme: "dark" }));
+    assert.equal(error._tag, "JsonStoreFormatError");
+  }),
+);
+
+it.effect("fails with JsonStoreFormatError when the version is not a positive integer", () =>
+  Effect.gen(function* () {
+    const error = yield* openWithFileContent(
+      JSON.stringify({ version: 0, data: { theme: "dark" } }),
+    );
+    assert.equal(error._tag, "JsonStoreFormatError");
+  }),
+);
+
+it.effect("fails with JsonStoreVersionTooNewError and leaves the file untouched", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      const original = JSON.stringify({ version: 2, data: { theme: "dark" } });
+      yield* fs.writeFileString(file, original);
+      const error = yield* Effect.flip(makeJsonDocument({ path: file, schema, defaults }));
+      assert.equal(error._tag, "JsonStoreVersionTooNewError");
+      assert.equal(error._tag === "JsonStoreVersionTooNewError" && error.fileVersion, 2);
+      assert.equal(error._tag === "JsonStoreVersionTooNewError" && error.latestVersion, 1);
+      assert.equal(yield* fs.readFileString(file), original);
+    }),
+  ),
+);
+
+it.effect("fails with JsonStoreDecodeError when latest-version data fails its schema", () =>
+  Effect.gen(function* () {
+    const error = yield* openWithFileContent(JSON.stringify({ version: 1, data: { theme: 42 } }));
+    assert.equal(error._tag, "JsonStoreDecodeError");
+  }),
+);
+
+/** Real filesystem for reads, but every write fails — for write-error injection. */
+const failingWrites = Layer.effect(
+  FileSystem.FileSystem,
+  Effect.gen(function* () {
+    const real = yield* FileSystem.FileSystem;
+    return {
+      ...real,
+      writeFileString: () =>
+        Effect.fail(
+          PlatformError.systemError({
+            _tag: "PermissionDenied",
+            module: "FileSystem",
+            method: "writeFileString",
+          }),
+        ),
+    };
+  }),
+).pipe(Layer.provide(NodeFileSystem.layer));
+
+it.effect(
+  "fails with JsonStoreWriteError when seeding cannot write, keeping migrations atomic",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const dir = yield* fs.makeTempDirectoryScoped();
+      const file = path.join(dir, "config.json");
+
+      // Seed write fails.
+      const seedError = yield* Effect.flip(
+        makeJsonDocument({ path: file, schema, defaults }).pipe(Effect.provide(failingWrites)),
+      );
+      assert.equal(seedError._tag, "JsonStoreWriteError");
+
+      // A migration whose write-back fails leaves the old file byte-identical.
+      const original = JSON.stringify({ version: 1, data: { theme: "dark" } });
+      yield* fs.writeFileString(file, original);
+      const V2 = Schema.Struct({ theme: Schema.String, fontSize: Schema.Number });
+      const migrateError = yield* Effect.flip(
+        makeJsonDocument({
+          path: file,
+          schema: V2,
+          migrations: [{ schema, migrate: (prev) => ({ ...prev, fontSize: 14 }) }],
+          defaults: { theme: "x", fontSize: 1 },
+        }).pipe(Effect.provide(failingWrites)),
+      );
+      assert.equal(migrateError._tag, "JsonStoreWriteError");
+      assert.equal(yield* fs.readFileString(file), original);
+    }).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer)),
+);

--- a/packages/effect-json-store/test/helpers.ts
+++ b/packages/effect-json-store/test/helpers.ts
@@ -1,0 +1,12 @@
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { Effect, FileSystem } from "effect";
+
+/** Run `f` against a scoped temp directory with the real Node FileSystem provided. */
+export const withTmp = <A, E>(
+  f: (dir: string) => Effect.Effect<A, E, FileSystem.FileSystem>,
+): Effect.Effect<A, E> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const dir = yield* Effect.orDie(fs.makeTempDirectoryScoped());
+    return yield* f(dir);
+  }).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer));

--- a/packages/effect-json-store/test/legacy.test.ts
+++ b/packages/effect-json-store/test/legacy.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { it } from "@effect/vitest";
+import { Effect, FileSystem, Option, Schema } from "effect";
+
+import { makeJsonCollection, makeJsonDocument } from "../src";
+import { withTmp } from "./helpers";
+
+const V1 = Schema.Struct({ theme: Schema.String });
+const V2 = Schema.Struct({ theme: Schema.String, fontSize: Schema.Number });
+
+// Pre-envelope shape: a bare object with a differently-named field.
+const LegacyShape = Schema.Struct({ colour: Schema.String });
+const legacy = {
+  schema: LegacyShape,
+  migrate: (old: typeof LegacyShape.Type) => ({ theme: old.colour }),
+};
+
+it.effect("document adopts a pre-envelope file and writes it back in envelope form", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      yield* fs.writeFileString(file, JSON.stringify({ colour: "dark" }));
+
+      const store = yield* makeJsonDocument({
+        path: file,
+        schema: V1,
+        legacy,
+        defaults: { theme: "light" },
+      });
+      assert.deepEqual(yield* store.get, { theme: "dark" });
+
+      const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
+      assert.deepEqual(parsed, { version: 1, data: { theme: "dark" } });
+    }),
+  ),
+);
+
+it.effect("a legacy body carrying an integer `version` field still takes the legacy path", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      // The session-record case: the bare body has `version: 1` but no `data`
+      // key, so it must miss the envelope decode and be adopted as legacy.
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      yield* fs.writeFileString(file, JSON.stringify({ version: 1, theme: "dark" }));
+
+      const VersionedBody = Schema.Struct({ version: Schema.Literal(1), theme: Schema.String });
+      const store = yield* makeJsonDocument({
+        path: file,
+        schema: V1,
+        legacy: {
+          schema: VersionedBody,
+          migrate: (body) => ({ theme: body.theme }),
+        },
+        defaults: { theme: "light" },
+      });
+      assert.deepEqual(yield* store.get, { theme: "dark" });
+
+      const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
+      assert.deepEqual(parsed, { version: 1, data: { theme: "dark" } });
+    }),
+  ),
+);
+
+it.effect("a legacy file runs through the whole migration chain after adoption", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      yield* fs.writeFileString(file, JSON.stringify({ colour: "dark" }));
+
+      const store = yield* makeJsonDocument({
+        path: file,
+        schema: V2,
+        migrations: [{ schema: V1, migrate: (v1) => ({ ...v1, fontSize: 14 }) }],
+        legacy,
+        defaults: { theme: "light", fontSize: 14 },
+      });
+      assert.deepEqual(yield* store.get, { theme: "dark", fontSize: 14 });
+
+      const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
+      assert.deepEqual(parsed, { version: 2, data: { theme: "dark", fontSize: 14 } });
+    }),
+  ),
+);
+
+it.effect("a file failing the legacy schema fails with JsonStoreDecodeError version 0", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      const original = JSON.stringify({ colour: 42 });
+      yield* fs.writeFileString(file, original);
+
+      const error = yield* Effect.flip(
+        makeJsonDocument({ path: file, schema: V1, legacy, defaults: { theme: "light" } }),
+      );
+      assert.equal(error._tag, "JsonStoreDecodeError");
+      assert.equal(error._tag === "JsonStoreDecodeError" && error.version, 0);
+      // A failed adoption never touches the file.
+      assert.equal(yield* fs.readFileString(file), original);
+    }),
+  ),
+);
+
+it.effect("collection entries are adopted on first get and written back", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const collectionDir = path.join(dir, "items");
+      const file = path.join(collectionDir, "a.json");
+      yield* fs.makeDirectory(collectionDir, { recursive: true });
+      yield* fs.writeFileString(file, JSON.stringify({ colour: "red" }));
+
+      const items = yield* makeJsonCollection({ dir: collectionDir, schema: V1, legacy });
+      assert.deepEqual(yield* items.get("a"), Option.some({ theme: "red" }));
+
+      const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
+      assert.deepEqual(parsed, { version: 1, data: { theme: "red" } });
+    }),
+  ),
+);

--- a/packages/effect-json-store/test/migration.test.ts
+++ b/packages/effect-json-store/test/migration.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { it } from "@effect/vitest";
+import { Effect, FileSystem, Schema } from "effect";
+
+import { makeJsonDocument } from "../src";
+import { withTmp } from "./helpers";
+
+const V1 = Schema.Struct({ theme: Schema.String });
+const V2 = Schema.Struct({ theme: Schema.String, fontSize: Schema.Number });
+const V3 = Schema.Struct({ appearance: V2 });
+
+const defaults = { appearance: { theme: "light", fontSize: 14 } };
+
+const makeV3Store = (file: string) =>
+  makeJsonDocument({
+    path: file,
+    schema: V3,
+    migrations: [
+      { schema: V1, migrate: (v1) => ({ ...v1, fontSize: 14 }) },
+      { schema: V2, migrate: (v2) => ({ appearance: v2 }) },
+    ],
+    defaults,
+  });
+
+it.effect("migrates a v2 file one step to v3 and writes the new version back", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      yield* fs.writeFileString(
+        file,
+        JSON.stringify({ version: 2, data: { theme: "dark", fontSize: 16 } }),
+      );
+      const store = yield* makeV3Store(file);
+      assert.deepEqual(yield* store.get, { appearance: { theme: "dark", fontSize: 16 } });
+
+      const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
+      assert.deepEqual(parsed, {
+        version: 3,
+        data: { appearance: { theme: "dark", fontSize: 16 } },
+      });
+    }),
+  ),
+);
+
+it.effect("migrates a v1 file through every intermediate version in order", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      yield* fs.writeFileString(file, JSON.stringify({ version: 1, data: { theme: "dark" } }));
+      const store = yield* makeV3Store(file);
+      // v1→v2 injects fontSize 14, v2→v3 nests under appearance — order is observable.
+      assert.deepEqual(yield* store.get, { appearance: { theme: "dark", fontSize: 14 } });
+
+      const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
+      assert.deepEqual(parsed, {
+        version: 3,
+        data: { appearance: { theme: "dark", fontSize: 14 } },
+      });
+    }),
+  ),
+);
+
+it.effect("does not rewrite a file that is already at the latest version", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      // Compact formatting: any write-back would pretty-print and change the bytes.
+      const original = JSON.stringify({
+        version: 3,
+        data: { appearance: { theme: "dark", fontSize: 16 } },
+      });
+      yield* fs.writeFileString(file, original);
+      yield* makeV3Store(file);
+      assert.equal(yield* fs.readFileString(file), original);
+    }),
+  ),
+);
+
+it.effect("fails with JsonStoreDecodeError when the data does not match its declared version", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      yield* fs.writeFileString(
+        file,
+        JSON.stringify({ version: 2, data: { theme: "dark" } }), // fontSize missing for v2
+      );
+      const error = yield* Effect.flip(makeV3Store(file));
+      assert.equal(error._tag, "JsonStoreDecodeError");
+      assert.equal(error._tag === "JsonStoreDecodeError" && error.version, 2);
+    }),
+  ),
+);
+
+it.effect("fails with JsonStoreMigrationError when a migrate() step throws", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      const original = JSON.stringify({ version: 1, data: { theme: "dark" } });
+      yield* fs.writeFileString(file, original);
+      const error = yield* Effect.flip(
+        makeJsonDocument({
+          path: file,
+          schema: V2,
+          migrations: [
+            {
+              schema: V1,
+              migrate: () => {
+                throw new Error("boom");
+              },
+            },
+          ],
+          defaults: { theme: "x", fontSize: 1 },
+        }),
+      );
+      assert.equal(error._tag, "JsonStoreMigrationError");
+      // The old file must survive a failed migration untouched.
+      assert.equal(yield* fs.readFileString(file), original);
+    }),
+  ),
+);
+
+it.effect("fails with JsonStoreMigrationError when a migrate() output fails the next schema", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      const original = JSON.stringify({ version: 1, data: { theme: "dark" } });
+      yield* fs.writeFileString(file, original);
+      const error = yield* Effect.flip(
+        makeJsonDocument({
+          path: file,
+          schema: V2,
+          // fontSize missing: output is invalid under V2
+          migrations: [{ schema: V1, migrate: (v1) => ({ theme: v1.theme }) }],
+          defaults: { theme: "x", fontSize: 1 },
+        }),
+      );
+      assert.equal(error._tag, "JsonStoreMigrationError");
+      assert.equal(error._tag === "JsonStoreMigrationError" && error.fromVersion, 1);
+      assert.equal(error._tag === "JsonStoreMigrationError" && error.toVersion, 2);
+      assert.equal(yield* fs.readFileString(file), original);
+    }),
+  ),
+);

--- a/packages/effect-json-store/test/path.test.ts
+++ b/packages/effect-json-store/test/path.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+import { expectTypeOf } from "vitest";
+
+import { makeJsonDocument } from "../src";
+import { withTmp } from "./helpers";
+
+const Appearance = Schema.Struct({ theme: Schema.String, fontSize: Schema.Number });
+const Settings = Schema.Struct({ appearance: Appearance, tags: Schema.Array(Schema.String) });
+const defaults = {
+  appearance: { theme: "light", fontSize: 14 },
+  tags: [] as ReadonlyArray<string>,
+};
+
+it.effect("getKey and setKey navigate typed dot-notation paths", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const file = path.join(dir, "config.json");
+      const store = yield* makeJsonDocument({ path: file, schema: Settings, defaults });
+
+      const fontSize = yield* store.getKey("appearance.fontSize");
+      expectTypeOf(fontSize).toEqualTypeOf<number>();
+      assert.equal(fontSize, 14);
+
+      yield* store.setKey("appearance.theme", "dark");
+      assert.deepEqual(yield* store.get, {
+        appearance: { theme: "dark", fontSize: 14 },
+        tags: [],
+      });
+
+      // Arrays are leaves: replaced as a whole at their own key.
+      yield* store.setKey("tags", ["a", "b"]);
+      assert.deepEqual(yield* store.getKey("tags"), ["a", "b"]);
+
+      // setKey persists — a reopened store sees the change.
+      const reopened = yield* makeJsonDocument({ path: file, schema: Settings, defaults });
+      assert.equal(yield* reopened.getKey("appearance.theme"), "dark");
+
+      // @ts-expect-error unknown paths are rejected at compile time
+      yield* store.getKey("appearance.nope").pipe(Effect.ignore);
+      // @ts-expect-error the value type must match the path's leaf type
+      yield* store.setKey("appearance.fontSize", "big").pipe(Effect.ignore);
+    }),
+  ),
+);

--- a/packages/effect-json-store/test/typing.test.ts
+++ b/packages/effect-json-store/test/typing.test.ts
@@ -1,0 +1,48 @@
+import { Effect, FileSystem, Schema } from "effect";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { type JsonDocument, type JsonStoreLoadError, makeJsonDocument } from "../src";
+
+const V1 = Schema.Struct({ theme: Schema.String });
+const V2 = Schema.Struct({ theme: Schema.String, fontSize: Schema.Number });
+
+describe("makeJsonDocument typing", () => {
+  it("infers each migrate input from its sibling schema and the store value from `schema`", () => {
+    // Constructing the effect is pure — nothing touches the filesystem here.
+    const effect = makeJsonDocument({
+      path: "/tmp/probe.json",
+      schema: V2,
+      migrations: [
+        {
+          schema: V1,
+          migrate: (v1) => {
+            expectTypeOf(v1.theme).toEqualTypeOf<string>();
+            return { ...v1, fontSize: 14 };
+          },
+        },
+      ],
+      defaults: { theme: "light", fontSize: 14 },
+    });
+
+    const valueCheck: Effect.Effect<
+      JsonDocument<{ readonly theme: string; readonly fontSize: number }>,
+      JsonStoreLoadError,
+      FileSystem.FileSystem
+    > = effect;
+    expect(valueCheck).toBe(effect);
+  });
+
+  it("accepts a store without migrations", () => {
+    const effect = makeJsonDocument({
+      path: "/tmp/probe.json",
+      schema: V1,
+      defaults: { theme: "light" },
+    });
+    const valueCheck: Effect.Effect<
+      JsonDocument<{ readonly theme: string }>,
+      JsonStoreLoadError,
+      FileSystem.FileSystem
+    > = effect;
+    expect(valueCheck).toBe(effect);
+  });
+});

--- a/packages/effect-json-store/tsconfig.json
+++ b/packages/effect-json-store/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@vibest/typescript/base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/effect-json-store/vitest.config.ts
+++ b/packages/effect-json-store/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    typecheck: { enabled: true, tsconfig: "./tsconfig.json" },
+  },
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,7 @@
     "@orpc/experimental-effect": "catalog:orpc",
     "@orpc/server": "catalog:orpc",
     "@vibest/contract": "workspace:*",
+    "@vibest/effect-json-store": "workspace:*",
     "@vibest/harness": "workspace:*",
     "effect": "catalog:",
     "simple-git": "catalog:",

--- a/packages/server/src/infra/json-store.ts
+++ b/packages/server/src/infra/json-store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 
 import { Effect } from "effect";
 
@@ -42,45 +42,6 @@ export const writeJsonAtomic = (
       const tmp = `${file}.${randomUUID()}.tmp`;
       await writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
       await rename(tmp, file);
-    },
-    catch: (cause) => new StoreWriteError({ file, cause }),
-  });
-
-/**
- * Read every `*.json` file in a directory, parsed as `A`. A missing directory
- * yields `[]` (the collection just hasn't been written to yet). A malformed
- * file fails the whole read with `StoreReadError`.
- */
-export const readJsonDir = <A>(dir: string): Effect.Effect<ReadonlyArray<A>, StoreReadError> =>
-  Effect.tryPromise({
-    try: async () => {
-      let names: string[];
-      try {
-        names = await readdir(dir);
-      } catch (cause) {
-        if (isEnoent(cause)) return [];
-        throw cause;
-      }
-      const out: A[] = [];
-      for (const name of names) {
-        if (!name.endsWith(".json")) continue;
-        const raw = await readFile(join(dir, name), "utf8");
-        out.push(JSON.parse(raw) as A);
-      }
-      return out;
-    },
-    catch: (cause) => new StoreReadError({ file: dir, cause }),
-  });
-
-/** Delete a file. A file that is already gone is not an error. */
-export const removeFile = (file: string): Effect.Effect<void, StoreWriteError> =>
-  Effect.tryPromise({
-    try: async () => {
-      try {
-        await rm(file);
-      } catch (cause) {
-        if (!isEnoent(cause)) throw cause;
-      }
     },
     catch: (cause) => new StoreWriteError({ file, cause }),
   });

--- a/packages/server/src/project/repository.ts
+++ b/packages/server/src/project/repository.ts
@@ -1,13 +1,21 @@
-import { Context, Effect, Layer } from "effect";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { ProjectSchema } from "@vibest/contract";
+import { makeJsonDocument } from "@vibest/effect-json-store";
+import { Context, Effect, Layer, Schema } from "effect";
 
 import { Paths } from "../config/paths";
-import type { StoreReadError, StoreWriteError } from "../errors";
-import { readJson, writeJsonAtomic } from "../infra/json-store";
+import { type StoreReadError, StoreWriteError } from "../errors";
 import type { Project } from "../types";
+
+const ProjectsSchema = Schema.Array(ProjectSchema);
 
 /**
  * Data access for `$VIBEST_HOME/storage/projects.json` — plain read/write of
  * `Project[]`, no business rules (those live in ProjectService).
+ *
+ * The document is loaded (and a missing file seeded with `[]`) when the layer
+ * is built; a corrupt or unreadable file is a defect that fails startup rather
+ * than a per-call error. `list` serves the in-memory cache.
  */
 export class ProjectRepository extends Context.Service<
   ProjectRepository,
@@ -21,9 +29,21 @@ export const ProjectRepositoryLayer: Layer.Layer<ProjectRepository, never, Paths
   ProjectRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
+    const document = yield* makeJsonDocument({
+      path: paths.projectsFile,
+      schema: ProjectsSchema,
+      // Pre-envelope files are the bare Project[] array.
+      legacy: { schema: ProjectsSchema, migrate: (projects) => projects },
+      defaults: [],
+    }).pipe(Effect.orDie);
     return {
-      list: () => readJson<ReadonlyArray<Project>>(paths.projectsFile, []),
-      save: (projects) => writeJsonAtomic(paths.projectsFile, projects),
+      list: () => document.get,
+      save: (projects) =>
+        document
+          .set(projects)
+          .pipe(
+            Effect.mapError((error) => new StoreWriteError({ file: error.file, cause: error })),
+          ),
     };
   }),
-);
+).pipe(Layer.provide(NodeFileSystem.layer));

--- a/packages/server/src/session/repository.ts
+++ b/packages/server/src/session/repository.ts
@@ -1,12 +1,28 @@
-import { readdir } from "node:fs/promises";
-import { join } from "node:path";
-
-import { Context, Effect, Layer } from "effect";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { type JsonStoreLoadError, makeJsonCollection } from "@vibest/effect-json-store";
+import { Context, Effect, Layer, Option, Schema } from "effect";
 
 import { Paths } from "../config/paths";
 import { SessionNotFound, SessionRefNotFound, StoreReadError, StoreWriteError } from "../errors";
-import { isEnoent, readJson, removeFile, writeJsonAtomic } from "../infra/json-store";
 import type { Session } from "../types";
+
+/**
+ * Persistence schema for {@link Session}. Compatibility with the interface is
+ * enforced structurally: `write` checks Session → schema Type, the readers
+ * check schema Type → Session.
+ */
+const SessionSchema = Schema.Struct({
+  version: Schema.Literal(1),
+  sessionId: Schema.String,
+  projectId: Schema.String,
+  harnessAgentId: Schema.Literals(["claude-code", "codex", "pi"]),
+  harnessSessionId: Schema.String,
+  createdAt: Schema.String,
+  cwd: Schema.optionalKey(Schema.String),
+  title: Schema.optionalKey(Schema.String),
+  updatedAt: Schema.optionalKey(Schema.String),
+  historyAvailable: Schema.optionalKey(Schema.Boolean),
+});
 
 /**
  * Data access for `storage/sessions/<projectId>/<sessionId>.json`. The filename
@@ -40,96 +56,57 @@ export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths
   SessionRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
-    const projectDir = (projectId: string) => join(paths.sessionsDir, projectId);
-    const sessionFile = (projectId: string, sessionId: string) =>
-      join(projectDir(projectId), `${sessionId}.json`);
-
-    const readIds = (projectId: string): Effect.Effect<ReadonlyArray<string>, StoreReadError> =>
-      Effect.tryPromise({
-        try: async () => {
-          try {
-            const entries = await readdir(projectDir(projectId));
-            return entries
-              .filter((name) => name.endsWith(".json"))
-              .map((name) => name.slice(0, -".json".length));
-          } catch (cause) {
-            if (isEnoent(cause)) return [];
-            throw cause;
-          }
-        },
-        catch: (cause) => new StoreReadError({ file: projectDir(projectId), cause }),
-      });
-
-    const read = (
-      projectId: string,
-      sessionId: string,
-    ): Effect.Effect<Session, StoreReadError | SessionNotFound> =>
-      // JSON.parse can never produce `undefined`, so the fallback is an
-      // unambiguous "file absent" signal.
-      readJson<Session | undefined>(sessionFile(projectId, sessionId), undefined).pipe(
-        Effect.flatMap((value) =>
-          value === undefined
-            ? Effect.fail(new SessionNotFound({ projectId, sessionId }))
-            : Effect.succeed(value),
-        ),
-      );
-
-    const listProjectIds = (): Effect.Effect<ReadonlyArray<string>, StoreReadError> =>
-      Effect.tryPromise({
-        try: async () => {
-          try {
-            const entries = await readdir(paths.sessionsDir, { withFileTypes: true });
-            return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
-          } catch (cause) {
-            if (isEnoent(cause)) return [];
-            throw cause;
-          }
-        },
-        catch: (cause) => new StoreReadError({ file: paths.sessionsDir, cause }),
-      });
+    const sessions = yield* makeJsonCollection({
+      dir: paths.sessionsDir,
+      schema: SessionSchema,
+      // Pre-envelope records are the bare body, already in the v1 shape.
+      legacy: { schema: SessionSchema, migrate: (session) => session },
+    });
+    const entryId = (projectId: string, sessionId: string) => `${projectId}/${sessionId}`;
+    const asReadError = (error: JsonStoreLoadError) =>
+      new StoreReadError({ file: error.file, cause: error });
+    const asWriteError = (error: { readonly file: string }) =>
+      new StoreWriteError({ file: error.file, cause: error });
 
     return {
       list: (projectId) =>
-        readIds(projectId).pipe(
-          Effect.flatMap((ids) =>
-            Effect.forEach(
-              ids,
-              (sessionId) =>
-                read(projectId, sessionId).pipe(
-                  // A file that vanished between listing and reading is skipped,
-                  // not fatal to the whole listing.
-                  Effect.catchTag("SessionNotFound", () => Effect.succeed(null)),
-                ),
-              { concurrency: "unbounded" },
-            ),
+        sessions
+          .list((entry) => entry.data.projectId === projectId)
+          .pipe(
+            Effect.map((entries) => entries.map((entry) => entry.data)),
+            Effect.mapError(asReadError),
           ),
-          Effect.map((entries) => entries.filter((entry) => entry !== null)),
-        ),
 
-      read,
+      read: (projectId, sessionId) =>
+        sessions.get(entryId(projectId, sessionId)).pipe(
+          Effect.mapError(asReadError),
+          Effect.flatMap((found) =>
+            Option.isSome(found)
+              ? Effect.succeed(found.value)
+              : Effect.fail(new SessionNotFound({ projectId, sessionId })),
+          ),
+        ),
 
       findBySessionId: (sessionId) =>
-        listProjectIds().pipe(
-          Effect.flatMap((projectIds) =>
-            Effect.forEach(
-              projectIds,
-              (projectId) =>
-                read(projectId, sessionId).pipe(
-                  Effect.catchTag("SessionNotFound", () => Effect.succeed(null)),
-                ),
-              { concurrency: "unbounded" },
-            ),
+        sessions
+          .list((entry) => entry.data.sessionId === sessionId)
+          .pipe(
+            Effect.mapError(asReadError),
+            Effect.flatMap((hits) => {
+              const hit = hits[0];
+              return hit === undefined
+                ? Effect.fail(new SessionRefNotFound({ sessionId }))
+                : Effect.succeed(hit.data);
+            }),
           ),
-          Effect.map((hits) => hits.find((hit) => hit !== null)),
-          Effect.flatMap((hit) =>
-            hit ? Effect.succeed(hit) : Effect.fail(new SessionRefNotFound({ sessionId })),
-          ),
-        ),
 
       write: (metadata) =>
-        writeJsonAtomic(sessionFile(metadata.projectId, metadata.sessionId), metadata),
+        sessions
+          .put(entryId(metadata.projectId, metadata.sessionId), metadata)
+          .pipe(Effect.mapError(asWriteError)),
 
-      remove: (projectId, sessionId) => removeFile(sessionFile(projectId, sessionId)),
+      remove: (projectId, sessionId) =>
+        sessions.remove(entryId(projectId, sessionId)).pipe(Effect.mapError(asWriteError)),
     };
   }),
-);
+).pipe(Layer.provide(NodeFileSystem.layer));

--- a/packages/server/test/project.test.ts
+++ b/packages/server/test/project.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -77,6 +77,25 @@ describe("ProjectService", () => {
       }),
     );
     expect(remaining).toHaveLength(0);
+  });
+
+  it("reads a pre-envelope projects.json and adopts it into envelope form", async () => {
+    const file = join(home, "storage", "projects.json");
+    const project = { id: "p1", name: "app", path: "/tmp/app", createdAt: "2026-07-16T00:00:00Z" };
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify([project]), "utf8");
+
+    const listed = await run(
+      Effect.gen(function* () {
+        const svc = yield* ProjectService;
+        return yield* svc.list();
+      }),
+    );
+    expect(listed).toEqual([project]);
+
+    const raw = JSON.parse(await readFile(file, "utf8"));
+    expect(raw.version).toBe(1);
+    expect(raw.data).toEqual([project]);
   });
 
   it("remove fails with ProjectNotFound for an unknown id", async () => {

--- a/packages/server/test/rpc-fs.test.ts
+++ b/packages/server/test/rpc-fs.test.ts
@@ -14,7 +14,7 @@ describe("fs router", () => {
     mkdirSync(join(dir, "alpha"));
     mkdirSync(join(dir, ".hidden"));
     mkdirSync(join(dir, "node_modules"));
-    const h = makeRpcTestHarness(home);
+    const h = await makeRpcTestHarness(home);
     try {
       const listing = await h.client.fs.browse({ path: dir });
       expect(listing.path).toBe(dir);

--- a/packages/server/test/rpc-harness.test.ts
+++ b/packages/server/test/rpc-harness.test.ts
@@ -50,7 +50,7 @@ describe("harness router", () => {
       fakeAdapter({ id: "pi", name: "Pi", available: true }),
     ];
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-rpc-harness-"));
-    const { client, dispose } = makeRpcTestHarness(home, adapters);
+    const { client, dispose } = await makeRpcTestHarness(home, adapters);
     try {
       const { harnessAgents } = await client.harness.list({});
 

--- a/packages/server/test/rpc-harness.ts
+++ b/packages/server/test/rpc-harness.ts
@@ -28,7 +28,7 @@ import {
  * service and project storage under `home`. Tests that need live adapters
  * (rpc-session) build their own layers instead.
  */
-export function makeRpcTestHarness(
+export async function makeRpcTestHarness(
   home: string,
   adapters: ReadonlyArray<HarnessAgentAdapter> = [],
 ) {
@@ -59,8 +59,10 @@ export function makeRpcTestHarness(
       NodeFileSystem.layer,
     ),
   );
+  // Layer construction does file I/O now (the project document loads eagerly),
+  // so the context must be built asynchronously.
   const context: RpcContext = {
-    "effect/context": runtime.runSync(runtime.contextEffect),
+    "effect/context": await runtime.runPromise(runtime.contextEffect),
   };
   return {
     client: createRouterClient(router, { context }),

--- a/packages/server/test/rpc-project.test.ts
+++ b/packages/server/test/rpc-project.test.ts
@@ -10,7 +10,7 @@ describe("project router", () => {
   it("creates a project named after the folder, dedupes by path, and lists it", async () => {
     const home = mkdtempSync(join(tmpdir(), "vibest-home-"));
     const workspace = mkdtempSync(join(tmpdir(), "vibest-project-"));
-    const h = makeRpcTestHarness(home);
+    const h = await makeRpcTestHarness(home);
     try {
       const created = await h.client.project.create({ path: workspace });
       expect(created).toMatchObject({ name: basename(workspace), path: workspace });

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -58,7 +58,7 @@ function makeFake(): string {
   return file;
 }
 
-function setup() {
+async function setup() {
   const home = mkdtempSync(join(tmpdir(), "vibest-home-"));
   const workspace = mkdtempSync(join(tmpdir(), "vibest-ws-"));
   const pathsLayer = layerPaths(home);
@@ -105,8 +105,10 @@ function setup() {
     NodeServices.layer,
   );
   const runtime = ManagedRuntime.make(appLayer);
+  // Layer construction does file I/O now (the project document loads eagerly),
+  // so the context must be built asynchronously.
   const context: RpcContext = {
-    "effect/context": runtime.runSync(runtime.contextEffect),
+    "effect/context": await runtime.runPromise(runtime.contextEffect),
   };
   const client = createRouterClient(router, { context });
   return { client, workspace, dispose: () => runtime.dispose() };
@@ -114,7 +116,7 @@ function setup() {
 
 describe("session router", () => {
   it("creates a session from a project and streams its scoped events", async () => {
-    const { client, workspace, dispose } = setup();
+    const { client, workspace, dispose } = await setup();
     try {
       const project = await client.project.create({ path: workspace });
       const ref = await client.session.create({
@@ -150,7 +152,7 @@ describe("session router", () => {
   });
 
   it("lists sessions with live status and drops them on delete", async () => {
-    const { client, workspace, dispose } = setup();
+    const { client, workspace, dispose } = await setup();
     try {
       const project = await client.project.create({ path: workspace });
       const ref = await client.session.create({ projectId: project.id, harnessAgentId: "codex" });

--- a/packages/server/test/session-repository.test.ts
+++ b/packages/server/test/session-repository.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -55,8 +55,27 @@ describe("SessionRepository", () => {
     const raw = JSON.parse(
       await readFile(join(home, "storage", "sessions", "proj-a", "sess-1.json"), "utf8"),
     );
-    expect(raw.sessionId).toBe("sess-1");
-    expect(raw.projectId).toBe("proj-a");
+    expect(raw.version).toBe(1);
+    expect(raw.data.sessionId).toBe("sess-1");
+    expect(raw.data.projectId).toBe("proj-a");
+  });
+
+  it("reads a pre-envelope record and adopts it into envelope form", async () => {
+    const file = join(home, "storage", "sessions", "proj-a", "sess-1.json");
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(meta("sess-1", "proj-a", "claude-uuid-1")), "utf8");
+
+    const read = await run(
+      Effect.gen(function* () {
+        const repo = yield* SessionRepository;
+        return yield* repo.read("proj-a", "sess-1");
+      }),
+    );
+    expect(read.harnessSessionId).toBe("claude-uuid-1");
+
+    const raw = JSON.parse(await readFile(file, "utf8"));
+    expect(raw.version).toBe(1);
+    expect(raw.data.sessionId).toBe("sess-1");
   });
 
   it("lists all sessions of a project", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,22 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@7.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/effect-json-store:
+    dependencies:
+      effect:
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97
+    devDependencies:
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1(supports-color@7.2.0))
+      '@effect/vitest':
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97(effect@4.0.0-beta.97)(vitest@4.1.10)
+      '@vibest/typescript':
+        specifier: workspace:*
+        version: link:../../tools/typescript
+
   packages/harness:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
@@ -505,6 +521,9 @@ importers:
       '@vibest/contract':
         specifier: workspace:*
         version: link:../contract
+      '@vibest/effect-json-store':
+        specifier: workspace:*
+        version: link:../effect-json-store
       '@vibest/harness':
         specifier: workspace:*
         version: link:../harness
@@ -3585,6 +3604,10 @@ packages:
     resolution: {integrity: sha512-80toEFD6s+0Le7jrYB6pHWLF703WSg0WyavAWqrBGWG8JkREHgedAxzFYgoY5GlMI756qk6Ea7UzhJTHd2zAXA==}
     engines: {node: '>=18'}
 
+  '@shaderfrog/glsl-parser@7.0.1':
+    resolution: {integrity: sha512-8mpfsoPeRhesY3pOrzNZBL8uG6N5GVX1EHLBYbd4gzKs+c7vaEIqpTNK5VrffU33qQN4cwpP2v3u4aPPBU32sw==}
+    engines: {node: '>=16'}
+
   '@shikijs/core@4.3.1':
     resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
     engines: {node: '>=20'}
@@ -5668,8 +5691,8 @@ packages:
   deslop-js@0.7.8:
     resolution: {integrity: sha512-QMmb3Z/ARvYZmZneudb8cnY/4mVvZTdhUyA9TC2skwOcm7KvY9zyOdn0TApQc4rL0VM2TffFkmo3ky/lJZX7qw==}
 
-  deslop-js@0.9.1:
-    resolution: {integrity: sha512-eo3Tn37bqC1mMS3BwsdwRITYgQQQdT30g8SMY9C/zRbMu6ekNf9o7aGNUEkxWiKd1dTND58Sndi5fBlT9V6UvA==}
+  deslop-js@0.9.2:
+    resolution: {integrity: sha512-rGhQ17gHnmsjG5KFJM4+oN4bOxktHiPGqzJxKqWt0Qw/NLZIsEgLH1wIo1tTXRyN/MNwhchKbfUieFiWyAh0pQ==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -7344,8 +7367,8 @@ packages:
     resolution: {integrity: sha512-3f9/jFLIC/KRLPYqxiXSk20cq47luGy9Oz5Ru7nK7w0EI9B9zuMvAU92bK9jFiwFE7Lc9PA8ER6Y+naYaGFQGw==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
-  oxlint-plugin-react-doctor@0.9.1:
-    resolution: {integrity: sha512-yCW8USbiuszbVsUMN4fL1iU7mRu3Ae3w96+k/xqCyWvW6bF6DzCMtLy5N/w6WLRX78iQsWxVqW/SEgzRBXLfsA==}
+  oxlint-plugin-react-doctor@0.9.2:
+    resolution: {integrity: sha512-fTciSOgAGe/KAgvFDKLz9crjxHyAuu0BvT5sXfSdo2B5QmY5Y/j3nliqX6FaGr7Wud1SYvkAky+/m+58b6K6fQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@0.24.0:
@@ -7730,8 +7753,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
-  react-doctor@0.9.1:
-    resolution: {integrity: sha512-pKCWENXuYZK7UNBHpNLbEBlpy+oVWwPnOxTD2B//gmrQLm+UvIknArzP3IOjNP5Nk1NKCR9uavypFA1QMbYFyg==}
+  react-doctor@0.9.2:
+    resolution: {integrity: sha512-A/e21t0y3j7zUTS8lJyNI2pKMfYLDH+zZwqAC7+MQW1vCD3xqWc2x8XCCWKnrQQwtFd6dwSZw2017x1iSLnGTA==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -9857,7 +9880,7 @@ snapshots:
   '@effect/vitest@4.0.0-beta.97(effect@4.0.0-beta.97)(vitest@4.1.10)':
     dependencies:
       effect: 4.0.0-beta.97
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@7.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@7.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@electron-internal/extract-zip@1.0.4': {}
 
@@ -11548,6 +11571,8 @@ snapshots:
       magic-string: 0.30.21
     transitivePeerDependencies:
       - supports-color
+
+  '@shaderfrog/glsl-parser@7.0.1': {}
 
   '@shikijs/core@4.3.1':
     dependencies:
@@ -13975,7 +14000,7 @@ snapshots:
       oxc-resolver: 11.23.0
       typescript: 5.9.3
 
-  deslop-js@0.9.1:
+  deslop-js@0.9.2:
     dependencies:
       '@oxc-project/types': 0.141.0
       fast-glob: 3.3.3
@@ -16221,8 +16246,9 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       oxc-parser: 0.138.0
 
-  oxlint-plugin-react-doctor@0.9.1:
+  oxlint-plugin-react-doctor@0.9.2:
     dependencies:
+      '@shaderfrog/glsl-parser': 7.0.1
       '@typescript-eslint/types': 8.63.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -16733,22 +16759,23 @@ snapshots:
       - oxlint-tsgolint
       - supports-color
 
-  react-doctor@0.9.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(oxlint-tsgolint@0.24.0)(supports-color@7.2.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
+  react-doctor@0.9.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(oxlint-tsgolint@0.24.0)(supports-color@7.2.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@7.2.0)
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.9.1
+      deslop-js: 0.9.2
       eslint-plugin-react-hooks: 7.1.1(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
       figures: 6.1.0
       ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
       ink-spinner: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5)
       jiti: 2.7.0
       magicast: 0.5.3
+      oxc-resolver: 11.24.2
       oxlint: 1.74.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint-plugin-react-doctor: 0.9.1
+      oxlint-plugin-react-doctor: 0.9.2
       prompts: 2.4.2
       react: 19.2.5
       typescript: 5.9.3
@@ -16811,7 +16838,7 @@ snapshots:
       preact: 10.29.7
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.9.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(oxlint-tsgolint@0.24.0)(supports-color@7.2.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      react-doctor: 0.9.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(oxlint-tsgolint@0.24.0)(supports-color@7.2.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@7.2.0))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.50(react@19.2.7)
     optionalDependencies:
@@ -17943,36 +17970,6 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.1
       yaml: 2.9.0
-
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@7.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 24.13.3
-      '@vitest/browser-preview': 4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-      jsdom: 26.1.0(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10))(jsdom@26.1.0(supports-color@7.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## What

New package `@vibest/effect-json-store`: Effect v4 native JSON file storage with schema validation and integer-versioned migrations, then adopts it for everything under `$VIBEST_HOME/storage/` (config.json and daemon.pid are deliberately out of scope).

### The library (`packages/effect-json-store`)

Two entry points over one shared engine (`codec.ts`: `{version, data}` envelope, per-version schema validation, stepwise migrations with runtime validation of each step's output, atomic tmp+rename writes):

- **`makeJsonDocument({ path, schema, migrations?, legacy?, defaults })`** — standalone file: seeded defaults, eager load, in-memory cache, `Semaphore(1)`-serialized writes, typed dot-notation `getKey`/`setKey`.
- **`makeJsonCollection({ dir, schema, migrations?, legacy? })`** — directory of keyed entries at `<dir>/<id>.json` (ids may nest via `/`): `get → Option` (missing is not an error, never seeded), `put`, idempotent `remove`, sorted `list` with optional filter.

`migrations` is a flat array where each entry pairs a superseded schema with the `migrate()` out of it — the migrate parameter type is inferred locally from the same entry, and every step's output is validated against the next version's schema at runtime. Corrupt files fail loudly with tagged errors (`JsonStore*`) and are never auto-reset; a file from a newer version is never touched.

**`legacy`** is the adoption path for pre-envelope files: anything failing the envelope decode is decoded with the legacy schema, migrated into the v1 shape, run through the normal chain, and written back in envelope form on first read. A test pins the subtle case: a bare session body carrying its own `version: 1` field (but no `data` key) still takes the legacy path.

Design rationale and rejected alternatives are in `docs/design/effect-json-store-api-rfc.md`.

### Server adoption

- `session/repository.ts` → `makeJsonCollection` with `id = <projectId>/<sessionId>`; existing bare records are adopted via an identity legacy step. `SessionSchema`/`Session` compatibility is enforced structurally (write checks interface→schema, reads check schema→interface).
- `project/repository.ts` → `makeJsonDocument` (`Schema.Array(ProjectSchema)`, defaults `[]`). Behavior change: the document loads eagerly with `orDie`, so a corrupt projects.json now fails startup instead of erroring on every `list`; `list` serves the in-memory cache.
- Repository error surfaces are unchanged — `JsonStore*` errors map back to `StoreReadError`/`StoreWriteError`, so services needed no changes.
- `infra/json-store.ts` drops the now-consumerless `readJsonDir`/`removeFile`; `readJson`/`writeJsonAtomic` remain for the config.json consumers.
- Layer construction now performs file I/O, so the RPC test harnesses build their runtime context with `runPromise` instead of `runSync` (the production `createRpcRuntime` was already async).

Existing on-disk data needs no manual migration — records are adopted into envelope form the first time they are read.

## Testing

- `@vibest/effect-json-store`: 31 tests (round-trips, stepwise migrations, legacy adoption incl. the versioned-body case, error taxonomy with write-failure injection preserving the old file, 20-way concurrent updates, type-level inference and dot-notation checks; vitest typecheck enabled).
- `@vibest/server`: 230 tests, including new integration tests that read pre-envelope session/project files and assert the envelope write-back.
- Full-repo `pnpm check` and `turbo run typecheck` clean.