### PR TITLE
fix: harden effect-json-store and its server adoption after review

### DIFF
--- a/docs/design/effect-json-store-api-rfc.md
+++ b/docs/design/effect-json-store-api-rfc.md
@@ -178,24 +178,29 @@ interface JsonCollection<A> {
   ) => Effect.Effect<void, JsonStoreEncodeError | JsonStoreWriteError>;
   /** 删除；缺失是 no-op */
   readonly remove: (id: string) => Effect.Effect<void, JsonStoreWriteError>;
-  /** 全部条目按 id 排序；目录不存在 = 空表；损坏条目 fail loud；有界并发（16） */
-  readonly list: (
-    filter?: (entry: JsonCollectionEntry<A>) => boolean,
-  ) => Effect.Effect<ReadonlyArray<JsonCollectionEntry<A>>, JsonStoreLoadError>;
+  /** 全部条目 id（可 `under` 限定子目录），已排序，不读条目内容；杂散非法文件名被跳过 */
+  readonly ids: (options?: {
+    readonly under?: string;
+  }) => Effect.Effect<ReadonlyArray<string>, JsonStoreReadError>;
+  /** 全部条目按 id 排序；目录不存在 = 空表；损坏条目 fail loud（用 `under` 收窄故障域）；有界并发（16） */
+  readonly list: (options?: {
+    readonly under?: string;
+    readonly filter?: (entry: JsonCollectionEntry<A>) => boolean;
+  }) => Effect.Effect<ReadonlyArray<JsonCollectionEntry<A>>, JsonStoreLoadError>;
 }
 ```
 
 与 document 的语义分野：
 
-| 维度         | document                       | collection                                        |
-| ------------ | ------------------------------ | ------------------------------------------------- |
-| 寻址         | 一个固定文件                   | `<dir>/<id>.json`，id 可含 `/` 嵌套（如 `p1/s1`） |
-| 缺失         | `defaults` 种子化写盘          | `Option.none`，绝不创建文件                       |
-| 加载时机     | 构造时急加载 + 缓存            | 每次 `get`/`list` 读盘，无缓存                    |
-| 写序         | Semaphore(1) 串行化            | 无（不同 id 天然无冲突；同 id 并发是消费方问题）  |
-| 构造失败通道 | `JsonStoreLoadError`（急加载） | `never`（构造纯粹，错误推迟到操作）               |
+| 维度         | document                       | collection                                                                                   |
+| ------------ | ------------------------------ | -------------------------------------------------------------------------------------------- |
+| 寻址         | 一个固定文件                   | `<dir>/<id>.json`，id 可含 `/` 嵌套（如 `p1/s1`）                                            |
+| 缺失         | `defaults` 种子化写盘          | `Option.none`，绝不创建文件                                                                  |
+| 加载时机     | 构造时急加载 + 缓存            | 每次 `get`/`list` 读盘，无缓存                                                               |
+| 写序         | Semaphore(1) 串行化            | 同 id 互斥（每 id 一把锁；`get` 的迁移写回不会覆盖并发 `put`/复活 `remove`），不同 id 全并发 |
+| 构造失败通道 | `JsonStoreLoadError`（急加载） | `never`（构造纯粹，错误推迟到操作）                                                          |
 
-id 校验：空串、绝对路径、`.`/`..` 段一律 `Effect.die`（这是调用方 bug，不是可恢复错误）。迁移写回发生在 `get`（含 `list` 内部的 get），与 document 一致走原子写。
+id 校验：空串、绝对路径、`.`/`..` 段一律 `Effect.die`——**这是"调用方 bug"契约，外部（客户端）可控的 id 必须在进入 collection 前由消费方 sanitize 成 typed error**（见 server SessionRepository 的 `isSafeId`）。磁盘上衍生的名字不受此约束：`ids`/`list` 会跳过非法文件名（如杂散的 `.json`）而不是 die。迁移写回发生在 `get`（含 `list` 内部的 get），与 document 一致走原子写，且受同 id 锁保护。
 
 - 命名取自 Firestore 的 document/collection 对偶；错误类型保留 `JsonStore*` 前缀作为包级伞名。
 
@@ -314,3 +319,14 @@ server `storage/` 接入（2026-07-28）：
   留给 config.json（provider/mcp，本次范围外）。
 - 层构造现在含文件 I/O：测试 harness 的 `runtime.runSync(contextEffect)` 改为 `runPromise`
   （生产路径 `createRpcRuntime` 本就是 async，不受影响）。
+
+审查修复（2026-07-29，对抗审查后）：
+
+- collection 增加同 id 互斥锁（`get` 迁移写回不再与并发 `put`/`remove` 竞态）与
+  `ids()` / `list({ under })`（session 按项目收窄故障域，`findBySessionId` 只读一个文件体）。
+- `listIds` 跳过非法文件名；`JSON.stringify` 包进 `Effect.try`（不可序列化值 → `JsonStoreWriteError`）。
+- server：SessionRepository 对客户端可控 id 做 `isSafeId` 消毒（畸形 id → typed not-found 而非 defect）；
+  ProjectRepository 改为惰性打开 + 成功后缓存——损坏或超前版本的 projects.json 不再 `orDie` 砖死启动，
+  错误按调用以 `StoreReadError` 呈现，文件修好后下次调用自愈。
+- 明确暂不做：写回失败使读路径失败（只读文件系统场景）、KeyPath 的 nullable/带点属性名收紧、
+  ProjectRepository 改用 `document.update`（lost-update 是旧代码既有行为）。

--- a/packages/effect-json-store/src/codec.ts
+++ b/packages/effect-json-store/src/codec.ts
@@ -75,9 +75,15 @@ export const makeFileCodec = (
     envelope: { readonly version: number; readonly data: unknown },
   ): Effect.Effect<void, JsonStoreWriteError> =>
     Effect.gen(function* () {
+      // Schema encoding cannot rule out values JSON.stringify rejects (BigInt,
+      // cycles behind Schema.Unknown), so the throw must stay a typed failure.
+      const text = yield* Effect.try({
+        try: () => `${JSON.stringify(envelope, null, 2)}\n`,
+        catch: (cause) => cause,
+      });
       yield* fs.makeDirectory(path.dirname(file), { recursive: true });
       const tmp = `${file}.${crypto.randomUUID()}.tmp`;
-      yield* fs.writeFileString(tmp, `${JSON.stringify(envelope, null, 2)}\n`);
+      yield* fs.writeFileString(tmp, text);
       yield* fs.rename(tmp, file);
     }).pipe(Effect.mapError((cause) => new JsonStoreWriteError({ file, cause })));
 

--- a/packages/effect-json-store/src/collection.ts
+++ b/packages/effect-json-store/src/collection.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { Effect, FileSystem, Option } from "effect";
+import { Effect, FileSystem, Option, Semaphore } from "effect";
 
 import { type AnySchema, makeFileCodec, type MigrationStep } from "./codec";
 import {
@@ -13,6 +13,16 @@ import {
 export interface JsonCollectionEntry<A> {
   readonly id: string;
   readonly data: A;
+}
+
+export interface JsonCollectionListOptions<A> {
+  /**
+   * Restrict to entries under one subdirectory (an id prefix), e.g.
+   * `under: "p1"` reads only `<dir>/p1/**`. Entries outside it — including
+   * corrupt ones — are never touched.
+   */
+  readonly under?: string;
+  readonly filter?: (entry: JsonCollectionEntry<A>) => boolean;
 }
 
 export interface JsonCollection<A> {
@@ -29,12 +39,21 @@ export interface JsonCollection<A> {
   /** Delete one entry; missing is a no-op. */
   readonly remove: (id: string) => Effect.Effect<void, JsonStoreWriteError>;
   /**
+   * All entry ids (optionally scoped with `under`), sorted, without reading
+   * any entry bodies. Non-id filenames (e.g. a stray `.json`) are skipped.
+   * A missing directory is an empty list.
+   */
+  readonly ids: (
+    options?: Pick<JsonCollectionListOptions<A>, "under">,
+  ) => Effect.Effect<ReadonlyArray<string>, JsonStoreReadError>;
+  /**
    * All entries, sorted by id. Files that vanish between listing and reading
    * are skipped; a corrupt entry fails the whole list (catch by tag to
-   * handle). A missing collection directory is an empty list.
+   * handle; scope with `under` to contain the blast radius). A missing
+   * directory is an empty list.
    */
   readonly list: (
-    filter?: (entry: JsonCollectionEntry<A>) => boolean,
+    options?: JsonCollectionListOptions<A>,
   ) => Effect.Effect<ReadonlyArray<JsonCollectionEntry<A>>, JsonStoreLoadError>;
 }
 
@@ -67,6 +86,14 @@ const LIST_CONCURRENCY = 16;
  * migrations, and atomic writes, but with record semantics: no eager load, no
  * cache, no defaults. Ids may contain `/` to nest entries in subdirectories
  * (e.g. `"<projectId>/<sessionId>"`).
+ *
+ * Ids are the caller's responsibility: an invalid id (empty/absolute/dot
+ * segments) is a defect, so sanitize untrusted input before it gets here.
+ *
+ * Operations on the same id are serialized within this collection instance —
+ * `get`'s migration/adoption write-back can therefore never overwrite a
+ * concurrent `put` or resurrect a concurrent `remove`. Distinct ids stay
+ * fully concurrent; cross-instance and cross-process writes are not covered.
  */
 export const makeJsonCollection = <
   Latest extends AnySchema,
@@ -97,50 +124,83 @@ export const makeJsonCollection = <
         ? Effect.succeed(path.join(dir, `${id}.json`))
         : Effect.die(new Error(`invalid collection id: ${JSON.stringify(id)}`));
 
+    // One mutex per id, created on first touch. Grows with the number of
+    // distinct ids used over the instance's lifetime — fine for file-backed
+    // collections, whose id sets are small.
+    const locks = new Map<string, Semaphore.Semaphore>();
+    const withIdLock =
+      (id: string) =>
+      <X, E, R>(effect: Effect.Effect<X, E, R>): Effect.Effect<X, E, R> =>
+        Effect.suspend(() => {
+          let lock = locks.get(id);
+          if (lock === undefined) {
+            lock = Semaphore.makeUnsafe(1);
+            locks.set(id, lock);
+          }
+          return lock.withPermit(effect);
+        });
+
     const get = (id: string): Effect.Effect<Option.Option<A>, JsonStoreLoadError> =>
       fileOf(id).pipe(
-        Effect.flatMap((file) => codec.load(file)),
+        Effect.flatMap((file) => withIdLock(id)(codec.load(file))),
         Effect.map((value) => (value === undefined ? Option.none<A>() : Option.some(value as A))),
       );
 
-    const listIds: Effect.Effect<ReadonlyArray<string>, JsonStoreReadError> = fs
-      .readDirectory(dir, { recursive: true })
-      .pipe(
-        Effect.map((entries) =>
-          entries
-            .map((entry) => entry.replaceAll("\\", "/"))
-            .filter((entry) => entry.endsWith(".json"))
-            .map((entry) => entry.slice(0, -".json".length)),
-        ),
-        Effect.catch((error) =>
-          error.reason._tag === "NotFound"
-            ? Effect.succeed([])
-            : Effect.fail(new JsonStoreReadError({ file: dir, cause: error })),
-        ),
-      );
+    const ids = (
+      listOptions?: Pick<JsonCollectionListOptions<A>, "under">,
+    ): Effect.Effect<ReadonlyArray<string>, JsonStoreReadError> =>
+      Effect.suspend(() => {
+        const under = listOptions?.under;
+        if (under !== undefined && !isValidId(under)) {
+          return Effect.die(new Error(`invalid collection id prefix: ${JSON.stringify(under)}`));
+        }
+        const root = under === undefined ? dir : path.join(dir, under);
+        return fs.readDirectory(root, { recursive: true }).pipe(
+          Effect.map((entries) =>
+            entries
+              .map((entry) => entry.replaceAll("\\", "/"))
+              .filter((entry) => entry.endsWith(".json"))
+              .map((entry) => entry.slice(0, -".json".length))
+              .map((entry) => (under === undefined ? entry : `${under}/${entry}`))
+              // Skip stray non-id filenames (a bare ".json", dot segments…)
+              // instead of letting them die in fileOf later.
+              .filter(isValidId)
+              .sort(),
+          ),
+          Effect.catch((error) =>
+            error.reason._tag === "NotFound"
+              ? Effect.succeed([])
+              : Effect.fail(new JsonStoreReadError({ file: root, cause: error })),
+          ),
+        );
+      });
 
     return {
       get,
-      put: (id, value) => fileOf(id).pipe(Effect.flatMap((file) => codec.save(file, value))),
+      ids,
+      put: (id, value) =>
+        fileOf(id).pipe(Effect.flatMap((file) => withIdLock(id)(codec.save(file, value)))),
       remove: (id) =>
         fileOf(id).pipe(
           Effect.flatMap((file) =>
-            fs
-              .remove(file)
-              .pipe(
-                Effect.catch((error) =>
-                  error.reason._tag === "NotFound"
-                    ? Effect.void
-                    : Effect.fail(new JsonStoreWriteError({ file, cause: error })),
+            withIdLock(id)(
+              fs
+                .remove(file)
+                .pipe(
+                  Effect.catch((error) =>
+                    error.reason._tag === "NotFound"
+                      ? Effect.void
+                      : Effect.fail(new JsonStoreWriteError({ file, cause: error })),
+                  ),
                 ),
-              ),
+            ),
           ),
         ),
-      list: (filter) =>
+      list: (listOptions) =>
         Effect.gen(function* () {
-          const ids = yield* listIds;
+          const found = yield* ids(listOptions);
           const loaded = yield* Effect.all(
-            ids.map((id) =>
+            found.map((id) =>
               get(id).pipe(
                 Effect.map(Option.map((data): JsonCollectionEntry<A> => ({ id, data }))),
               ),
@@ -148,7 +208,7 @@ export const makeJsonCollection = <
             { concurrency: LIST_CONCURRENCY },
           );
           const entries = loaded.flatMap((entry) => (Option.isSome(entry) ? [entry.value] : []));
-          entries.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+          const filter = listOptions?.filter;
           return filter === undefined ? entries : entries.filter(filter);
         }),
     };

--- a/packages/effect-json-store/src/index.ts
+++ b/packages/effect-json-store/src/index.ts
@@ -11,6 +11,7 @@ export type { AnySchema, MigrationStep } from "./codec";
 export {
   type JsonCollection,
   type JsonCollectionEntry,
+  type JsonCollectionListOptions,
   type JsonCollectionOptions,
   makeJsonCollection,
 } from "./collection";

--- a/packages/effect-json-store/test/collection.test.ts
+++ b/packages/effect-json-store/test/collection.test.ts
@@ -73,7 +73,7 @@ it.effect("list returns entries sorted by id, supports filter, and an absent dir
         ["p1/s1", "p1/s2", "p2/s1"],
       );
 
-      const starred = yield* sessions.list((entry) => entry.data.starred);
+      const starred = yield* sessions.list({ filter: (entry) => entry.data.starred });
       assert.deepEqual(
         starred.map((entry) => entry.id),
         ["p1/s2"],
@@ -100,6 +100,88 @@ it.effect("get migrates an old entry and writes the new version back", () =>
       assert.deepEqual(yield* sessions.get("p1/s1"), Option.some({ title: "old", starred: false }));
       const parsed: unknown = JSON.parse(yield* fs.readFileString(file));
       assert.deepEqual(parsed, { version: 2, data: { title: "old", starred: false } });
+    }),
+  ),
+);
+
+it.effect("ids lists sorted entry ids without reading bodies, and skips stray filenames", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const collectionDir = path.join(dir, "sessions");
+      const sessions = yield* makeJsonCollection({ dir: collectionDir, schema: V2 });
+
+      yield* sessions.put("p2/s1", { title: "b", starred: false });
+      yield* sessions.put("p1/s1", { title: "a", starred: true });
+      // Corrupt body and stray names: ids must not decode or die on them.
+      yield* fs.writeFileString(path.join(collectionDir, "p1", "s2.json"), "{ not json");
+      yield* fs.writeFileString(path.join(collectionDir, ".json"), "stray");
+
+      assert.deepEqual(yield* sessions.ids(), ["p1/s1", "p1/s2", "p2/s1"]);
+      assert.deepEqual(yield* sessions.ids({ under: "p1" }), ["p1/s1", "p1/s2"]);
+    }),
+  ),
+);
+
+it.effect("list scoped with `under` is unaffected by corruption in other subdirectories", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const collectionDir = path.join(dir, "sessions");
+      const sessions = yield* makeJsonCollection({ dir: collectionDir, schema: V2 });
+
+      yield* sessions.put("p1/s1", { title: "a", starred: false });
+      yield* fs.makeDirectory(path.join(collectionDir, "p2"), { recursive: true });
+      yield* fs.writeFileString(path.join(collectionDir, "p2", "bad.json"), "{ not json");
+
+      const scoped = yield* sessions.list({ under: "p1" });
+      assert.deepEqual(
+        scoped.map((entry) => entry.id),
+        ["p1/s1"],
+      );
+      // The unscoped list still fails loudly on the corrupt entry.
+      const error = yield* Effect.flip(sessions.list());
+      assert.equal(error._tag, "JsonStoreParseError");
+    }),
+  ),
+);
+
+it.effect("a stray '.json' filename does not break list", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const collectionDir = path.join(dir, "sessions");
+      yield* fs.makeDirectory(collectionDir, { recursive: true });
+      yield* fs.writeFileString(path.join(collectionDir, ".json"), "stray");
+
+      const sessions = yield* makeJsonCollection({ dir: collectionDir, schema: V2 });
+      assert.deepEqual(yield* sessions.list(), []);
+    }),
+  ),
+);
+
+it.effect("a migrating get racing a put on the same id never loses the put", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const collectionDir = path.join(dir, "sessions");
+      const file = path.join(collectionDir, "p1", "s1.json");
+      yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+      yield* fs.writeFileString(file, JSON.stringify({ version: 1, data: { title: "old" } }));
+
+      const sessions = yield* makeJsonCollection({
+        dir: collectionDir,
+        schema: V2,
+        migrations: [{ schema: V1, migrate: (v1) => ({ ...v1, starred: false }) }],
+      });
+
+      // Whichever order the id lock serializes them in, the migration
+      // write-back must never overwrite the concurrent put.
+      const fresh = { title: "fresh", starred: true };
+      yield* Effect.all([sessions.get("p1/s1"), sessions.put("p1/s1", fresh)], {
+        concurrency: "unbounded",
+      });
+      assert.deepEqual(yield* sessions.get("p1/s1"), Option.some(fresh));
     }),
   ),
 );

--- a/packages/effect-json-store/test/errors.test.ts
+++ b/packages/effect-json-store/test/errors.test.ts
@@ -73,6 +73,22 @@ it.effect("fails with JsonStoreDecodeError when latest-version data fails its sc
   }),
 );
 
+it.effect("fails with JsonStoreWriteError when the encoded value is not JSON-serializable", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const AnyValue = Schema.Struct({ value: Schema.Unknown });
+      const store = yield* makeJsonDocument({
+        path: path.join(dir, "config.json"),
+        schema: AnyValue,
+        defaults: { value: 1 },
+      });
+      // BigInt slips through Schema.Unknown but JSON.stringify rejects it.
+      const error = yield* Effect.flip(store.set({ value: 1n }));
+      assert.equal(error._tag, "JsonStoreWriteError");
+    }),
+  ),
+);
+
 /** Real filesystem for reads, but every write fails — for write-error injection. */
 const failingWrites = Layer.effect(
   FileSystem.FileSystem,

--- a/packages/server/src/project/repository.ts
+++ b/packages/server/src/project/repository.ts
@@ -1,10 +1,10 @@
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import { ProjectSchema } from "@vibest/contract";
-import { makeJsonDocument } from "@vibest/effect-json-store";
-import { Context, Effect, Layer, Schema } from "effect";
+import { type JsonDocument, makeJsonDocument } from "@vibest/effect-json-store";
+import { Context, Effect, FileSystem, Layer, Option, Ref, Schema, Semaphore } from "effect";
 
 import { Paths } from "../config/paths";
-import { type StoreReadError, StoreWriteError } from "../errors";
+import { StoreReadError, StoreWriteError } from "../errors";
 import type { Project } from "../types";
 
 const ProjectsSchema = Schema.Array(ProjectSchema);
@@ -13,9 +13,10 @@ const ProjectsSchema = Schema.Array(ProjectSchema);
  * Data access for `$VIBEST_HOME/storage/projects.json` — plain read/write of
  * `Project[]`, no business rules (those live in ProjectService).
  *
- * The document is loaded (and a missing file seeded with `[]`) when the layer
- * is built; a corrupt or unreadable file is a defect that fails startup rather
- * than a per-call error. `list` serves the in-memory cache.
+ * The document opens lazily on first use and is cached once open. A corrupt
+ * file — or one written by a newer version — must not brick the daemon, so an
+ * open failure surfaces per call as a typed error and the next call retries,
+ * recovering as soon as the file is fixed.
  */
 export class ProjectRepository extends Context.Service<
   ProjectRepository,
@@ -29,21 +30,50 @@ export const ProjectRepositoryLayer: Layer.Layer<ProjectRepository, never, Paths
   ProjectRepository,
   Effect.gen(function* () {
     const paths = yield* Paths;
-    const document = yield* makeJsonDocument({
-      path: paths.projectsFile,
-      schema: ProjectsSchema,
-      // Pre-envelope files are the bare Project[] array.
-      legacy: { schema: ProjectsSchema, migrate: (projects) => projects },
-      defaults: [],
-    }).pipe(Effect.orDie);
-    return {
-      list: () => document.get,
-      save: (projects) =>
-        document
-          .set(projects)
-          .pipe(
-            Effect.mapError((error) => new StoreWriteError({ file: error.file, cause: error })),
+    // Captured at layer build so the lazily-run open below needs no services.
+    const fs = yield* FileSystem.FileSystem;
+    const opened = yield* Ref.make(Option.none<JsonDocument<ReadonlyArray<Project>>>());
+    // Serializes the first open so concurrent calls cannot seed/adopt twice.
+    const openGate = yield* Semaphore.make(1);
+    const document: Effect.Effect<
+      JsonDocument<ReadonlyArray<Project>>,
+      StoreReadError
+    > = openGate.withPermit(
+      Effect.gen(function* () {
+        const cached = yield* Ref.get(opened);
+        if (Option.isSome(cached)) {
+          return cached.value;
+        }
+        const doc = yield* makeJsonDocument({
+          path: paths.projectsFile,
+          schema: ProjectsSchema,
+          // Pre-envelope files are the bare Project[] array.
+          legacy: { schema: ProjectsSchema, migrate: (projects) => projects },
+          defaults: [],
+        }).pipe(
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.mapError(
+            (error) => new StoreReadError({ file: paths.projectsFile, cause: error }),
           ),
+        );
+        yield* Ref.set(opened, Option.some(doc));
+        return doc;
+      }),
+    );
+    return {
+      list: () => document.pipe(Effect.flatMap((doc) => doc.get)),
+      save: (projects) =>
+        document.pipe(
+          // An unopenable file also means it cannot be safely overwritten.
+          Effect.mapError((error) => new StoreWriteError({ file: error.file, cause: error })),
+          Effect.flatMap((doc) =>
+            doc
+              .set(projects)
+              .pipe(
+                Effect.mapError((error) => new StoreWriteError({ file: error.file, cause: error })),
+              ),
+          ),
+        ),
     };
   }),
 ).pipe(Layer.provide(NodeFileSystem.layer));

--- a/packages/server/src/session/repository.ts
+++ b/packages/server/src/session/repository.ts
@@ -52,6 +52,15 @@ export class SessionRepository extends Context.Service<
   }
 >()("SessionRepository") {}
 
+/**
+ * Ids reach this repository from RPC input, so they must be sanitized before
+ * they become path segments: the collection treats an invalid id as a defect
+ * (caller bug), but here a malformed id is client data and means "no such
+ * session", not a crash.
+ */
+const isSafeId = (id: string): boolean =>
+  id.length > 0 && !/[/\\]/.test(id) && id !== "." && id !== "..";
+
 export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths> = Layer.effect(
   SessionRepository,
   Effect.gen(function* () {
@@ -70,35 +79,43 @@ export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths
 
     return {
       list: (projectId) =>
-        sessions
-          .list((entry) => entry.data.projectId === projectId)
-          .pipe(
-            Effect.map((entries) => entries.map((entry) => entry.data)),
-            Effect.mapError(asReadError),
-          ),
+        // Scoped to the project's own subdirectory: a corrupt record in
+        // another project cannot fail this listing.
+        isSafeId(projectId)
+          ? sessions.list({ under: projectId }).pipe(
+              Effect.map((entries) => entries.map((entry) => entry.data)),
+              Effect.mapError(asReadError),
+            )
+          : Effect.succeed([]),
 
       read: (projectId, sessionId) =>
-        sessions.get(entryId(projectId, sessionId)).pipe(
-          Effect.mapError(asReadError),
-          Effect.flatMap((found) =>
-            Option.isSome(found)
-              ? Effect.succeed(found.value)
-              : Effect.fail(new SessionNotFound({ projectId, sessionId })),
-          ),
-        ),
+        !isSafeId(projectId) || !isSafeId(sessionId)
+          ? Effect.fail(new SessionNotFound({ projectId, sessionId }))
+          : sessions.get(entryId(projectId, sessionId)).pipe(
+              Effect.mapError(asReadError),
+              Effect.flatMap((found) =>
+                Option.isSome(found)
+                  ? Effect.succeed(found.value)
+                  : Effect.fail(new SessionNotFound({ projectId, sessionId })),
+              ),
+            ),
 
       findBySessionId: (sessionId) =>
-        sessions
-          .list((entry) => entry.data.sessionId === sessionId)
-          .pipe(
-            Effect.mapError(asReadError),
-            Effect.flatMap((hits) => {
-              const hit = hits[0];
-              return hit === undefined
-                ? Effect.fail(new SessionRefNotFound({ sessionId }))
-                : Effect.succeed(hit.data);
+        // Scan filenames only (no entry bodies), then read the single match.
+        !isSafeId(sessionId)
+          ? Effect.fail(new SessionRefNotFound({ sessionId }))
+          : Effect.gen(function* () {
+              const ids = yield* sessions.ids().pipe(Effect.mapError(asReadError));
+              const id = ids.find((candidate) => candidate.endsWith(`/${sessionId}`));
+              const found =
+                id === undefined
+                  ? Option.none<Session>()
+                  : yield* sessions.get(id).pipe(Effect.mapError(asReadError));
+              if (Option.isNone(found)) {
+                return yield* Effect.fail(new SessionRefNotFound({ sessionId }));
+              }
+              return found.value;
             }),
-          ),
 
       write: (metadata) =>
         sessions
@@ -106,7 +123,9 @@ export const SessionRepositoryLayer: Layer.Layer<SessionRepository, never, Paths
           .pipe(Effect.mapError(asWriteError)),
 
       remove: (projectId, sessionId) =>
-        sessions.remove(entryId(projectId, sessionId)).pipe(Effect.mapError(asWriteError)),
+        !isSafeId(projectId) || !isSafeId(sessionId)
+          ? Effect.void
+          : sessions.remove(entryId(projectId, sessionId)).pipe(Effect.mapError(asWriteError)),
     };
   }),
 ).pipe(Layer.provide(NodeFileSystem.layer));

--- a/packages/server/test/project.test.ts
+++ b/packages/server/test/project.test.ts
@@ -98,6 +98,26 @@ describe("ProjectService", () => {
     expect(raw.data).toEqual([project]);
   });
 
+  it("a corrupt projects.json fails per call with StoreReadError and recovers once fixed", async () => {
+    const file = join(home, "storage", "projects.json");
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, "{ not json", "utf8");
+
+    // The layer must still build (no startup defect); the error is per call.
+    const result = await run(
+      Effect.gen(function* () {
+        const svc = yield* ProjectService;
+        const error = yield* Effect.flip(svc.list());
+        // Fix the file on disk; the next call retries the open and recovers.
+        yield* Effect.promise(() => writeFile(file, "[]", "utf8"));
+        const listed = yield* svc.list();
+        return { error, listed };
+      }),
+    );
+    expect(result.error._tag).toBe("StoreReadError");
+    expect(result.listed).toEqual([]);
+  });
+
   it("remove fails with ProjectNotFound for an unknown id", async () => {
     const err = await run(
       Effect.flip(

--- a/packages/server/test/session-repository.test.ts
+++ b/packages/server/test/session-repository.test.ts
@@ -140,6 +140,41 @@ describe("SessionRepository", () => {
     expect(hit.harnessSessionId).toBe("u2");
   });
 
+  it("a corrupt record in another project does not break this project's list", async () => {
+    const badFile = join(home, "storage", "sessions", "proj-b", "bad.json");
+    await mkdir(dirname(badFile), { recursive: true });
+    await writeFile(badFile, "{ not json", "utf8");
+
+    const result = await run(
+      Effect.gen(function* () {
+        const repo = yield* SessionRepository;
+        yield* repo.write(meta("sess-1", "proj-a", "u1"));
+        const listedA = yield* repo.list("proj-a");
+        const errorB = yield* Effect.flip(repo.list("proj-b"));
+        return { listedA, errorB };
+      }),
+    );
+    expect(result.listedA.map((session) => session.sessionId)).toEqual(["sess-1"]);
+    expect(result.errorB._tag).toBe("StoreReadError");
+  });
+
+  it("malformed ids yield typed results, never defects", async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const repo = yield* SessionRepository;
+        yield* repo.write(meta("sess-1", "proj-a", "u1"));
+        const readError = yield* Effect.flip(repo.read("..", "sess-1"));
+        const findError = yield* Effect.flip(repo.findBySessionId("a/../b"));
+        const listed = yield* repo.list("../proj-a");
+        yield* repo.remove("..", ".."); // no-op, must not die
+        return { readError, findError, listed };
+      }),
+    );
+    expect(result.readError._tag).toBe("SessionNotFound");
+    expect(result.findError._tag).toBe("SessionRefNotFound");
+    expect(result.listed).toEqual([]);
+  });
+
   it("findBySessionId fails with SessionRefNotFound for an unknown session", async () => {
     const err = await run(
       Effect.flip(


### PR DESCRIPTION
## What

Fixes the confirmed findings from the adversarial reviews of #145 (Codex peer review + workflow code review). Six issues addressed, three deliberately deferred.

### Library (`packages/effect-json-store`)

- **Per-id mutex in `JsonCollection`** — `get`'s migration/legacy write-back could race a concurrent `put` (silently reverting it to stale migrated data) or `remove` (resurrecting the deleted entry). Same-id operations now serialize through a lazily-created per-id `Semaphore(1)`; distinct ids stay fully concurrent.
- **`ids()` + `list({ under })`** — `ids()` lists sorted entry ids without reading any bodies; `list({ under: \"p1\" })` scopes the recursive read to one subdirectory so corruption elsewhere can't fail the call. `list(filter)` became `list({ under?, filter? })`.
- **Stray filenames no longer die** — ids derived from directory contents (e.g. a bare `.json` file) are filtered through the id validator instead of hitting the `Effect.die` path meant for caller bugs.
- **`JSON.stringify` wrapped in `Effect.try`** — a non-serializable encoded value (BigInt behind `Schema.Unknown`) now fails as `JsonStoreWriteError` instead of a fiber defect.

### Server

- **`SessionRepository` sanitizes client-supplied ids** — `sessionId`/`projectId` reach the repository from RPC input; malformed values (`..`, `a/b`, absolute paths) previously hit the collection's `Effect.die` and surfaced as bare 500s. They now yield `SessionNotFound`/`SessionRefNotFound`/empty list/no-op.
- **Failure locality restored** — `list(projectId)` scopes to the project's subdirectory (a corrupt record in project B no longer fails project A's listing) and `findBySessionId` scans filenames then reads the single match, restoring the old I/O profile instead of loading every session body.
- **`ProjectRepository` no longer bricks startup** — the eager `orDie` load meant a corrupt (or newer-versioned, post-downgrade) projects.json crash-looped the daemon. The document now opens lazily and is cached on success: the error surfaces per call as `StoreReadError` and the next call recovers once the file is fixed.

### Deliberately deferred (recorded in the RFC §8)

- Read paths failing on read-only/full storage when a migration write-back is due.
- `KeyPath` tightening for nullable object fields and dot-containing property names (no call sites use dot-notation yet).
- `ProjectRepository` adopting `document.update` (the list-append-save race predates #145).

## Testing

- `@vibest/effect-json-store`: 36 tests — new coverage for the same-id race (concurrent migrating `get` + `put` never loses the put), `ids()`/`under` scoping, stray-filename tolerance, and BigInt serialization failure.
- `@vibest/server`: 240 tests — new coverage for cross-project corruption isolation, malformed-id typed results, and corrupt-projects.json per-call error + recovery within one runtime.
- Full-repo `pnpm check` and `turbo run typecheck` clean.