### PR TITLE
fix(desktop): silence the dev overlay's Google Fonts CSP violation

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -5,6 +5,47 @@ import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
 import { codeInspectorPlugin } from "code-inspector-plugin";
 import { defineConfig } from "electron-vite";
+import type { Plugin } from "vite";
+
+// The dev overlays (react-grab, react-scan) reach outside the origin on boot,
+// which the shipped CSP rejects with console errors on every `electron-vite dev`.
+// Production builds eliminate both overlays, so index.html stays strict and the
+// origins they need are spliced in for the dev server only. Each entry is
+// [exact substring of the shipped policy, its dev replacement].
+const DEV_CSP_PATCHES: ReadonlyArray<readonly [string, string]> = [
+  // react-grab's overlay @imports Geist from Google Fonts inside its shadow root.
+  // The stylesheet's own @font-face points at gstatic, and the strict policy has
+  // no font-src at all, so that directive has to be spelled out — including
+  // 'self', which the bundled @fontsource faces rely on.
+  [
+    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com",
+  ],
+  // Deliberately NOT relaxed: both overlays fetch react-grab.com/api/version at
+  // startup to nag about outdated versions, and react-grab exposes no opt-out.
+  // `connect-src` blocking it is the opt-out, so its four console errors per dev
+  // boot are the accepted price of not phoning home. Do not add that origin.
+];
+
+/** `apply: "serve"` keeps the built index.html byte-identical to the source. */
+function devOverlayCsp(): Plugin {
+  return {
+    name: "vibest:dev-overlay-csp",
+    apply: "serve",
+    transformIndexHtml(html) {
+      return DEV_CSP_PATCHES.reduce((patched, [anchor, replacement]) => {
+        if (!patched.includes(anchor)) {
+          throw new Error(
+            `dev CSP relaxation found no \`${anchor}\` in the renderer HTML — reconcile ` +
+              "it with src/renderer/index.html, or drop the entry if the dev overlay " +
+              "no longer needs that origin.",
+          );
+        }
+        return patched.replace(anchor, replacement);
+      }, html);
+    },
+  };
+}
 
 export default defineConfig({
   main: {
@@ -41,6 +82,7 @@ export default defineConfig({
       alias: { "@": fileURLToPath(new URL("../app/src/", import.meta.url)) },
     },
     plugins: [
+      devOverlayCsp(),
       codeInspectorPlugin({ bundler: "vite" }),
       tanstackRouter({
         target: "react",


### PR DESCRIPTION
## Problem

Every `electron-vite dev` boot logged this in the renderer console:

```
Loading the stylesheet 'https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap'
violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline'".
```

The source is not ours. `react-grab`'s dev overlay builds a `<style>` inside its shadow root whose text starts with `@import url("https://fonts.googleapis.com/…")`. The inline `<style>` passes on `'unsafe-inline'`, but the cross-origin `@import` is a separate fetch that `style-src 'self'` rejects. npm's latest `react-grab` (0.1.50) still ships it, so upgrading does not help.

Only the Electron renderer is affected — `apps/app/index.html` carries no CSP meta.

## Change

One file. A dev-only `transformIndexHtml` plugin splices the two Google Fonts origins into the CSP meta of `src/renderer/index.html`.

- `apply: "serve"` — the built `index.html` stays byte-identical, so nothing ships.
- `font-src` has to be spelled out: the strict policy has none, so it would fall back to `default-src 'self'` and block the gstatic faces the Google stylesheet points at. Its `'self'` keeps the bundled `@fontsource` faces working.
- A missing anchor string throws instead of silently degrading, so a future edit to `index.html`'s CSP surfaces immediately.

`react-grab.com/api/version` is **deliberately left blocked**. Both overlays fetch it at startup to nag about outdated versions, react-grab exposes no opt-out, and `connect-src` refusing it *is* the opt-out. Its four console errors per dev boot are the accepted price of not phoning home; the code comment says so, to stop anyone "completing" the relaxation later.

## Production is unaffected

`import.meta.env.DEV` is statically false in production, so `if (false) { void import("react-grab") }` is eliminated and the chunk is never generated. Verified by grepping a fresh build rather than trusting the comment:

```
grep -ro "fonts.googleapis" apps/desktop/dist/renderer | wc -l   →  0
grep -rl "react-grab|react-scan|Geist:wght" apps/desktop/dist/renderer  →  no match
```

## Verification

Attached to the running dev Electron over CDP and read the renderer's real console:

- Enforced CSP now carries `https://fonts.googleapis.com` (style-src) and `https://fonts.gstatic.com` (font-src).
- The font request completes: `200 https://fonts.googleapis.com/css2?family=Geist:wght@500&display=swap`.
- Zero console lines mentioning CSP / style-src / fonts.
- The only off-origin response that completes is that stylesheet — the react-grab.com version pings are still blocked at the CSP check, so no version data leaves the machine.

Build with the plugin in place → strict policy in `dist`. Same build with `apply` flipped to `"build"` → relaxed policy, confirming the plugin is wired and the replacement lands where intended.

`oxlint --deny-warnings`, `oxfmt --check`, and `tsc --noEmit -p tsconfig.node.json` all pass.

## Not addressed

A pre-existing, unrelated React warning surfaced while reading the console; left alone:

```
Each child in a list should have a unique "key" prop.
Check the render method of `SidebarMenu`. It was passed a child from ProjectSessionsGroup.
```