### PR TITLE
chore(lint): enforce default-only node: builtin imports

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,11 +1,14 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["react", "typescript", "unicorn", "oxc", "jsx-a11y", "vitest", "vue"],
+  "jsPlugins": ["./tools/oxlint/node-import-style.mjs"],
   "categories": {
     "correctness": "error",
     "suspicious": "warn"
   },
   "rules": {
+    "unicorn/prefer-node-protocol": "error",
+    "vibest/node-import-style": "error",
     "react/exhaustive-deps": [
       "error",
       {

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "node:url";
+import url from "node:url";
 
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
@@ -9,15 +9,15 @@ import { defineConfig } from "vite";
 export default defineConfig({
   resolve: {
     tsconfigPaths: true,
-    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+    alias: { "@": url.fileURLToPath(new URL("./src", import.meta.url)) },
   },
   plugins: [
     codeInspectorPlugin({ bundler: "vite" }),
     tanstackRouter({
       target: "react",
       autoCodeSplitting: true,
-      routesDirectory: fileURLToPath(new URL("./src/routes", import.meta.url)),
-      generatedRouteTree: fileURLToPath(new URL("./src/routeTree.gen.ts", import.meta.url)),
+      routesDirectory: url.fileURLToPath(new URL("./src/routes", import.meta.url)),
+      generatedRouteTree: url.fileURLToPath(new URL("./src/routeTree.gen.ts", import.meta.url)),
     }),
     react(),
     tailwindcss(),

--- a/apps/app/vitest.config.ts
+++ b/apps/app/vitest.config.ts
@@ -1,9 +1,9 @@
-import { fileURLToPath } from "node:url";
+import url from "node:url";
 
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
-    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+    alias: { "@": url.fileURLToPath(new URL("./src", import.meta.url)) },
   },
 });

--- a/apps/desktop/e2e/tests/desktop-rpc.spec.ts
+++ b/apps/desktop/e2e/tests/desktop-rpc.spec.ts
@@ -1,14 +1,20 @@
-import { execFileSync } from "node:child_process";
-import { createReadStream, existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
-import { createServer } from "node:http";
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import nodeHttp from "node:http";
 import path from "node:path";
 
-import { _electron as electron, type Page } from "@playwright/test";
+import { type ElectronApplication, _electron as electron, type Page } from "@playwright/test";
 
-import { expect, test } from "./fixtures";
+import { expect, test } from "./fixtures.js";
+
+function appPid(electronApp: ElectronApplication): number {
+  const pid = electronApp.process().pid;
+  if (pid === undefined) throw new Error("Electron process has no pid");
+  return pid;
+}
 
 function findServerPid(parentPid: number): number | undefined {
-  const processes = execFileSync("ps", ["-axo", "pid=,ppid=,command="], {
+  const processes = childProcess.execFileSync("ps", ["-axo", "pid=,ppid=,command="], {
     encoding: "utf8",
   });
   for (const line of processes.split("\n")) {
@@ -41,10 +47,16 @@ function processExists(pid: number): boolean {
 
 function frontmostApplicationPid(): number | undefined {
   if (process.platform !== "darwin") return undefined;
-  const application = execFileSync("/usr/bin/lsappinfo", ["front"], { encoding: "utf8" }).trim();
-  const info = execFileSync("/usr/bin/lsappinfo", ["info", "-only", "pid", application], {
-    encoding: "utf8",
-  });
+  const application = childProcess
+    .execFileSync("/usr/bin/lsappinfo", ["front"], { encoding: "utf8" })
+    .trim();
+  const info = childProcess.execFileSync(
+    "/usr/bin/lsappinfo",
+    ["info", "-only", "pid", application],
+    {
+      encoding: "utf8",
+    },
+  );
   const match = info.match(/"pid"=(\d+)/);
   return match ? Number(match[1]) : undefined;
 }
@@ -109,10 +121,11 @@ test("renders in the background without taking focus and connects to the server"
   });
   expect(renderSize.width).toBeGreaterThan(0);
   expect(renderSize.height).toBeGreaterThan(0);
-  expect(frontmostApplicationPid()).not.toBe(electronApp.process().pid);
+  expect(frontmostApplicationPid()).not.toBe(appPid(electronApp));
   await expect(
     window.evaluate(() => {
-      const globals = window as Window & {
+      // Runs in the renderer, where `window` is the DOM window, not the Page.
+      const globals = window as unknown as Window & {
         vibest?: unknown;
         require?: unknown;
         process?: unknown;
@@ -127,25 +140,25 @@ test("renders in the background without taking focus and connects to the server"
 });
 
 test("gives a reloaded renderer document a new MessagePort", async ({ electronApp, window }) => {
-  const pid = await waitForServer(electronApp.process().pid);
+  const pid = await waitForServer(appPid(electronApp));
 
   await window.reload();
   await expect(window).toHaveTitle("Vibest");
   await expect(window.locator("#root")).toBeVisible();
   await expect(window.getByText("Vibest could not start")).toHaveCount(0);
-  expect(serverPid(electronApp.process().pid)).toBe(pid);
+  expect(serverPid(appPid(electronApp))).toBe(pid);
 });
 
 // oxlint-disable-next-line no-empty-pattern -- required by Playwright's fixture API
 test("boots the development HTTP renderer through MessagePort", async ({}, testInfo) => {
   const rendererRoot = path.join(import.meta.dirname, "../../dist/renderer");
-  const server = createServer((request, response) => {
+  const server = nodeHttp.createServer((request, response) => {
     const requested = path.join(
       rendererRoot,
       new URL(request.url ?? "/", "http://localhost").pathname,
     );
     const target =
-      existsSync(requested) && statSync(requested).isFile()
+      fs.existsSync(requested) && fs.statSync(requested).isFile()
         ? requested
         : path.join(rendererRoot, "index.html");
     response.setHeader(
@@ -156,7 +169,7 @@ test("boots the development HTTP renderer through MessagePort", async ({}, testI
           ? "text/css"
           : "text/html",
     );
-    createReadStream(target).pipe(response);
+    fs.createReadStream(target).pipe(response);
   });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const address = server.address();
@@ -165,10 +178,10 @@ test("boots the development HTTP renderer through MessagePort", async ({}, testI
 
   // Own userData so its single-instance lock can't collide with a real `dev`.
   const userData = path.join(testInfo.outputPath(), "user-data");
-  mkdirSync(userData, { recursive: true });
+  fs.mkdirSync(userData, { recursive: true });
   // Own server storage so the developer's real ~/.vibest never leaks in.
   const vibestHome = path.join(testInfo.outputPath(), "vibest-home");
-  mkdirSync(vibestHome, { recursive: true });
+  fs.mkdirSync(vibestHome, { recursive: true });
 
   const app = await electron.launch({
     args: [
@@ -213,7 +226,7 @@ test("chats through Claude Agent SDK and the fake Claude executable", async ({
   await expect(window.getByText("Desktop fake Claude reply", { exact: true })).toBeVisible();
   await expect
     .poll(() =>
-      existsSync(e2ePaths.fakeClaudeLog) ? readFileSync(e2ePaths.fakeClaudeLog, "utf8") : "",
+      fs.existsSync(e2ePaths.fakeClaudeLog) ? fs.readFileSync(e2ePaths.fakeClaudeLog, "utf8") : "",
     )
     .toContain('"type":"user","text":"Desktop SDK E2E"');
 });
@@ -223,21 +236,21 @@ test("reports a server crash and recovers on the pinned connection", async ({
   window,
 }) => {
   await waitForConnectedUi(window);
-  const initialPid = await waitForServer(electronApp.process().pid);
+  const initialPid = await waitForServer(appPid(electronApp));
   process.kill(initialPid, "SIGKILL");
 
   const reconnecting = window.getByText("Reconnecting…");
   await expect(reconnecting).toBeVisible({ timeout: 10_000 });
   await expect(reconnecting).toBeHidden({ timeout: 15_000 });
 
-  const restartedPid = serverPid(electronApp.process().pid);
+  const restartedPid = serverPid(appPid(electronApp));
   expect(restartedPid).not.toBe(initialPid);
   await expect(window.getByText("Vibest could not start")).toHaveCount(0);
 });
 
 test("disposes the server process during Electron shutdown", async ({ electronApp, window }) => {
   await expect(window).toHaveTitle("Vibest");
-  const pid = await waitForServer(electronApp.process().pid);
+  const pid = await waitForServer(appPid(electronApp));
 
   await electronApp.close();
 
@@ -246,7 +259,7 @@ test("disposes the server process during Electron shutdown", async ({ electronAp
 
 test("offers Retry after repeated server failures", async ({ electronApp, window }) => {
   test.setTimeout(60_000);
-  const parentPid = electronApp.process().pid;
+  const parentPid = appPid(electronApp);
   await driveServerToFailed(window, parentPid);
 
   await expect(window.getByText("The local server stopped")).toBeVisible({ timeout: 10_000 });
@@ -264,7 +277,7 @@ test("quits through Desktop RPC from the terminal failure state", async ({
   window,
 }) => {
   test.setTimeout(60_000);
-  const parentPid = electronApp.process().pid;
+  const parentPid = appPid(electronApp);
   await driveServerToFailed(window, parentPid);
   await expect(window.getByText("The local server stopped")).toBeVisible({ timeout: 10_000 });
 

--- a/apps/desktop/e2e/tests/desktop-rpc.spec.ts
+++ b/apps/desktop/e2e/tests/desktop-rpc.spec.ts
@@ -1,6 +1,6 @@
 import childProcess from "node:child_process";
 import fs from "node:fs";
-import nodeHttp from "node:http";
+import http from "node:http";
 import path from "node:path";
 
 import { type ElectronApplication, _electron as electron, type Page } from "@playwright/test";
@@ -152,7 +152,7 @@ test("gives a reloaded renderer document a new MessagePort", async ({ electronAp
 // oxlint-disable-next-line no-empty-pattern -- required by Playwright's fixture API
 test("boots the development HTTP renderer through MessagePort", async ({}, testInfo) => {
   const rendererRoot = path.join(import.meta.dirname, "../../dist/renderer");
-  const server = nodeHttp.createServer((request, response) => {
+  const server = http.createServer((request, response) => {
     const requested = path.join(
       rendererRoot,
       new URL(request.url ?? "/", "http://localhost").pathname,

--- a/apps/desktop/e2e/tests/fixtures.ts
+++ b/apps/desktop/e2e/tests/fixtures.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import fs from "node:fs";
 import path from "node:path";
 
 import {
@@ -23,12 +23,12 @@ export const test = base.extend<{
   // oxlint-disable-next-line no-empty-pattern -- required by Playwright's fixture API
   e2ePaths: async ({}, use, testInfo) => {
     const output = testInfo.outputPath();
-    mkdirSync(output, { recursive: true });
+    fs.mkdirSync(output, { recursive: true });
     // Per-test server storage: without this the spawned server resolves
     // $VIBEST_HOME to the developer's real ~/.vibest, so their projects and
     // sessions leak into the UI and test chats write into their history.
     const vibestHome = path.join(output, "vibest-home");
-    mkdirSync(vibestHome, { recursive: true });
+    fs.mkdirSync(vibestHome, { recursive: true });
     await use({
       fakeClaudeLog: path.join(output, "fake-claude.jsonl"),
       userData: path.join(output, "user-data"),

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "node:url";
+import url from "node:url";
 
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
@@ -77,9 +77,9 @@ export default defineConfig({
     },
   },
   renderer: {
-    root: fileURLToPath(new URL("./src/renderer/", import.meta.url)),
+    root: url.fileURLToPath(new URL("./src/renderer/", import.meta.url)),
     resolve: {
-      alias: { "@": fileURLToPath(new URL("../app/src/", import.meta.url)) },
+      alias: { "@": url.fileURLToPath(new URL("../app/src/", import.meta.url)) },
     },
     plugins: [
       devOverlayCsp(),
@@ -87,8 +87,10 @@ export default defineConfig({
       tanstackRouter({
         target: "react",
         autoCodeSplitting: true,
-        routesDirectory: fileURLToPath(new URL("../app/src/routes/", import.meta.url)),
-        generatedRouteTree: fileURLToPath(new URL("../app/src/routeTree.gen.ts", import.meta.url)),
+        routesDirectory: url.fileURLToPath(new URL("../app/src/routes/", import.meta.url)),
+        generatedRouteTree: url.fileURLToPath(
+          new URL("../app/src/routeTree.gen.ts", import.meta.url),
+        ),
       }),
       react(),
       tailwindcss(),
@@ -97,7 +99,7 @@ export default defineConfig({
       outDir: "dist/renderer",
       rollupOptions: {
         input: {
-          index: fileURLToPath(new URL("./src/renderer/index.html", import.meta.url)),
+          index: url.fileURLToPath(new URL("./src/renderer/index.html", import.meta.url)),
         },
       },
     },

--- a/apps/desktop/src/main/desktop-config.ts
+++ b/apps/desktop/src/main/desktop-config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import url from "node:url";
 
 import { Context, Layer } from "effect";
 
@@ -30,7 +30,7 @@ export function resolveServerEntry(isPackaged: boolean, resourcesPath: string): 
       "server.mjs",
     );
   }
-  return fileURLToPath(new URL("../../../../packages/server/dist/server.mjs", import.meta.url));
+  return url.fileURLToPath(new URL("../../../../packages/server/dist/server.mjs", import.meta.url));
 }
 
 export function buildDesktopConfig(inputs: DesktopConfigInputs): DesktopConfig["Service"] {

--- a/apps/desktop/src/main/electron/app-protocol.test.ts
+++ b/apps/desktop/src/main/electron/app-protocol.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import url from "node:url";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -37,9 +37,9 @@ describe("resolveAssetPath", () => {
 
 describe("createAppRequestHandler", () => {
   it("serves a renderer asset without an RPC dispatch path", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "vibest-renderer-"));
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-renderer-"));
     const asset = path.join(root, "asset.js");
-    writeFileSync(asset, "asset");
+    fs.writeFileSync(asset, "asset");
     const fetch = vi.fn<FetchAsset>(async () => new Response("asset"));
 
     const response = await createAppRequestHandler(
@@ -48,13 +48,13 @@ describe("createAppRequestHandler", () => {
     )(new Request("vibest://app/asset.js"));
 
     expect(await response.text()).toBe("asset");
-    expect(fetch).toHaveBeenCalledWith(pathToFileURL(asset).toString());
+    expect(fetch).toHaveBeenCalledWith(url.pathToFileURL(asset).toString());
   });
 
   it("falls back to the SPA entry for an unknown renderer path", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "vibest-renderer-"));
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-renderer-"));
     const entry = path.join(root, "index.html");
-    writeFileSync(entry, "app");
+    fs.writeFileSync(entry, "app");
     const fetch = vi.fn<FetchAsset>(async () => new Response("app"));
 
     const response = await createAppRequestHandler(
@@ -63,7 +63,7 @@ describe("createAppRequestHandler", () => {
     )(new Request("vibest://app/chat/session"));
 
     expect(await response.text()).toBe("app");
-    expect(fetch).toHaveBeenCalledWith(pathToFileURL(entry).toString());
+    expect(fetch).toHaveBeenCalledWith(url.pathToFileURL(entry).toString());
   });
 
   it("rejects a different custom-protocol host", async () => {

--- a/apps/desktop/src/main/electron/app-protocol.ts
+++ b/apps/desktop/src/main/electron/app-protocol.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import nodeUrl from "node:url";
+import url from "node:url";
 
 import { Data, Effect, Scope } from "effect";
 import { net, protocol } from "electron";
@@ -47,10 +47,10 @@ export type FetchAsset = (url: string) => Promise<Response>;
 /** Serve renderer assets with SPA fallback. */
 export function createAppRequestHandler(rendererRoot: string, fetchAsset: FetchAsset = net.fetch) {
   return async (request: Request): Promise<Response> => {
-    const url = new URL(request.url);
-    if (url.host !== HOST) return new Response("Not found", { status: 404 });
+    const requestUrl = new URL(request.url);
+    if (requestUrl.host !== HOST) return new Response("Not found", { status: 404 });
 
-    const file = resolveAssetPath(rendererRoot, url.pathname);
+    const file = resolveAssetPath(rendererRoot, requestUrl.pathname);
     if (!file) return new Response("Not found", { status: 404 });
 
     const target =
@@ -58,7 +58,7 @@ export function createAppRequestHandler(rendererRoot: string, fetchAsset: FetchA
         ? file
         : path.join(rendererRoot, "index.html");
 
-    return fetchAsset(nodeUrl.pathToFileURL(target).toString());
+    return fetchAsset(url.pathToFileURL(target).toString());
   };
 }
 

--- a/apps/desktop/src/main/electron/app-protocol.ts
+++ b/apps/desktop/src/main/electron/app-protocol.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import nodeUrl from "node:url";
 
 import { Data, Effect, Scope } from "effect";
 import { net, protocol } from "electron";
@@ -58,7 +58,7 @@ export function createAppRequestHandler(rendererRoot: string, fetchAsset: FetchA
         ? file
         : path.join(rendererRoot, "index.html");
 
-    return fetchAsset(pathToFileURL(target).toString());
+    return fetchAsset(nodeUrl.pathToFileURL(target).toString());
   };
 }
 

--- a/apps/desktop/src/main/electron/main-window.ts
+++ b/apps/desktop/src/main/electron/main-window.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import nodeUrl from "node:url";
 
 import { is } from "@electron-toolkit/utils";
 import { Context, Effect, Layer, Scope } from "effect";
@@ -61,7 +61,10 @@ export function makeMainWindow(
         trafficLightPosition: { x: 22, y: 20 },
         ...(process.platform === "linux" ? { icon } : {}),
         webPreferences: {
-          preload: path.join(path.dirname(fileURLToPath(import.meta.url)), "../preload/index.js"),
+          preload: path.join(
+            path.dirname(nodeUrl.fileURLToPath(import.meta.url)),
+            "../preload/index.js",
+          ),
           sandbox: true,
           contextIsolation: true,
           nodeIntegration: false,
@@ -136,7 +139,7 @@ export function makeMainWindow(
 }
 
 export function rendererRoot(): string {
-  return path.join(path.dirname(fileURLToPath(import.meta.url)), "../renderer");
+  return path.join(path.dirname(nodeUrl.fileURLToPath(import.meta.url)), "../renderer");
 }
 
 export const MainWindowLive = Layer.effect(

--- a/apps/desktop/src/main/electron/main-window.ts
+++ b/apps/desktop/src/main/electron/main-window.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import nodeUrl from "node:url";
+import url from "node:url";
 
 import { is } from "@electron-toolkit/utils";
 import { Context, Effect, Layer, Scope } from "effect";
@@ -23,9 +23,9 @@ export type MainWindowOptions = {
   readonly connectRenderer: (webContents: WebContents) => () => Promise<void>;
 };
 
-function canOpenExternal(url: string): boolean {
+function canOpenExternal(href: string): boolean {
   try {
-    const protocol = new URL(url).protocol;
+    const protocol = new URL(href).protocol;
     return protocol === "http:" || protocol === "https:";
   } catch {
     return false;
@@ -62,7 +62,7 @@ export function makeMainWindow(
         ...(process.platform === "linux" ? { icon } : {}),
         webPreferences: {
           preload: path.join(
-            path.dirname(nodeUrl.fileURLToPath(import.meta.url)),
+            path.dirname(url.fileURLToPath(import.meta.url)),
             "../preload/index.js",
           ),
           sandbox: true,
@@ -85,8 +85,8 @@ export function makeMainWindow(
         if (mainWindow === window) mainWindow = undefined;
       });
 
-      window.webContents.setWindowOpenHandler(({ url }) => {
-        if (canOpenExternal(url)) void shell.openExternal(url);
+      window.webContents.setWindowOpenHandler(({ url: href }) => {
+        if (canOpenExternal(href)) void shell.openExternal(href);
         return { action: "deny" };
       });
 
@@ -94,9 +94,9 @@ export function makeMainWindow(
         APP_ORIGIN,
         ...(options.devUrl ? [new URL(options.devUrl).origin] : []),
       ]);
-      window.webContents.on("will-navigate", (event, url) => {
+      window.webContents.on("will-navigate", (event, href) => {
         try {
-          if (allowedOrigins.has(new URL(url).origin)) return;
+          if (allowedOrigins.has(new URL(href).origin)) return;
         } catch {
           // Invalid navigation targets are denied below.
         }
@@ -139,7 +139,7 @@ export function makeMainWindow(
 }
 
 export function rendererRoot(): string {
-  return path.join(path.dirname(nodeUrl.fileURLToPath(import.meta.url)), "../renderer");
+  return path.join(path.dirname(url.fileURLToPath(import.meta.url)), "../renderer");
 }
 
 export const MainWindowLive = Layer.effect(

--- a/apps/desktop/src/main/lib/utils.ts
+++ b/apps/desktop/src/main/lib/utils.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import childProcess from "node:child_process";
 import path from "node:path";
 
 import { Effect } from "effect";
@@ -24,14 +24,16 @@ export function devUserDataPath(slug: string | undefined): string {
  * Basename of the current git worktree, sanitized for a path segment (e.g.
  * `dapper-mochi`). Used to key each dev checkout's userData dir. Not
  * `basename(cwd)` — dev's cwd is `apps/desktop`, identical across worktrees.
- * Succeeds with undefined outside a git checkout. Synchronous (execFileSync) so
+ * Succeeds with undefined outside a git checkout. Synchronous (childProcess.execFileSync) so
  * it can run in the pre-`whenReady` bootstrap, before any runtime exists.
  */
 export const devWorktreeSlug: Effect.Effect<string | undefined> = Effect.try(() =>
-  execFileSync("git", ["rev-parse", "--show-toplevel"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  }).trim(),
+  childProcess
+    .execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    .trim(),
 ).pipe(
   Effect.map((top) => {
     const slug = path.basename(top).replace(/[^a-zA-Z0-9._-]/g, "-");

--- a/apps/desktop/src/main/rpc/desktop-rpc-server.test.ts
+++ b/apps/desktop/src/main/rpc/desktop-rpc-server.test.ts
@@ -1,4 +1,4 @@
-import { MessageChannel } from "node:worker_threads";
+import workerThreads from "node:worker_threads";
 
 import { consumeEventIterator, createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/message-port";
@@ -67,7 +67,7 @@ function makeHarness(
     }),
   });
   const rpcServer = makeDesktopRpcServer(override ? override(base) : base, rpcContext);
-  const { port1, port2 } = new MessageChannel();
+  const { port1, port2 } = new workerThreads.MessageChannel();
   const detach = rpcServer.attach(port1);
   port1.start();
   port2.start();

--- a/packages/harness/test/claude-code/fold.test.ts
+++ b/packages/harness/test/claude-code/fold.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { it } from "@effect/vitest";

--- a/packages/harness/test/claude-code/fold.test.ts
+++ b/packages/harness/test/claude-code/fold.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { it } from "@effect/vitest";
@@ -21,10 +21,10 @@ describe("foldToUIMessages", () => {
       ] as unknown as SDKMessage[];
 
       const messages = yield* foldToUIMessages(transcript);
-      NodeAssert.equal(messages.length, 1);
+      assert.equal(messages.length, 1);
       const parts = messages[0]!.parts as ReadonlyArray<{ type: string; text?: string }>;
-      NodeAssert.ok(parts.some((part) => part.type === "text" && part.text === "hello"));
-      NodeAssert.ok(!parts.some((part) => part.type.startsWith("data-")));
+      assert.ok(parts.some((part) => part.type === "text" && part.text === "hello"));
+      assert.ok(!parts.some((part) => part.type.startsWith("data-")));
     }),
   );
 
@@ -56,8 +56,8 @@ describe("foldToUIMessages", () => {
       const part = messages[0]!.parts.find(
         (candidate) => (candidate as { type: string }).type === "tool-Read",
       ) as { output?: unknown } | undefined;
-      NodeAssert.ok(part);
-      NodeAssert.deepStrictEqual(part.output, {
+      assert.ok(part);
+      assert.deepStrictEqual(part.output, {
         type: "text",
         file: { filePath: "/a", content: "hi" },
       });
@@ -91,9 +91,9 @@ describe("foldToUIMessages", () => {
       const part = messages[0]!.parts.find(
         (candidate) => (candidate as { type: string }).type === "dynamic-tool",
       ) as { toolName?: string; output?: unknown } | undefined;
-      NodeAssert.ok(part);
-      NodeAssert.equal(part.toolName, "mcp__foo__bar");
-      NodeAssert.equal(part.output, undefined);
+      assert.ok(part);
+      assert.equal(part.toolName, "mcp__foo__bar");
+      assert.equal(part.output, undefined);
     }),
   );
 });

--- a/packages/harness/test/claude-code/tools-registry.test.ts
+++ b/packages/harness/test/claude-code/tools-registry.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { createRequire } from "node:module";
+import module from "node:module";
 import path from "node:path";
 
 import { describe, expect, test } from "vitest";
@@ -38,7 +38,7 @@ const EXCLUDED: Record<string, string> = {
 const NON_SDK_KEYS = new Set(["Task"]); // Task is a registry alias of Agent
 
 function readSdkToolsSource(): string {
-  const require = createRequire(import.meta.url);
+  const require = module.createRequire(import.meta.url);
   const main = require.resolve("@anthropic-ai/claude-agent-sdk");
   return fs.readFileSync(path.join(path.dirname(main), "sdk-tools.d.ts"), "utf8");
 }

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -1,5 +1,5 @@
-import { homedir } from "node:os";
-import { join } from "node:path";
+import os from "node:os";
+import path from "node:path";
 
 import { Context, Layer } from "effect";
 
@@ -23,9 +23,9 @@ export class Paths extends Context.Service<
 
 const resolve = (home: string) => ({
   home,
-  projectsFile: join(home, "storage", "projects.json"),
-  configFile: join(home, "config.json"),
-  sessionsDir: join(home, "storage", "sessions"),
+  projectsFile: path.join(home, "storage", "projects.json"),
+  configFile: path.join(home, "config.json"),
+  sessionsDir: path.join(home, "storage", "sessions"),
 });
 
 /**
@@ -34,7 +34,7 @@ const resolve = (home: string) => ({
  * one-daemon-per-home invariant can never drift on a second definition.
  */
 export function resolveVibestHome(env: NodeJS.ProcessEnv = process.env): string {
-  return env.VIBEST_HOME ?? join(homedir(), ".vibest");
+  return env.VIBEST_HOME ?? path.join(os.homedir(), ".vibest");
 }
 
 /** Point the runtime at an explicit home directory (used in tests). */

--- a/packages/server/src/fs/service.ts
+++ b/packages/server/src/fs/service.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import nodePath from "node:path";
 
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import { Context, Effect, FileSystem, Layer } from "effect";
@@ -23,8 +23,11 @@ const NUL = String.fromCharCode(0);
  * and t3code's `WorkspacePaths` use.)
  */
 const contains = (parent: string, child: string): boolean => {
-  const rel = relative(parent, child);
-  return rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`));
+  const rel = nodePath.relative(parent, child);
+  return (
+    rel === "" ||
+    (!nodePath.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${nodePath.sep}`))
+  );
 };
 
 type ReadFileError =
@@ -44,7 +47,7 @@ type ReadFileError =
 export class FileSystemService extends Context.Service<
   FileSystemService,
   {
-    /** Read `path` (relative to `cwd`) as UTF-8 text. */
+    /** Read `path` (nodePath.relative to `cwd`) as UTF-8 text. */
     readonly readFileString: (cwd: string, path: string) => Effect.Effect<string, ReadFileError>;
   }
 >()("FileSystemService") {}
@@ -62,10 +65,10 @@ export const FileSystemServiceLayer: Layer.Layer<FileSystemService> = Layer.effe
       Effect.gen(function* () {
         // `cwd` is the trusted root and must be absolute; `path` must be relative
         // to it (an absolute `path` would silently ignore `cwd`).
-        if (!isAbsolute(cwd) || isAbsolute(path)) {
+        if (!nodePath.isAbsolute(cwd) || nodePath.isAbsolute(path)) {
           return yield* new WorkspacePathEscape({ cwd, path });
         }
-        const absolute = resolve(cwd, path);
+        const absolute = nodePath.resolve(cwd, path);
         if (!contains(cwd, absolute)) {
           return yield* new WorkspacePathEscape({ cwd, path });
         }

--- a/packages/server/src/fs/service.ts
+++ b/packages/server/src/fs/service.ts
@@ -1,4 +1,4 @@
-import nodePath from "node:path";
+import path from "node:path";
 
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import { Context, Effect, FileSystem, Layer } from "effect";
@@ -23,11 +23,8 @@ const NUL = String.fromCharCode(0);
  * and t3code's `WorkspacePaths` use.)
  */
 const contains = (parent: string, child: string): boolean => {
-  const rel = nodePath.relative(parent, child);
-  return (
-    rel === "" ||
-    (!nodePath.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${nodePath.sep}`))
-  );
+  const rel = path.relative(parent, child);
+  return rel === "" || (!path.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${path.sep}`));
 };
 
 type ReadFileError =
@@ -47,7 +44,7 @@ type ReadFileError =
 export class FileSystemService extends Context.Service<
   FileSystemService,
   {
-    /** Read `path` (nodePath.relative to `cwd`) as UTF-8 text. */
+    /** Read `path` (relative to `cwd`) as UTF-8 text. */
     readonly readFileString: (cwd: string, path: string) => Effect.Effect<string, ReadFileError>;
   }
 >()("FileSystemService") {}
@@ -57,44 +54,47 @@ export const FileSystemServiceLayer: Layer.Layer<FileSystemService> = Layer.effe
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
 
-    const readErr = (path: string) => (cause: unknown) => new WorkspaceReadError({ path, cause });
+    const readErr = (relPath: string) => (cause: unknown) =>
+      new WorkspaceReadError({ path: relPath, cause });
 
-    // Resolve `path` against `cwd` and confine it there both lexically and after
+    // Resolve `relPath` against `cwd` and confine it there both lexically and after
     // realpath — the first stops `..`, the second stops symlinks pointing out.
-    const resolveWithin = (cwd: string, path: string) =>
+    const resolveWithin = (cwd: string, relPath: string) =>
       Effect.gen(function* () {
-        // `cwd` is the trusted root and must be absolute; `path` must be relative
-        // to it (an absolute `path` would silently ignore `cwd`).
-        if (!nodePath.isAbsolute(cwd) || nodePath.isAbsolute(path)) {
-          return yield* new WorkspacePathEscape({ cwd, path });
+        // `cwd` is the trusted root and must be absolute; `relPath` must be relative
+        // to it (an absolute `relPath` would silently ignore `cwd`).
+        if (!path.isAbsolute(cwd) || path.isAbsolute(relPath)) {
+          return yield* new WorkspacePathEscape({ cwd, path: relPath });
         }
-        const absolute = nodePath.resolve(cwd, path);
+        const absolute = path.resolve(cwd, relPath);
         if (!contains(cwd, absolute)) {
-          return yield* new WorkspacePathEscape({ cwd, path });
+          return yield* new WorkspacePathEscape({ cwd, path: relPath });
         }
-        const realRoot = yield* fs.realPath(cwd).pipe(Effect.mapError(readErr(path)));
-        const realTarget = yield* fs.realPath(absolute).pipe(Effect.mapError(readErr(path)));
+        const realRoot = yield* fs.realPath(cwd).pipe(Effect.mapError(readErr(relPath)));
+        const realTarget = yield* fs.realPath(absolute).pipe(Effect.mapError(readErr(relPath)));
         if (!contains(realRoot, realTarget)) {
-          return yield* new WorkspacePathEscape({ cwd, path });
+          return yield* new WorkspacePathEscape({ cwd, path: relPath });
         }
         return absolute;
       });
 
     return {
-      readFileString: (cwd, path) =>
+      readFileString: (cwd, relPath) =>
         Effect.gen(function* () {
-          const absolute = yield* resolveWithin(cwd, path);
-          const info = yield* fs.stat(absolute).pipe(Effect.mapError(readErr(path)));
+          const absolute = yield* resolveWithin(cwd, relPath);
+          const info = yield* fs.stat(absolute).pipe(Effect.mapError(readErr(relPath)));
           if (info.type !== "File") {
-            return yield* new WorkspaceNotFile({ path });
+            return yield* new WorkspaceNotFile({ path: relPath });
           }
           const size = Number(info.size);
           if (size > MAX_FILE_BYTES) {
-            return yield* new WorkspaceFileTooLarge({ path, size, limit: MAX_FILE_BYTES });
+            return yield* new WorkspaceFileTooLarge({ path: relPath, size, limit: MAX_FILE_BYTES });
           }
-          const content = yield* fs.readFileString(absolute).pipe(Effect.mapError(readErr(path)));
+          const content = yield* fs
+            .readFileString(absolute)
+            .pipe(Effect.mapError(readErr(relPath)));
           if (content.includes(NUL)) {
-            return yield* new WorkspaceBinaryFile({ path });
+            return yield* new WorkspaceBinaryFile({ path: relPath });
           }
           return content;
         }),

--- a/packages/server/src/harness/claude-code/executable.ts
+++ b/packages/server/src/harness/claude-code/executable.ts
@@ -1,12 +1,12 @@
-import { execFile } from "node:child_process";
-import { accessSync, constants, readFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import { homedir } from "node:os";
+import childProcess from "node:child_process";
+import nodeFs from "node:fs";
+import module from "node:module";
+import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
+import util from "node:util";
 
-const moduleRequire = createRequire(import.meta.url);
-const execFileAsync = promisify(execFile);
+const moduleRequire = module.createRequire(import.meta.url);
+const execFileAsync = util.promisify(childProcess.execFile);
 
 /** Where the native installer and the common package managers put `claude`. */
 function extraInstallDirs(home: string): string[] {
@@ -20,7 +20,7 @@ function extraInstallDirs(home: string): string[] {
 
 function isExecutableFile(candidate: string): boolean {
   try {
-    accessSync(candidate, constants.X_OK);
+    nodeFs.accessSync(candidate, nodeFs.constants.X_OK);
     return true;
   } catch {
     return false;
@@ -67,7 +67,7 @@ export type ResolveDeps = {
 export function resolveClaudeExecutable(deps: ResolveDeps = {}): string {
   const {
     env = process.env,
-    home = homedir(),
+    home = os.homedir(),
     bundled = sdkBinary,
     isExecutable = isExecutableFile,
     platform = process.platform,
@@ -106,7 +106,7 @@ export function resolveClaudeExecutable(deps: ResolveDeps = {}): string {
 export function requiredClaudeVersion(): string {
   const main = moduleRequire.resolve("@anthropic-ai/claude-agent-sdk");
   const manifest = JSON.parse(
-    readFileSync(path.join(path.dirname(main), "package.json"), "utf8"),
+    nodeFs.readFileSync(path.join(path.dirname(main), "package.json"), "utf8"),
   ) as { claudeCodeVersion?: string };
   if (!manifest.claudeCodeVersion) {
     throw new Error("Claude Agent SDK manifest is missing claudeCodeVersion.");

--- a/packages/server/src/harness/claude-code/executable.ts
+++ b/packages/server/src/harness/claude-code/executable.ts
@@ -1,5 +1,5 @@
 import childProcess from "node:child_process";
-import nodeFs from "node:fs";
+import fs from "node:fs";
 import module from "node:module";
 import os from "node:os";
 import path from "node:path";
@@ -20,7 +20,7 @@ function extraInstallDirs(home: string): string[] {
 
 function isExecutableFile(candidate: string): boolean {
   try {
-    nodeFs.accessSync(candidate, nodeFs.constants.X_OK);
+    fs.accessSync(candidate, fs.constants.X_OK);
     return true;
   } catch {
     return false;
@@ -106,7 +106,7 @@ export function resolveClaudeExecutable(deps: ResolveDeps = {}): string {
 export function requiredClaudeVersion(): string {
   const main = moduleRequire.resolve("@anthropic-ai/claude-agent-sdk");
   const manifest = JSON.parse(
-    nodeFs.readFileSync(path.join(path.dirname(main), "package.json"), "utf8"),
+    fs.readFileSync(path.join(path.dirname(main), "package.json"), "utf8"),
   ) as { claudeCodeVersion?: string };
   if (!manifest.claudeCodeVersion) {
     throw new Error("Claude Agent SDK manifest is missing claudeCodeVersion.");

--- a/packages/server/src/harness/executable.ts
+++ b/packages/server/src/harness/executable.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants } from "node:fs";
+import fs from "node:fs";
 import path from "node:path";
 
 /**
@@ -35,7 +35,7 @@ function candidateNames(command: string, platform: NodeJS.Platform): string[] {
 
 function isExecutableFile(candidate: string): boolean {
   try {
-    accessSync(candidate, constants.X_OK);
+    fs.accessSync(candidate, fs.constants.X_OK);
     return true;
   } catch {
     return false;

--- a/packages/server/src/http/auth.ts
+++ b/packages/server/src/http/auth.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import crypto from "node:crypto";
 
 /** How long an issued WebSocket ticket stays redeemable. */
 export const TICKET_TTL_MS = 10_000;
@@ -20,7 +20,7 @@ export function createTicketStore(now: () => number = Date.now): TicketStore {
 
   return {
     issue() {
-      const ticket = randomUUID();
+      const ticket = crypto.randomUUID();
       expiries.set(ticket, now() + TICKET_TTL_MS);
       return ticket;
     },

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
-import nodeHttp from "node:http";
+import http from "node:http";
 
 import type { WebSocket } from "ws";
 import { WebSocketServer } from "ws";
@@ -45,7 +45,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
   let serveUI: UIHandler;
   let closeUI = async () => {};
 
-  const server = nodeHttp.createServer((req, res) => {
+  const server = http.createServer((req, res) => {
     void handleRequest(req, res);
   });
 

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
-import { createServer as createHttpServer } from "node:http";
+import nodeHttp from "node:http";
 
 import type { WebSocket } from "ws";
 import { WebSocketServer } from "ws";
@@ -45,7 +45,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
   let serveUI: UIHandler;
   let closeUI = async () => {};
 
-  const server = createHttpServer((req, res) => {
+  const server = nodeHttp.createServer((req, res) => {
     void handleRequest(req, res);
   });
 

--- a/packages/server/src/http/ui.ts
+++ b/packages/server/src/http/ui.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import url from "node:url";
 
 import sirv from "sirv";
 
@@ -24,7 +24,7 @@ function resolveStaticDir(): string | undefined {
     new URL("../../../apps/app/dist/", import.meta.url), // monorepo, from packages/vibest/dist
   ];
   for (const candidate of candidates) {
-    const dir = path.resolve(fileURLToPath(candidate));
+    const dir = path.resolve(url.fileURLToPath(candidate));
     if (fs.existsSync(path.join(dir, "index.html"))) {
       return dir;
     }
@@ -47,7 +47,7 @@ export async function createUIHandler(
     const { createServer: createViteDevServer } = await import("vite");
     const vite = await createViteDevServer({
       // Serve the standalone web app package (apps/app) through this server.
-      root: path.resolve(fileURLToPath(new URL("../../../../apps/app/", import.meta.url))),
+      root: path.resolve(url.fileURLToPath(new URL("../../../../apps/app/", import.meta.url))),
       server: {
         middlewareMode: true,
         hmr: { server },

--- a/packages/server/src/infra/json-store.ts
+++ b/packages/server/src/infra/json-store.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
 
 import { Effect } from "effect";
 
@@ -18,7 +18,7 @@ export const readJson = <A>(file: string, fallback: A): Effect.Effect<A, StoreRe
     try: async () => {
       let raw: string;
       try {
-        raw = await readFile(file, "utf8");
+        raw = await fs.readFile(file, "utf8");
       } catch (cause) {
         if (isEnoent(cause)) return fallback;
         throw cause;
@@ -38,10 +38,10 @@ export const writeJsonAtomic = (
 ): Effect.Effect<void, StoreWriteError> =>
   Effect.tryPromise({
     try: async () => {
-      await mkdir(dirname(file), { recursive: true });
-      const tmp = `${file}.${randomUUID()}.tmp`;
-      await writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-      await rename(tmp, file);
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      const tmp = `${file}.${crypto.randomUUID()}.tmp`;
+      await fs.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+      await fs.rename(tmp, file);
     },
     catch: (cause) => new StoreWriteError({ file, cause }),
   });

--- a/packages/server/src/project/service.ts
+++ b/packages/server/src/project/service.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Context, Effect, Layer } from "effect";
 
@@ -48,24 +48,24 @@ export const ProjectServiceLayer: Layer.Layer<ProjectService, never, ProjectRepo
             return found;
           }),
 
-        findByPath: (path) =>
+        findByPath: (targetPath) =>
           Effect.gen(function* () {
             const projects = yield* repo.list();
-            const target = nodePath.resolve(path);
-            return projects.find((p) => nodePath.resolve(p.path) === target);
+            const target = path.resolve(targetPath);
+            return projects.find((p) => path.resolve(p.path) === target);
           }),
 
         create: (input) =>
           Effect.gen(function* () {
-            const normalized = nodePath.resolve(input.path);
+            const normalized = path.resolve(input.path);
             const projects = yield* repo.list();
             // Reuse an existing project pointing at the same path.
-            const existing = projects.find((p) => nodePath.resolve(p.path) === normalized);
+            const existing = projects.find((p) => path.resolve(p.path) === normalized);
             if (existing !== undefined) return existing;
 
             const project: Project = {
               id: crypto.randomUUID(),
-              name: input.name ?? nodePath.basename(normalized),
+              name: input.name ?? path.basename(normalized),
               path: normalized,
               createdAt: new Date().toISOString(),
             };

--- a/packages/server/src/project/service.ts
+++ b/packages/server/src/project/service.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from "node:crypto";
-import { basename, resolve as resolvePath } from "node:path";
+import crypto from "node:crypto";
+import nodePath from "node:path";
 
 import { Context, Effect, Layer } from "effect";
 
@@ -51,21 +51,21 @@ export const ProjectServiceLayer: Layer.Layer<ProjectService, never, ProjectRepo
         findByPath: (path) =>
           Effect.gen(function* () {
             const projects = yield* repo.list();
-            const target = resolvePath(path);
-            return projects.find((p) => resolvePath(p.path) === target);
+            const target = nodePath.resolve(path);
+            return projects.find((p) => nodePath.resolve(p.path) === target);
           }),
 
         create: (input) =>
           Effect.gen(function* () {
-            const normalized = resolvePath(input.path);
+            const normalized = nodePath.resolve(input.path);
             const projects = yield* repo.list();
             // Reuse an existing project pointing at the same path.
-            const existing = projects.find((p) => resolvePath(p.path) === normalized);
+            const existing = projects.find((p) => nodePath.resolve(p.path) === normalized);
             if (existing !== undefined) return existing;
 
             const project: Project = {
-              id: randomUUID(),
-              name: input.name ?? basename(normalized),
+              id: crypto.randomUUID(),
+              name: input.name ?? nodePath.basename(normalized),
               path: normalized,
               createdAt: new Date().toISOString(),
             };

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -1,6 +1,6 @@
 import "@orpc/experimental-effect/extensions/effect";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { implement } from "@orpc/server";
 import { fsContract } from "@vibest/contract/fs";
@@ -36,19 +36,19 @@ export const fsRouter = orpc.router({
   }),
   browse: orpc.browse.effect(function* ({ input, errors }) {
     const fs = yield* FileSystem;
-    const path = nodePath.resolve(input.path ?? os.homedir());
+    const root = path.resolve(input.path ?? os.homedir());
     // Folder-picker policy (owned here, not a shared fs service): directories
     // only, hide dotfolders and node_modules, sorted by name.
     const names = yield* fs
-      .readDirectory(path)
-      .pipe(Effect.mapError(() => errors.READ_FAILED({ data: { path } })));
+      .readDirectory(root)
+      .pipe(Effect.mapError(() => errors.READ_FAILED({ data: { path: root } })));
     const candidates = names.filter((name) => !name.startsWith(".") && !IGNORED_DIRS.has(name));
     // readDirectory yields names only, so stat each to keep just directories. A
     // failing stat (e.g. broken symlink) drops that entry rather than the list.
     const flagged = yield* Effect.forEach(
       candidates,
       (name) =>
-        fs.stat(nodePath.join(path, name)).pipe(
+        fs.stat(path.join(root, name)).pipe(
           Effect.map((info) => info.type === "Directory"),
           Effect.catch(() => Effect.succeed(false)),
           Effect.map((isDirectory) => ({ name, isDirectory })),
@@ -57,10 +57,10 @@ export const fsRouter = orpc.router({
     );
     const directories = flagged
       .filter((e) => e.isDirectory)
-      .map((e) => ({ name: e.name, path: nodePath.join(path, e.name) }));
+      .map((e) => ({ name: e.name, path: path.join(root, e.name) }));
     directories.sort((a, b) => a.name.localeCompare(b.name));
-    const parent = nodePath.dirname(path);
-    return { path, parent: parent === path ? null : parent, directories };
+    const parent = path.dirname(root);
+    return { path: root, parent: parent === root ? null : parent, directories };
   }),
 });
 

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -1,6 +1,6 @@
 import "@orpc/experimental-effect/extensions/effect";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import os from "node:os";
+import nodePath from "node:path";
 
 import { implement } from "@orpc/server";
 import { fsContract } from "@vibest/contract/fs";
@@ -36,7 +36,7 @@ export const fsRouter = orpc.router({
   }),
   browse: orpc.browse.effect(function* ({ input, errors }) {
     const fs = yield* FileSystem;
-    const path = resolve(input.path ?? homedir());
+    const path = nodePath.resolve(input.path ?? os.homedir());
     // Folder-picker policy (owned here, not a shared fs service): directories
     // only, hide dotfolders and node_modules, sorted by name.
     const names = yield* fs
@@ -48,7 +48,7 @@ export const fsRouter = orpc.router({
     const flagged = yield* Effect.forEach(
       candidates,
       (name) =>
-        fs.stat(join(path, name)).pipe(
+        fs.stat(nodePath.join(path, name)).pipe(
           Effect.map((info) => info.type === "Directory"),
           Effect.catch(() => Effect.succeed(false)),
           Effect.map((isDirectory) => ({ name, isDirectory })),
@@ -57,9 +57,9 @@ export const fsRouter = orpc.router({
     );
     const directories = flagged
       .filter((e) => e.isDirectory)
-      .map((e) => ({ name: e.name, path: join(path, e.name) }));
+      .map((e) => ({ name: e.name, path: nodePath.join(path, e.name) }));
     directories.sort((a, b) => a.name.localeCompare(b.name));
-    const parent = dirname(path);
+    const parent = nodePath.dirname(path);
     return { path, parent: parent === path ? null : parent, directories };
   }),
 });

--- a/packages/server/src/session/service.ts
+++ b/packages/server/src/session/service.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import crypto from "node:crypto";
 
 import type {
   AgentResponse,
@@ -245,7 +245,7 @@ export const SessionServiceLayer: Layer.Layer<
           Effect.flatMap((project) =>
             port.create(harnessAgentId, project.path, config).pipe(
               Effect.flatMap((harnessSessionId) => {
-                const sessionId = randomUUID();
+                const sessionId = crypto.randomUUID();
                 const metadata: Session = {
                   version: 1,
                   sessionId,

--- a/packages/server/test/event-bus-overflow.test.ts
+++ b/packages/server/test/event-bus-overflow.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import type { SessionRef, SessionScopedEvent } from "@vibest/contract";
@@ -27,11 +27,11 @@ it.effect("terminates a slow consumer once its bounded queue overflows", () =>
       yield* bus.publish(started(3));
 
       const items = yield* Stream.runCollect(stream.pipe(Stream.take(3)));
-      NodeAssert.deepStrictEqual(
+      assert.deepStrictEqual(
         items.map((item) => item.type),
         ["event", "event", "closed"],
       );
-      NodeAssert.deepStrictEqual(items[2], { type: "closed", reason: "slow_consumer" });
+      assert.deepStrictEqual(items[2], { type: "closed", reason: "slow_consumer" });
     }),
   ),
 );
@@ -46,11 +46,11 @@ it.effect("closeSession ends a matching subscriber with its reason", () =>
       yield* bus.closeSession(ref, "session_closed");
 
       const items = yield* Stream.runCollect(stream);
-      NodeAssert.deepStrictEqual(
+      assert.deepStrictEqual(
         items.map((item) => item.type),
         ["event", "closed"],
       );
-      NodeAssert.deepStrictEqual(items.at(-1), { type: "closed", reason: "session_closed" });
+      assert.deepStrictEqual(items.at(-1), { type: "closed", reason: "session_closed" });
     }),
   ),
 );

--- a/packages/server/test/event-bus-overflow.test.ts
+++ b/packages/server/test/event-bus-overflow.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import type { SessionRef, SessionScopedEvent } from "@vibest/contract";

--- a/packages/server/test/events.test.ts
+++ b/packages/server/test/events.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import { layer } from "@effect/vitest";
 import type { CollectionEvent, SessionRef, SessionScopedEvent } from "@vibest/contract";
@@ -34,7 +34,7 @@ layer(EventBusLayer)("EventBus", (it) => {
       const seqs = items.flatMap((item) =>
         item.type === "event" && "seq" in item.event ? [item.event.seq] : [],
       );
-      NodeAssert.deepStrictEqual(seqs, [1, 2]);
+      assert.deepStrictEqual(seqs, [1, 2]);
     }),
   );
 
@@ -49,7 +49,7 @@ layer(EventBusLayer)("EventBus", (it) => {
       yield* bus.publish({ ref: ref("a"), type: "session.created" } satisfies CollectionEvent);
 
       const items = yield* Fiber.join(collector);
-      NodeAssert.deepStrictEqual(
+      assert.deepStrictEqual(
         items.map((item) => (item.type === "event" ? item.event.type : item.type)),
         ["session.turn.started", "session.turn.started", "session.created"],
       );

--- a/packages/server/test/events.test.ts
+++ b/packages/server/test/events.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import { layer } from "@effect/vitest";
 import type { CollectionEvent, SessionRef, SessionScopedEvent } from "@vibest/contract";

--- a/packages/server/test/fs.test.ts
+++ b/packages/server/test/fs.test.ts
@@ -1,6 +1,6 @@
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import nodeFs from "node:fs/promises";
+import os from "node:os";
+import nodePath from "node:path";
 
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -11,17 +11,17 @@ describe("FileSystemService", () => {
   let cwd: string;
   let outside: string;
   beforeEach(async () => {
-    cwd = await mkdtemp(join(tmpdir(), "vibest-fs-"));
-    outside = await mkdtemp(join(tmpdir(), "vibest-out-"));
-    await writeFile(join(cwd, "a.txt"), "hello\nworld");
-    await mkdir(join(cwd, "sub"), { recursive: true });
-    await writeFile(join(outside, "secret.txt"), "top secret");
-    await symlink(join(outside, "secret.txt"), join(cwd, "link"));
-    await writeFile(join(cwd, "bin"), Buffer.from([104, 0, 105])); // "h\0i"
+    cwd = await nodeFs.mkdtemp(nodePath.join(os.tmpdir(), "vibest-fs-"));
+    outside = await nodeFs.mkdtemp(nodePath.join(os.tmpdir(), "vibest-out-"));
+    await nodeFs.writeFile(nodePath.join(cwd, "a.txt"), "hello\nworld");
+    await nodeFs.mkdir(nodePath.join(cwd, "sub"), { recursive: true });
+    await nodeFs.writeFile(nodePath.join(outside, "secret.txt"), "top secret");
+    await nodeFs.symlink(nodePath.join(outside, "secret.txt"), nodePath.join(cwd, "link"));
+    await nodeFs.writeFile(nodePath.join(cwd, "bin"), Buffer.from([104, 0, 105])); // "h\0i"
   });
   afterEach(async () => {
-    await rm(cwd, { recursive: true, force: true });
-    await rm(outside, { recursive: true, force: true });
+    await nodeFs.rm(cwd, { recursive: true, force: true });
+    await nodeFs.rm(outside, { recursive: true, force: true });
   });
 
   const run = <A, E>(program: Effect.Effect<A, E, FileSystemService>) =>
@@ -52,7 +52,9 @@ describe("FileSystemService", () => {
   });
 
   it("rejects an absolute path", async () => {
-    expect(await errorTag(readFile(join(outside, "secret.txt")))).toBe("WorkspacePathEscape");
+    expect(await errorTag(readFile(nodePath.join(outside, "secret.txt")))).toBe(
+      "WorkspacePathEscape",
+    );
   });
 
   it("rejects a `..` escape", async () => {

--- a/packages/server/test/fs.test.ts
+++ b/packages/server/test/fs.test.ts
@@ -1,6 +1,6 @@
-import nodeFs from "node:fs/promises";
+import fs from "node:fs/promises";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -11,17 +11,17 @@ describe("FileSystemService", () => {
   let cwd: string;
   let outside: string;
   beforeEach(async () => {
-    cwd = await nodeFs.mkdtemp(nodePath.join(os.tmpdir(), "vibest-fs-"));
-    outside = await nodeFs.mkdtemp(nodePath.join(os.tmpdir(), "vibest-out-"));
-    await nodeFs.writeFile(nodePath.join(cwd, "a.txt"), "hello\nworld");
-    await nodeFs.mkdir(nodePath.join(cwd, "sub"), { recursive: true });
-    await nodeFs.writeFile(nodePath.join(outside, "secret.txt"), "top secret");
-    await nodeFs.symlink(nodePath.join(outside, "secret.txt"), nodePath.join(cwd, "link"));
-    await nodeFs.writeFile(nodePath.join(cwd, "bin"), Buffer.from([104, 0, 105])); // "h\0i"
+    cwd = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-fs-"));
+    outside = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-out-"));
+    await fs.writeFile(path.join(cwd, "a.txt"), "hello\nworld");
+    await fs.mkdir(path.join(cwd, "sub"), { recursive: true });
+    await fs.writeFile(path.join(outside, "secret.txt"), "top secret");
+    await fs.symlink(path.join(outside, "secret.txt"), path.join(cwd, "link"));
+    await fs.writeFile(path.join(cwd, "bin"), Buffer.from([104, 0, 105])); // "h\0i"
   });
   afterEach(async () => {
-    await nodeFs.rm(cwd, { recursive: true, force: true });
-    await nodeFs.rm(outside, { recursive: true, force: true });
+    await fs.rm(cwd, { recursive: true, force: true });
+    await fs.rm(outside, { recursive: true, force: true });
   });
 
   const run = <A, E>(program: Effect.Effect<A, E, FileSystemService>) =>
@@ -41,10 +41,10 @@ describe("FileSystemService", () => {
       ),
     );
 
-  const readFile = (path: string) =>
+  const readFile = (relPath: string) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystemService;
-      return yield* fs.readFileString(cwd, path);
+      const service = yield* FileSystemService;
+      return yield* service.readFileString(cwd, relPath);
     });
 
   it("reads a file relative to cwd", async () => {
@@ -52,9 +52,7 @@ describe("FileSystemService", () => {
   });
 
   it("rejects an absolute path", async () => {
-    expect(await errorTag(readFile(nodePath.join(outside, "secret.txt")))).toBe(
-      "WorkspacePathEscape",
-    );
+    expect(await errorTag(readFile(path.join(outside, "secret.txt")))).toBe("WorkspacePathEscape");
   });
 
   it("rejects a `..` escape", async () => {

--- a/packages/server/test/git.test.ts
+++ b/packages/server/test/git.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { Effect } from "effect";
 import { simpleGit } from "simple-git";
@@ -11,24 +11,24 @@ import { GitService, GitServiceLayer } from "../src/index";
 describe("GitService", () => {
   let dir: string;
   beforeEach(async () => {
-    dir = await mkdtemp(join(tmpdir(), "vibest-git-"));
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-git-"));
     const git = simpleGit(dir);
     await git.raw(["init", "-b", "main"]);
     await git.addConfig("user.email", "test@example.com");
     await git.addConfig("user.name", "Test");
-    await writeFile(join(dir, "a.txt"), "hi");
+    await fs.writeFile(path.join(dir, "a.txt"), "hi");
     await git.add(".");
     await git.commit("init");
   });
   afterEach(async () => {
-    await rm(dir, { recursive: true, force: true });
+    await fs.rm(dir, { recursive: true, force: true });
   });
 
   const run = <A, E>(program: Effect.Effect<A, E, GitService>) =>
     Effect.runPromise(Effect.provide(program, GitServiceLayer));
 
   it("reports working-tree status with untracked files", async () => {
-    await writeFile(join(dir, "untracked.txt"), "x");
+    await fs.writeFile(path.join(dir, "untracked.txt"), "x");
     const status = await run(
       Effect.gen(function* () {
         const git = yield* GitService;

--- a/packages/server/test/harness/child-process.test.ts
+++ b/packages/server/test/harness/child-process.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";

--- a/packages/server/test/harness/child-process.test.ts
+++ b/packages/server/test/harness/child-process.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
@@ -19,8 +19,8 @@ layer(NodeServices.layer)("Effect child process integration", (it) => {
       );
       const exitCode = yield* handle.exitCode;
 
-      NodeAssert.equal(output, "ready\n");
-      NodeAssert.equal(exitCode, 0);
+      assert.equal(output, "ready\n");
+      assert.equal(exitCode, 0);
     }),
   );
 
@@ -36,11 +36,11 @@ layer(NodeServices.layer)("Effect child process integration", (it) => {
         )
         .pipe(Effect.provideService(Scope.Scope, childScope));
 
-      NodeAssert.equal(yield* handle.isRunning, true);
+      assert.equal(yield* handle.isRunning, true);
 
       yield* Scope.close(childScope, Exit.void);
 
-      NodeAssert.equal(yield* handle.isRunning, false);
+      assert.equal(yield* handle.isRunning, false);
     }),
   );
 });

--- a/packages/server/test/harness/claude-code/agent.test.ts
+++ b/packages/server/test/harness/claude-code/agent.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import type * as sdk from "@anthropic-ai/claude-agent-sdk";
 import { it } from "@effect/vitest";

--- a/packages/server/test/harness/claude-code/agent.test.ts
+++ b/packages/server/test/harness/claude-code/agent.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import type * as sdk from "@anthropic-ai/claude-agent-sdk";
 import { it } from "@effect/vitest";
@@ -101,7 +101,7 @@ describe("ClaudeCodeAgent", () => {
       });
       const { sessionId } = yield* agent.session.create();
 
-      NodeAssert.equal(lastOptions().env?.["HTTPS_PROXY"], "http://desktop-proxy.test:8443");
+      assert.equal(lastOptions().env?.["HTTPS_PROXY"], "http://desktop-proxy.test:8443");
       yield* agent.session.abort(sessionId);
     }),
   );
@@ -111,10 +111,10 @@ describe("ClaudeCodeAgent", () => {
       const agent = yield* makeClaudeCodeAgent();
       const { sessionId } = yield* agent.session.create();
 
-      NodeAssert.equal(lastOptions().permissionMode, undefined);
+      assert.equal(lastOptions().permissionMode, undefined);
       // The bypass capability is always enabled so a session can be switched to
       // "bypassPermissions" at runtime; the active mode stays the SDK default.
-      NodeAssert.equal(lastOptions().allowDangerouslySkipPermissions, true);
+      assert.equal(lastOptions().allowDangerouslySkipPermissions, true);
       yield* agent.session.abort(sessionId);
     }),
   );
@@ -124,8 +124,8 @@ describe("ClaudeCodeAgent", () => {
       const agent = yield* makeClaudeCodeAgent({ permissionMode: "bypassPermissions" });
       const { sessionId } = yield* agent.session.create();
 
-      NodeAssert.equal(lastOptions().permissionMode, "bypassPermissions");
-      NodeAssert.equal(lastOptions().allowDangerouslySkipPermissions, true);
+      assert.equal(lastOptions().permissionMode, "bypassPermissions");
+      assert.equal(lastOptions().allowDangerouslySkipPermissions, true);
       yield* agent.session.abort(sessionId);
     }),
   );
@@ -135,22 +135,22 @@ describe("ClaudeCodeAgent", () => {
       const agent = yield* makeClaudeCodeAgent();
       const { sessionId } = yield* agent.session.create();
 
-      NodeAssert.match(
+      assert.match(
         sessionId,
         /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
       );
-      NodeAssert.equal(lastOptions().sessionId, sessionId);
-      NodeAssert.deepStrictEqual(yield* agent.session.getSupportedCommands(sessionId), [
+      assert.equal(lastOptions().sessionId, sessionId);
+      assert.deepStrictEqual(yield* agent.session.getSupportedCommands(sessionId), [
         { name: "read", description: "Read files", argumentHint: "<file>" },
       ]);
-      NodeAssert.deepStrictEqual(yield* agent.session.getSupportedModels(sessionId), [
+      assert.deepStrictEqual(yield* agent.session.getSupportedModels(sessionId), [
         { value: "sonnet", displayName: "Sonnet", description: "Fast" },
       ]);
-      NodeAssert.deepStrictEqual(yield* agent.session.getMcpServers(sessionId), [
+      assert.deepStrictEqual(yield* agent.session.getMcpServers(sessionId), [
         { name: "filesystem", status: "connected" },
       ]);
       yield* agent.session.abort(sessionId);
-      NodeAssert.equal(queryInstance.interrupt.mock.calls.length, 1);
+      assert.equal(queryInstance.interrupt.mock.calls.length, 1);
     }),
   );
 
@@ -170,11 +170,11 @@ describe("ClaudeCodeAgent", () => {
       });
       const output = yield* Stream.runCollect(prompt.output);
 
-      NodeAssert.deepStrictEqual(
+      assert.deepStrictEqual(
         Array.from(output, (message) => message.type),
         ["system", "result"],
       );
-      NodeAssert.deepStrictEqual(queryInstance.setModel.mock.calls, [["opus"]]);
+      assert.deepStrictEqual(queryInstance.setModel.mock.calls, [["opus"]]);
     }),
   );
 
@@ -200,7 +200,7 @@ describe("ClaudeCodeAgent", () => {
       yield* Effect.promise(() => nativeFailed);
       yield* Effect.forEach([1, 2, 3, 4], () => Effect.yieldNow, { discard: true });
 
-      NodeAssert.equal(
+      assert.equal(
         yield* Deferred.isDone(crashSeen),
         true,
         "idle Claude adapter session did not publish session.crashed",
@@ -232,12 +232,12 @@ describe("ClaudeCodeAgent", () => {
       });
       const events = yield* Fiber.join(collected);
 
-      NodeAssert.equal(typeof receipt.turnId, "string");
-      NodeAssert.deepStrictEqual(
+      assert.equal(typeof receipt.turnId, "string");
+      assert.deepStrictEqual(
         Array.from(events, (event) => event.body.type),
         ["session.turn.started", "start", "finish", "session.turn.ended"],
       );
-      NodeAssert.deepStrictEqual(queryInstance.setModel.mock.calls, [["opus"]]);
+      assert.deepStrictEqual(queryInstance.setModel.mock.calls, [["opus"]]);
       yield* session.close;
     }),
   );
@@ -259,7 +259,7 @@ describe("ClaudeCodeAgent", () => {
           message: { role: "user", content: "second" },
         })
         .pipe(Effect.flip);
-      NodeAssert.equal(error._tag, "TurnAlreadyRunning");
+      assert.equal(error._tag, "TurnAlreadyRunning");
       yield* agent.session.abort(sessionId);
     }),
   );
@@ -281,7 +281,7 @@ describe("ClaudeCodeAgent", () => {
         message: { role: "user", content: "fail" },
       });
       const firstExit = yield* Stream.runCollect(first.output).pipe(Effect.exit);
-      NodeAssert.equal(firstExit._tag, "Failure");
+      assert.equal(firstExit._tag, "Failure");
 
       yield* Effect.eventually(
         agent.session.getSupportedCommands(sessionId).pipe(
@@ -291,8 +291,8 @@ describe("ClaudeCodeAgent", () => {
           ),
         ),
       );
-      NodeAssert.equal(build, 2);
-      NodeAssert.equal(lastOptions().resume, sessionId);
+      assert.equal(build, 2);
+      assert.equal(lastOptions().resume, sessionId);
     }),
   );
 
@@ -309,17 +309,17 @@ describe("ClaudeCodeAgent", () => {
         ],
         { concurrency: "unbounded" },
       );
-      NodeAssert.equal(mockGetSessionInfo.mock.calls.length, 1);
-      NodeAssert.equal(mockQuery.mock.calls.length, 1);
-      NodeAssert.equal(lastOptions().resume, sessionId);
-      NodeAssert.equal(lastOptions().sessionId, undefined);
+      assert.equal(mockGetSessionInfo.mock.calls.length, 1);
+      assert.equal(mockQuery.mock.calls.length, 1);
+      assert.equal(lastOptions().resume, sessionId);
+      assert.equal(lastOptions().sessionId, undefined);
 
       mockGetSessionInfo.mockResolvedValue(undefined);
       const missing = yield* makeClaudeCodeAgent();
       const error = yield* missing.session
         .getSupportedCommands("019f6013-0000-7000-8000-000000000003")
         .pipe(Effect.flip);
-      NodeAssert.equal(error._tag, "SessionNotResumable");
+      assert.equal(error._tag, "SessionNotResumable");
     }),
   );
 
@@ -331,7 +331,7 @@ describe("ClaudeCodeAgent", () => {
         Effect.forkChild,
       );
       const canUseTool = lastOptions().canUseTool;
-      NodeAssert.ok(canUseTool);
+      assert.ok(canUseTool);
 
       const permission = canUseTool!(
         "Bash",
@@ -349,7 +349,7 @@ describe("ClaudeCodeAgent", () => {
       yield* Fiber.join(requestFiber);
       yield* agent.session.abort(sessionId);
 
-      NodeAssert.deepStrictEqual(yield* Effect.tryPromise(() => permission), {
+      assert.deepStrictEqual(yield* Effect.tryPromise(() => permission), {
         behavior: "deny",
         message: "Request aborted due to session termination",
         interrupt: true,
@@ -365,7 +365,7 @@ describe("ClaudeCodeAgent", () => {
         Effect.forkChild,
       );
       const canUseTool = lastOptions().canUseTool;
-      NodeAssert.ok(canUseTool);
+      assert.ok(canUseTool);
 
       const permission = canUseTool!(
         "Bash",
@@ -381,7 +381,7 @@ describe("ClaudeCodeAgent", () => {
         },
       );
       const request = yield* Fiber.join(requestFiber);
-      NodeAssert.equal(request._tag, "Some");
+      assert.equal(request._tag, "Some");
       if (request._tag === "Some") {
         yield* agent.session.respondPermission(sessionId, request.value.requestId, {
           behavior: "allow",
@@ -389,7 +389,7 @@ describe("ClaudeCodeAgent", () => {
         });
       }
 
-      NodeAssert.deepStrictEqual(yield* Effect.tryPromise(() => permission), {
+      assert.deepStrictEqual(yield* Effect.tryPromise(() => permission), {
         behavior: "allow",
         updatedInput: { command: "pwd" },
       });

--- a/packages/server/test/harness/claude-code/sdk-executable.test.ts
+++ b/packages/server/test/harness/claude-code/sdk-executable.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 import path from "node:path";
 
 import { it } from "@effect/vitest";
@@ -22,14 +22,14 @@ it.effect("communicates with Claude Agent SDK through a fake Claude executable",
     });
     const { sessionId } = yield* agent.session.create();
 
-    NodeAssert.deepStrictEqual(yield* agent.session.getSupportedModels(sessionId), [
+    assert.deepStrictEqual(yield* agent.session.getSupportedModels(sessionId), [
       {
         value: "fake-claude",
         displayName: "Fake Claude",
         description: "Deterministic Claude executable used by Vibest tests",
       },
     ]);
-    NodeAssert.deepStrictEqual(yield* agent.session.getMcpServers(sessionId), []);
+    assert.deepStrictEqual(yield* agent.session.getMcpServers(sessionId), []);
 
     const turn = yield* agent.session.prompt({
       sessionId,
@@ -38,7 +38,7 @@ it.effect("communicates with Claude Agent SDK through a fake Claude executable",
     const output = yield* Stream.runCollect(turn.output);
     const assistant = Array.from(output).find((message) => message.type === "assistant");
 
-    NodeAssert.deepStrictEqual(assistant?.message.content, [
+    assert.deepStrictEqual(assistant?.message.content, [
       { type: "text", text: "Fake Claude received: SDK integration" },
     ]);
   }),

--- a/packages/server/test/harness/claude-code/sdk-executable.test.ts
+++ b/packages/server/test/harness/claude-code/sdk-executable.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 import path from "node:path";
 
 import { it } from "@effect/vitest";

--- a/packages/server/test/harness/codex/agent.smoke.test.ts
+++ b/packages/server/test/harness/codex/agent.smoke.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";

--- a/packages/server/test/harness/codex/agent.smoke.test.ts
+++ b/packages/server/test/harness/codex/agent.smoke.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
@@ -18,7 +18,7 @@ layer(NodeServices.layer)("codex live smoke", (it) => {
           text: "Reply with exactly: PONG",
         });
         const chunks = yield* Stream.runCollect(prompt.output);
-        NodeAssert.ok(Array.from(chunks).some((chunk) => chunk.type === "finish"));
+        assert.ok(Array.from(chunks).some((chunk) => chunk.type === "finish"));
         yield* agent.session.abort(sessionId);
       }),
     120_000,

--- a/packages/server/test/harness/codex/agent.test.ts
+++ b/packages/server/test/harness/codex/agent.test.ts
@@ -1,7 +1,7 @@
-import * as NodeAssert from "node:assert/strict";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import NodeAssert from "node:assert/strict";
+import nodeFs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
@@ -95,10 +95,10 @@ rl.on("line", (line) => {
 `;
 
 function makeFake(): string {
-  const dir = mkdtempSync(join(tmpdir(), "fake-codex-"));
-  const file = join(dir, "fake-codex.js");
-  writeFileSync(file, FAKE);
-  chmodSync(file, 0o755);
+  const dir = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "fake-codex-"));
+  const file = nodePath.join(dir, "fake-codex.js");
+  nodeFs.writeFileSync(file, FAKE);
+  nodeFs.chmodSync(file, 0o755);
   return file;
 }
 
@@ -203,7 +203,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       // Codex fixes a model at thread/start and has no set-model call, so a
       // create-time choice can only reach it as a turn override. If this
       // regresses, picking a model silently does nothing.
-      const workspace = mkdtempSync(join(tmpdir(), "codex-model-"));
+      const workspace = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "codex-model-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const session = yield* makeCodexAdapter(agent).open({
         cwd: workspace,
@@ -212,13 +212,16 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
       yield* session.prompt({ parts: [{ type: "text", text: "ping" }] });
 
-      NodeAssert.equal(readFileSync(join(workspace, "turn-model"), "utf8"), "gpt-5.6-luna");
+      NodeAssert.equal(
+        nodeFs.readFileSync(nodePath.join(workspace, "turn-model"), "utf8"),
+        "gpt-5.6-luna",
+      );
     }).pipe(Effect.scoped),
   );
 
   it.effect("leaves the model unset when nothing was chosen", () =>
     Effect.gen(function* () {
-      const workspace = mkdtempSync(join(tmpdir(), "codex-model-"));
+      const workspace = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "codex-model-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const session = yield* makeCodexAdapter(agent).open({ cwd: workspace });
 
@@ -226,7 +229,10 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
       // Absent, not null or undefined: the key has to be missing entirely so
       // codex keeps the model from its own config.
-      NodeAssert.equal(readFileSync(join(workspace, "turn-model"), "utf8"), "<absent>");
+      NodeAssert.equal(
+        nodeFs.readFileSync(nodePath.join(workspace, "turn-model"), "utf8"),
+        "<absent>",
+      );
     }).pipe(Effect.scoped),
   );
 
@@ -297,7 +303,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("interrupts a turn requested while turn/start is still pending", () =>
     Effect.gen(function* () {
-      const cwd = mkdtempSync(join(tmpdir(), "codex-starting-interrupt-"));
+      const cwd = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "codex-starting-interrupt-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* Effect.forkChild(
@@ -305,7 +311,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
 
       yield* Effect.eventually(
-        Effect.sync(() => existsSync(join(cwd, "turn-start-requested"))).pipe(
+        Effect.sync(() => nodeFs.existsSync(nodePath.join(cwd, "turn-start-requested"))).pipe(
           Effect.filterOrFail(
             (requested) => requested,
             () => new Error("turn/start was not requested"),
@@ -317,7 +323,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       yield* Effect.forEach([1, 2, 3, 4], () => Effect.yieldNow, { discard: true });
 
       NodeAssert.equal(
-        existsSync(join(cwd, "turn-interrupted")),
+        nodeFs.existsSync(nodePath.join(cwd, "turn-interrupted")),
         true,
         "turn/start completed without the pending interrupt",
       );
@@ -327,7 +333,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("interrupts the native turn when the prompt caller cancels during turn/start", () =>
     Effect.gen(function* () {
-      const cwd = mkdtempSync(join(tmpdir(), "codex-starting-cancel-"));
+      const cwd = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "codex-starting-cancel-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* Effect.forkChild(
@@ -335,7 +341,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
 
       yield* Effect.eventually(
-        Effect.sync(() => existsSync(join(cwd, "turn-start-requested"))).pipe(
+        Effect.sync(() => nodeFs.existsSync(nodePath.join(cwd, "turn-start-requested"))).pipe(
           Effect.filterOrFail(
             (requested) => requested,
             () => new Error("turn/start was not requested"),
@@ -344,7 +350,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
       yield* Fiber.interrupt(prompt);
       yield* Effect.eventually(
-        Effect.sync(() => existsSync(join(cwd, "turn-start-replied"))).pipe(
+        Effect.sync(() => nodeFs.existsSync(nodePath.join(cwd, "turn-start-replied"))).pipe(
           Effect.filterOrFail(
             (replied) => replied,
             () => new Error("turn/start did not reply"),
@@ -354,7 +360,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       yield* Effect.forEach([1, 2, 3, 4], () => Effect.yieldNow, { discard: true });
 
       NodeAssert.equal(
-        existsSync(join(cwd, "turn-interrupted")),
+        nodeFs.existsSync(nodePath.join(cwd, "turn-interrupted")),
         true,
         "cancelled prompt left the native turn running",
       );

--- a/packages/server/test/harness/codex/agent.test.ts
+++ b/packages/server/test/harness/codex/agent.test.ts
@@ -1,7 +1,7 @@
-import NodeAssert from "node:assert/strict";
-import nodeFs from "node:fs";
+import assert from "node:assert/strict";
+import fs from "node:fs";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
@@ -95,10 +95,10 @@ rl.on("line", (line) => {
 `;
 
 function makeFake(): string {
-  const dir = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "fake-codex-"));
-  const file = nodePath.join(dir, "fake-codex.js");
-  nodeFs.writeFileSync(file, FAKE);
-  nodeFs.chmodSync(file, 0o755);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-codex-"));
+  const file = path.join(dir, "fake-codex.js");
+  fs.writeFileSync(file, FAKE);
+  fs.chmodSync(file, 0o755);
   return file;
 }
 
@@ -177,7 +177,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
 
       const prompt = yield* agent.session.prompt({ sessionId: second.sessionId, text: "ping" });
-      NodeAssert.equal(prompt.turnId, "turn_2");
+      assert.equal(prompt.turnId, "turn_2");
       yield* agent.session.abort(second.sessionId);
     }),
   );
@@ -186,11 +186,11 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
-      NodeAssert.equal(sessionId, "th_1");
+      assert.equal(sessionId, "th_1");
 
       const prompt = yield* agent.session.prompt({ sessionId, text: "ping" });
       const chunks = yield* Stream.runCollect(prompt.output);
-      NodeAssert.deepStrictEqual(
+      assert.deepStrictEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "text-start", "text-delta", "text-end", "finish"],
       );
@@ -203,7 +203,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       // Codex fixes a model at thread/start and has no set-model call, so a
       // create-time choice can only reach it as a turn override. If this
       // regresses, picking a model silently does nothing.
-      const workspace = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "codex-model-"));
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-model-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const session = yield* makeCodexAdapter(agent).open({
         cwd: workspace,
@@ -212,16 +212,13 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
       yield* session.prompt({ parts: [{ type: "text", text: "ping" }] });
 
-      NodeAssert.equal(
-        nodeFs.readFileSync(nodePath.join(workspace, "turn-model"), "utf8"),
-        "gpt-5.6-luna",
-      );
+      assert.equal(fs.readFileSync(path.join(workspace, "turn-model"), "utf8"), "gpt-5.6-luna");
     }).pipe(Effect.scoped),
   );
 
   it.effect("leaves the model unset when nothing was chosen", () =>
     Effect.gen(function* () {
-      const workspace = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "codex-model-"));
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-model-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const session = yield* makeCodexAdapter(agent).open({ cwd: workspace });
 
@@ -229,10 +226,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
       // Absent, not null or undefined: the key has to be missing entirely so
       // codex keeps the model from its own config.
-      NodeAssert.equal(
-        nodeFs.readFileSync(nodePath.join(workspace, "turn-model"), "utf8"),
-        "<absent>",
-      );
+      assert.equal(fs.readFileSync(path.join(workspace, "turn-model"), "utf8"), "<absent>");
     }).pipe(Effect.scoped),
   );
 
@@ -240,11 +234,11 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const result = yield* makeCodexAdapter(agent).getSessionInfo("th_1");
-      NodeAssert.equal(result._tag, "found");
+      assert.equal(result._tag, "found");
       if (result._tag === "found") {
-        NodeAssert.equal(result.info.title, "My Thread");
+        assert.equal(result.info.title, "My Thread");
         // Codex timestamps are seconds; the adapter reports milliseconds.
-        NodeAssert.equal(result.info.updatedAt, 1_700_000);
+        assert.equal(result.info.updatedAt, 1_700_000);
       }
     }),
   );
@@ -253,8 +247,8 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const result = yield* makeCodexAdapter(agent).getSessionInfo("th_untitled");
-      NodeAssert.equal(result._tag, "found");
-      if (result._tag === "found") NodeAssert.equal(result.info.title, "first message");
+      assert.equal(result._tag, "found");
+      if (result._tag === "found") assert.equal(result.info.title, "first message");
     }),
   );
 
@@ -262,7 +256,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
     Effect.gen(function* () {
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const result = yield* makeCodexAdapter(agent).getSessionInfo("th_missing");
-      NodeAssert.equal(result._tag, "missing");
+      assert.equal(result._tag, "missing");
     }),
   );
 
@@ -293,7 +287,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
       yield* Effect.forEach([1, 2, 3, 4], () => Effect.yieldNow, { discard: true });
 
-      NodeAssert.equal(
+      assert.equal(
         yield* Deferred.isDone(crashSeen),
         true,
         "idle adapter session did not publish session.crashed",
@@ -303,7 +297,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("interrupts a turn requested while turn/start is still pending", () =>
     Effect.gen(function* () {
-      const cwd = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "codex-starting-interrupt-"));
+      const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "codex-starting-interrupt-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* Effect.forkChild(
@@ -311,7 +305,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
 
       yield* Effect.eventually(
-        Effect.sync(() => nodeFs.existsSync(nodePath.join(cwd, "turn-start-requested"))).pipe(
+        Effect.sync(() => fs.existsSync(path.join(cwd, "turn-start-requested"))).pipe(
           Effect.filterOrFail(
             (requested) => requested,
             () => new Error("turn/start was not requested"),
@@ -322,8 +316,8 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       yield* Fiber.join(prompt);
       yield* Effect.forEach([1, 2, 3, 4], () => Effect.yieldNow, { discard: true });
 
-      NodeAssert.equal(
-        nodeFs.existsSync(nodePath.join(cwd, "turn-interrupted")),
+      assert.equal(
+        fs.existsSync(path.join(cwd, "turn-interrupted")),
         true,
         "turn/start completed without the pending interrupt",
       );
@@ -333,7 +327,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("interrupts the native turn when the prompt caller cancels during turn/start", () =>
     Effect.gen(function* () {
-      const cwd = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "codex-starting-cancel-"));
+      const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "codex-starting-cancel-"));
       const agent = yield* makeCodexAgent({ executablePath: makeFake() });
       const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* Effect.forkChild(
@@ -341,7 +335,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
 
       yield* Effect.eventually(
-        Effect.sync(() => nodeFs.existsSync(nodePath.join(cwd, "turn-start-requested"))).pipe(
+        Effect.sync(() => fs.existsSync(path.join(cwd, "turn-start-requested"))).pipe(
           Effect.filterOrFail(
             (requested) => requested,
             () => new Error("turn/start was not requested"),
@@ -350,7 +344,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
       yield* Fiber.interrupt(prompt);
       yield* Effect.eventually(
-        Effect.sync(() => nodeFs.existsSync(nodePath.join(cwd, "turn-start-replied"))).pipe(
+        Effect.sync(() => fs.existsSync(path.join(cwd, "turn-start-replied"))).pipe(
           Effect.filterOrFail(
             (replied) => replied,
             () => new Error("turn/start did not reply"),
@@ -359,8 +353,8 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
       yield* Effect.forEach([1, 2, 3, 4], () => Effect.yieldNow, { discard: true });
 
-      NodeAssert.equal(
-        nodeFs.existsSync(nodePath.join(cwd, "turn-interrupted")),
+      assert.equal(
+        fs.existsSync(path.join(cwd, "turn-interrupted")),
         true,
         "cancelled prompt left the native turn running",
       );
@@ -396,7 +390,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       );
       yield* Effect.forEach([1, 2, 3, 4], () => Effect.yieldNow, { discard: true });
 
-      NodeAssert.equal(
+      assert.equal(
         yield* Deferred.isDone(secondDone),
         true,
         "waiting prompt remained blocked on the crashed turn",
@@ -419,8 +413,8 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       const receipt = yield* session.prompt({ parts: [{ type: "text", text: "ping" }] });
       const events = yield* Fiber.join(collected);
 
-      NodeAssert.equal(receipt.turnId, "turn_1");
-      NodeAssert.deepStrictEqual(
+      assert.equal(receipt.turnId, "turn_1");
+      assert.deepStrictEqual(
         Array.from(events, (event) => event.body.type),
         [
           "session.turn.started",
@@ -443,8 +437,8 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       const prompt = yield* agent.session.prompt({ sessionId, text: "retry" });
       const chunks = yield* Stream.runCollect(prompt.output);
 
-      NodeAssert.ok(Array.from(chunks).some((chunk) => chunk.type === "error"));
-      NodeAssert.equal(chunks.at(-1)?.type, "finish");
+      assert.ok(Array.from(chunks).some((chunk) => chunk.type === "error"));
+      assert.equal(chunks.at(-1)?.type, "finish");
       yield* agent.session.abort(sessionId);
     }),
   );
@@ -459,7 +453,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       const replacement = yield* agent.session
         .create({ cwd: "/tmp" })
         .pipe(Effect.timeout("2 seconds"));
-      NodeAssert.equal(replacement.sessionId, "th_1");
+      assert.equal(replacement.sessionId, "th_1");
       yield* agent.session.abort(replacement.sessionId);
     }),
   );
@@ -470,7 +464,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const prompt = yield* agent.session.prompt({ sessionId, text: "crash" });
       const chunks = yield* Stream.runCollect(prompt.output);
-      NodeAssert.deepStrictEqual(
+      assert.deepStrictEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "text-start", "text-delta", "error"],
       );
@@ -481,7 +475,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
         text: "ping",
       });
       const replacementChunks = yield* Stream.runCollect(replacementPrompt.output);
-      NodeAssert.equal(replacementChunks.at(-1)?.type, "finish");
+      assert.equal(replacementChunks.at(-1)?.type, "finish");
       yield* agent.session.abort(replacement.sessionId);
     }),
   );

--- a/packages/server/test/harness/codex/transport-holder.test.ts
+++ b/packages/server/test/harness/codex/transport-holder.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import { Deferred, Effect, Exit, Fiber, Ref, Scope, Stream } from "effect";

--- a/packages/server/test/harness/codex/transport-holder.test.ts
+++ b/packages/server/test/harness/codex/transport-holder.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import { Deferred, Effect, Exit, Fiber, Ref, Scope, Stream } from "effect";
@@ -51,19 +51,19 @@ it.effect("Codex transport holder starts lazily and shares concurrent startup", 
         }),
     });
 
-    NodeAssert.equal(yield* Ref.get(buildCount), 0);
+    assert.equal(yield* Ref.get(buildCount), 0);
 
     const first = yield* holder.ensure.pipe(Effect.forkChild);
     const second = yield* holder.ensure.pipe(Effect.forkChild);
     yield* Deferred.await(buildStarted);
-    NodeAssert.equal(yield* Ref.get(buildCount), 1);
+    assert.equal(yield* Ref.get(buildCount), 1);
 
     yield* Deferred.succeed(releaseBuild, undefined);
     const firstTransport = yield* Fiber.join(first);
     const secondTransport = yield* Fiber.join(second);
 
-    NodeAssert.strictEqual(firstTransport, secondTransport);
-    NodeAssert.equal(yield* holder.status, "Running");
+    assert.strictEqual(firstTransport, secondTransport);
+    assert.equal(yield* holder.status, "Running");
   }),
 );
 
@@ -89,8 +89,8 @@ it.effect("canceling the first waiter does not cancel shared startup", () =>
     yield* Deferred.succeed(releaseBuild, undefined);
 
     yield* holder.ensure;
-    NodeAssert.equal(yield* Ref.get(buildCount), 1);
-    NodeAssert.equal(yield* holder.status, "Running");
+    assert.equal(yield* Ref.get(buildCount), 1);
+    assert.equal(yield* holder.status, "Running");
   }),
 );
 
@@ -108,7 +108,7 @@ it.effect("fails startup waiters when the owner scope closes", () =>
     yield* Scope.close(ownerScope, Exit.void);
 
     const result = yield* Fiber.await(waiter);
-    NodeAssert.equal(result._tag, "Failure");
+    assert.equal(result._tag, "Failure");
   }),
 );
 
@@ -132,12 +132,12 @@ it.effect("resets failed startup so a later call can retry", () =>
     });
 
     const firstError = yield* holder.ensure.pipe(Effect.flip);
-    NodeAssert.equal(firstError._tag, "CodexTransportError");
-    NodeAssert.equal(yield* holder.status, "Idle");
+    assert.equal(firstError._tag, "CodexTransportError");
+    assert.equal(yield* holder.status, "Idle");
 
     yield* holder.ensure;
-    NodeAssert.equal(yield* Ref.get(buildCount), 2);
-    NodeAssert.equal(yield* holder.status, "Running");
+    assert.equal(yield* Ref.get(buildCount), 2);
+    assert.equal(yield* holder.status, "Running");
   }),
 );
 
@@ -158,7 +158,7 @@ it.effect("clears a crashed generation and starts a replacement", () =>
 
     const first = yield* holder.ensure;
     const firstBuild = builds[0];
-    NodeAssert.ok(firstBuild);
+    assert.ok(firstBuild);
     yield* firstBuild!.crash(new AgentProcessExited({ harnessAgentId: "codex", code: 7 }));
 
     yield* Effect.eventually(
@@ -171,7 +171,7 @@ it.effect("clears a crashed generation and starts a replacement", () =>
     );
 
     const second = yield* holder.ensure;
-    NodeAssert.notStrictEqual(second, first);
-    NodeAssert.equal(builds.length, 2);
+    assert.notStrictEqual(second, first);
+    assert.equal(builds.length, 2);
   }),
 );

--- a/packages/server/test/harness/codex/transport.test.ts
+++ b/packages/server/test/harness/codex/transport.test.ts
@@ -1,7 +1,7 @@
-import * as NodeAssert from "node:assert/strict";
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import NodeAssert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
@@ -45,10 +45,10 @@ rl.on("line", (line) => {
 `;
 
 function makeFake(): string {
-  const dir = mkdtempSync(join(tmpdir(), "fake-effect-codex-"));
-  const file = join(dir, "fake-codex.js");
-  writeFileSync(file, FAKE);
-  chmodSync(file, 0o755);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-effect-codex-"));
+  const file = path.join(dir, "fake-codex.js");
+  fs.writeFileSync(file, FAKE);
+  fs.chmodSync(file, 0o755);
   return file;
 }
 

--- a/packages/server/test/harness/codex/transport.test.ts
+++ b/packages/server/test/harness/codex/transport.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -57,13 +57,13 @@ layer(NodeServices.layer)("CodexTransport", (it) => {
     Effect.gen(function* () {
       const transport = yield* makeCodexTransport({ executablePath: makeFake() });
 
-      NodeAssert.deepStrictEqual(yield* transport.request("echo", { answer: 42 }), {
+      assert.deepStrictEqual(yield* transport.request("echo", { answer: 42 }), {
         answer: 42,
       });
 
       const error = yield* transport.request("boom").pipe(Effect.flip);
-      NodeAssert.equal(error._tag, "CodexRpcError");
-      if (error._tag === "CodexRpcError") NodeAssert.equal(error.code, -1);
+      assert.equal(error._tag, "CodexRpcError");
+      if (error._tag === "CodexRpcError") assert.equal(error.code, -1);
     }),
   );
 
@@ -71,7 +71,7 @@ layer(NodeServices.layer)("CodexTransport", (it) => {
     Effect.gen(function* () {
       const transport = yield* makeCodexTransport({ executablePath: makeFake() });
 
-      NodeAssert.equal(yield* transport.request("stderrFlood"), "drained");
+      assert.equal(yield* transport.request("stderrFlood"), "drained");
     }),
   );
 
@@ -88,12 +88,12 @@ layer(NodeServices.layer)("CodexTransport", (it) => {
 
       const notification = yield* Fiber.join(notificationFiber);
       const request = yield* Fiber.join(requestFiber);
-      NodeAssert.equal(notification._tag, "Some");
-      NodeAssert.equal(request._tag, "Some");
+      assert.equal(notification._tag, "Some");
+      assert.equal(request._tag, "Some");
       if (notification._tag === "Some") {
-        NodeAssert.equal(notification.value.method, "turn/started");
+        assert.equal(notification.value.method, "turn/started");
       }
-      if (request._tag === "Some") NodeAssert.equal(request.value.id, 999);
+      if (request._tag === "Some") assert.equal(request.value.id, 999);
     }),
   );
 
@@ -102,7 +102,7 @@ layer(NodeServices.layer)("CodexTransport", (it) => {
       const transport = yield* makeCodexTransport({ executablePath: makeFake() });
       const error = yield* transport.request("invalid").pipe(Effect.flip);
 
-      NodeAssert.equal(error._tag, "AgentProtocolError");
+      assert.equal(error._tag, "AgentProtocolError");
     }),
   );
 
@@ -114,8 +114,8 @@ layer(NodeServices.layer)("CodexTransport", (it) => {
         { concurrency: "unbounded" },
       ).pipe(Effect.timeout("2 seconds"));
 
-      NodeAssert.equal(exits.length, 128);
-      for (const exit of exits) NodeAssert.equal(exit._tag, "Failure");
+      assert.equal(exits.length, 128);
+      for (const exit of exits) assert.equal(exit._tag, "Failure");
     }),
   );
 
@@ -126,8 +126,8 @@ layer(NodeServices.layer)("CodexTransport", (it) => {
         .request("exitWithInheritedStderr")
         .pipe(Effect.flip, Effect.timeout("750 millis"));
 
-      NodeAssert.equal(error._tag, "AgentProcessExited");
-      if (error._tag === "AgentProcessExited") NodeAssert.equal(error.code, 8);
+      assert.equal(error._tag, "AgentProcessExited");
+      if (error._tag === "AgentProcessExited") assert.equal(error.code, 8);
     }),
   );
 
@@ -136,10 +136,10 @@ layer(NodeServices.layer)("CodexTransport", (it) => {
       const transport = yield* makeCodexTransport({ executablePath: makeFake() });
       const error = yield* transport.request("exit").pipe(Effect.flip);
 
-      NodeAssert.equal(error._tag, "AgentProcessExited");
+      assert.equal(error._tag, "AgentProcessExited");
       if (error._tag === "AgentProcessExited") {
-        NodeAssert.equal(error.code, 7);
-        NodeAssert.match(error.stderrTail ?? "", /fatal codex detail/);
+        assert.equal(error.code, 7);
+        assert.match(error.stderrTail ?? "", /fatal codex detail/);
       }
     }),
   );

--- a/packages/server/test/harness/list.test.ts
+++ b/packages/server/test/harness/list.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import { Effect } from "effect";

--- a/packages/server/test/harness/list.test.ts
+++ b/packages/server/test/harness/list.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import { Effect } from "effect";
@@ -35,7 +35,7 @@ it.effect("declares each harness's availability and permission subset", () =>
 
     const { harnessAgents } = yield* makeHarnessList(registry).list;
 
-    NodeAssert.deepStrictEqual(harnessAgents[0], {
+    assert.deepStrictEqual(harnessAgents[0], {
       id: "claude-code",
       name: "claude-code",
       available: true,
@@ -55,9 +55,9 @@ it.effect("keeps declaring settings for a harness whose CLI is missing", () =>
 
     // The picker greys it out and shows the reason — but what it *would* be
     // able to do has nothing to do with whether it is installed right now.
-    NodeAssert.equal(harnessAgents[0]?.available, false);
-    NodeAssert.equal(harnessAgents[0]?.reason, "Codex was not found on PATH.");
-    NodeAssert.equal(harnessAgents[0]?.defaultPermissionMode, "ask");
+    assert.equal(harnessAgents[0]?.available, false);
+    assert.equal(harnessAgents[0]?.reason, "Codex was not found on PATH.");
+    assert.equal(harnessAgents[0]?.defaultPermissionMode, "ask");
   }),
 );
 
@@ -71,7 +71,7 @@ it.effect("reports every registered harness, in registration order", () =>
 
     const { harnessAgents } = yield* makeHarnessList(registry).list;
 
-    NodeAssert.deepStrictEqual(
+    assert.deepStrictEqual(
       harnessAgents.map((harnessAgent) => harnessAgent.id),
       ["claude-code", "codex", "pi"],
     );

--- a/packages/server/test/harness/pi/agent.smoke.test.ts
+++ b/packages/server/test/harness/pi/agent.smoke.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";

--- a/packages/server/test/harness/pi/agent.smoke.test.ts
+++ b/packages/server/test/harness/pi/agent.smoke.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
@@ -26,8 +26,8 @@ layer(NodeServices.layer)("pi live smoke", (it) => {
           .filter((chunk) => chunk.type === "text-delta")
           .map((chunk) => ("delta" in chunk ? chunk.delta : ""))
           .join("");
-        NodeAssert.match(text, /PONG/i);
-        NodeAssert.equal(chunks.at(-1)?.type, "finish");
+        assert.match(text, /PONG/i);
+        assert.equal(chunks.at(-1)?.type, "finish");
         yield* agent.session.abort(sessionId);
       }),
     120_000,

--- a/packages/server/test/harness/pi/agent.test.ts
+++ b/packages/server/test/harness/pi/agent.test.ts
@@ -1,7 +1,7 @@
-import * as NodeAssert from "node:assert/strict";
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import NodeAssert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
@@ -76,10 +76,10 @@ rl.on("line", (line) => {
 `;
 
 function makeFake(): string {
-  const dir = mkdtempSync(join(tmpdir(), "fake-pi-"));
-  const file = join(dir, "fake-pi.js");
-  writeFileSync(file, FAKE);
-  chmodSync(file, 0o755);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-pi-"));
+  const file = path.join(dir, "fake-pi.js");
+  fs.writeFileSync(file, FAKE);
+  fs.chmodSync(file, 0o755);
   return file;
 }
 

--- a/packages/server/test/harness/pi/agent.test.ts
+++ b/packages/server/test/harness/pi/agent.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -88,12 +88,12 @@ layer(NodeServices.layer)("PiAgent", (it) => {
     Effect.gen(function* () {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
       const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
-      NodeAssert.match(sessionId, /^[0-9a-f]{8}-[0-9a-f-]{27}$/);
+      assert.match(sessionId, /^[0-9a-f]{8}-[0-9a-f-]{27}$/);
 
       const prompt = yield* agent.session.prompt({ sessionId, text: "ping" });
-      NodeAssert.equal(prompt.started, true);
+      assert.equal(prompt.started, true);
       const chunks = yield* Stream.runCollect(prompt.output);
-      NodeAssert.deepStrictEqual(
+      assert.deepStrictEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "text-start", "text-delta", "text-end", "finish"],
       );
@@ -108,7 +108,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
         sessionId: "custom-id",
         cwd: "/tmp",
       });
-      NodeAssert.equal(sessionId, "custom-id");
+      assert.equal(sessionId, "custom-id");
       yield* agent.session.abort(sessionId);
     }),
   );
@@ -119,7 +119,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const error = yield* agent.session
         .resume({ sessionId: "missing-session", cwd: "/tmp" })
         .pipe(Effect.flip);
-      NodeAssert.equal(error._tag, "AgentProcessExited");
+      assert.equal(error._tag, "AgentProcessExited");
     }),
   );
 
@@ -129,7 +129,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const prompt = yield* agent.session.prompt({ sessionId, text: "tool" });
       const chunks = yield* Stream.runCollect(prompt.output);
-      NodeAssert.deepStrictEqual(
+      assert.deepStrictEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "tool-input-available", "tool-output-available", "finish"],
       );
@@ -148,9 +148,9 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const collected = yield* Effect.forkChild(Stream.runCollect(prompt.output));
 
       const request = yield* Fiber.join(requestFiber);
-      NodeAssert.equal(request._tag, "Some");
+      assert.equal(request._tag, "Some");
       if (request._tag !== "Some") return;
-      NodeAssert.deepStrictEqual(request.value, {
+      assert.deepStrictEqual(request.value, {
         harnessAgentId: "pi",
         type: "question",
         id: "ui1",
@@ -176,11 +176,11 @@ layer(NodeServices.layer)("PiAgent", (it) => {
         type: "question",
         answers: [{ questionId: "ui1", values: ["Yes"] }],
       });
-      NodeAssert.equal(accepted, true);
+      assert.equal(accepted, true);
 
       const chunks = yield* Fiber.join(collected);
       const deltas = Array.from(chunks).filter((chunk) => chunk.type === "text-delta");
-      NodeAssert.ok(
+      assert.ok(
         deltas.some((chunk) => "delta" in chunk && chunk.delta === "confirmed:true"),
         "the confirm answer did not reach the pi child",
       );
@@ -193,14 +193,14 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
       const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const first = yield* agent.session.prompt({ sessionId, text: "hold" });
-      NodeAssert.equal(first.started, true);
+      assert.equal(first.started, true);
 
       const second = yield* agent.session.prompt({ sessionId, text: "also do this" });
-      NodeAssert.equal(second.started, false);
-      NodeAssert.equal(second.turnId, first.turnId);
+      assert.equal(second.started, false);
+      assert.equal(second.turnId, first.turnId);
 
       const chunks = yield* Stream.runCollect(first.output);
-      NodeAssert.equal(Array.from(chunks).at(-1)?.type, "finish");
+      assert.equal(Array.from(chunks).at(-1)?.type, "finish");
       yield* agent.session.abort(sessionId);
     }),
   );
@@ -214,7 +214,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
 
       yield* agent.session.interrupt(sessionId);
       const chunks = yield* Fiber.join(collected);
-      NodeAssert.equal(Array.from(chunks).at(-1)?.type, "finish");
+      assert.equal(Array.from(chunks).at(-1)?.type, "finish");
       yield* agent.session.abort(sessionId);
     }),
   );
@@ -224,11 +224,11 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const agent = yield* makePiAgent({ executablePath: makeFake() });
       const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const error = yield* agent.session.prompt({ sessionId, text: "fail" }).pipe(Effect.flip);
-      NodeAssert.equal(error._tag, "PiRpcError");
+      assert.equal(error._tag, "PiRpcError");
 
       const prompt = yield* agent.session.prompt({ sessionId, text: "ping" });
       const chunks = yield* Stream.runCollect(prompt.output);
-      NodeAssert.equal(Array.from(chunks).at(-1)?.type, "finish");
+      assert.equal(Array.from(chunks).at(-1)?.type, "finish");
       yield* agent.session.abort(sessionId);
     }),
   );
@@ -241,7 +241,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
 
       const prompt = yield* agent.session.prompt({ sessionId: doomed.sessionId, text: "crash" });
       const chunks = yield* Stream.runCollect(prompt.output);
-      NodeAssert.deepStrictEqual(
+      assert.deepStrictEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "text-start", "text-delta", "error"],
       );
@@ -264,7 +264,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       // The sibling session's child is untouched.
       const sibling = yield* agent.session.prompt({ sessionId: healthy.sessionId, text: "ping" });
       const siblingChunks = yield* Stream.runCollect(sibling.output);
-      NodeAssert.equal(Array.from(siblingChunks).at(-1)?.type, "finish");
+      assert.equal(Array.from(siblingChunks).at(-1)?.type, "finish");
       yield* agent.session.abort(healthy.sessionId);
     }),
   );
@@ -284,8 +284,8 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const receipt = yield* session.prompt({ parts: [{ type: "text", text: "ping" }] });
       const events = yield* Fiber.join(collected);
 
-      NodeAssert.equal(typeof receipt.turnId, "string");
-      NodeAssert.deepStrictEqual(
+      assert.equal(typeof receipt.turnId, "string");
+      assert.deepStrictEqual(
         Array.from(events, (event) => event.body.type),
         [
           "session.turn.started",
@@ -299,7 +299,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       );
 
       const capabilities = yield* session.getCapabilities;
-      NodeAssert.deepStrictEqual(capabilities, {
+      assert.deepStrictEqual(capabilities, {
         supportsResume: true,
         supportsSteering: true,
         supportsPermissions: false,

--- a/packages/server/test/harness/pi/transport.test.ts
+++ b/packages/server/test/harness/pi/transport.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -51,15 +51,15 @@ layer(NodeServices.layer)("PiTransport", (it) => {
     Effect.gen(function* () {
       const transport = yield* makePiTransport({ executablePath: makeFake() });
 
-      NodeAssert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
+      assert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
         sessionId: "s1",
       });
 
       const error = yield* transport.command({ type: "compact" }).pipe(Effect.flip);
-      NodeAssert.equal(error._tag, "PiRpcError");
+      assert.equal(error._tag, "PiRpcError");
       if (error._tag === "PiRpcError") {
-        NodeAssert.equal(error.command, "compact");
-        NodeAssert.equal(error.errorMessage, "nothing to compact");
+        assert.equal(error.command, "compact");
+        assert.equal(error.errorMessage, "nothing to compact");
       }
     }),
   );
@@ -69,7 +69,7 @@ layer(NodeServices.layer)("PiTransport", (it) => {
       const transport = yield* makePiTransport({ executablePath: makeFake() });
       // The banner and setStatus arrive before this response; neither must
       // fail the frame reader nor surface as an event or a blocking request.
-      NodeAssert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
+      assert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
         sessionId: "s1",
       });
     }),
@@ -85,20 +85,20 @@ layer(NodeServices.layer)("PiTransport", (it) => {
 
       const event = yield* Fiber.join(eventFiber);
       const request = yield* Fiber.join(requestFiber);
-      NodeAssert.equal(event._tag, "Some");
-      if (event._tag === "Some") NodeAssert.equal(event.value.type, "agent_start");
-      NodeAssert.equal(request._tag, "Some");
+      assert.equal(event._tag, "Some");
+      if (event._tag === "Some") assert.equal(event.value.type, "agent_start");
+      assert.equal(request._tag, "Some");
       if (request._tag === "Some") {
-        NodeAssert.equal(request.value.method, "confirm");
-        NodeAssert.equal(request.value.id, "c1");
+        assert.equal(request.value.method, "confirm");
+        assert.equal(request.value.id, "c1");
       }
 
       const echoFiber = yield* Stream.runHead(transport.events).pipe(Effect.forkChild);
       yield* transport.respondUi({ type: "extension_ui_response", id: "c1", confirmed: true });
       const echo = yield* Fiber.join(echoFiber);
-      NodeAssert.equal(echo._tag, "Some");
+      assert.equal(echo._tag, "Some");
       if (echo._tag === "Some") {
-        NodeAssert.match((echo.value as { name?: string }).name ?? "", /"confirmed":true/);
+        assert.match((echo.value as { name?: string }).name ?? "", /"confirmed":true/);
       }
     }),
   );
@@ -106,7 +106,7 @@ layer(NodeServices.layer)("PiTransport", (it) => {
   it.effect("drains child stderr without blocking protocol responses", () =>
     Effect.gen(function* () {
       const transport = yield* makePiTransport({ executablePath: makeFake() });
-      NodeAssert.equal(yield* transport.command({ type: "bash", command: "x" }), "drained");
+      assert.equal(yield* transport.command({ type: "bash", command: "x" }), "drained");
     }),
   );
 
@@ -115,10 +115,10 @@ layer(NodeServices.layer)("PiTransport", (it) => {
       const transport = yield* makePiTransport({ executablePath: makeFake() });
       const error = yield* transport.command({ type: "abort" }).pipe(Effect.flip);
 
-      NodeAssert.equal(error._tag, "AgentProcessExited");
+      assert.equal(error._tag, "AgentProcessExited");
       if (error._tag === "AgentProcessExited") {
-        NodeAssert.equal(error.code, 7);
-        NodeAssert.match(error.stderrTail ?? "", /pi fatal detail/);
+        assert.equal(error.code, 7);
+        assert.match(error.stderrTail ?? "", /pi fatal detail/);
       }
     }),
   );
@@ -141,7 +141,7 @@ rl.on("line", (line) => {
       );
       fs.chmodSync(file, 0o755);
       const transport = yield* makePiTransport({ executablePath: file, sessionId: "sid-42" });
-      NodeAssert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
+      assert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
         sessionId: "sid-42",
       });
     }),

--- a/packages/server/test/harness/pi/transport.test.ts
+++ b/packages/server/test/harness/pi/transport.test.ts
@@ -1,7 +1,7 @@
-import * as NodeAssert from "node:assert/strict";
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import NodeAssert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
@@ -39,10 +39,10 @@ rl.on("line", (line) => {
 `;
 
 function makeFake(): string {
-  const dir = mkdtempSync(join(tmpdir(), "fake-pi-transport-"));
-  const file = join(dir, "fake-pi.js");
-  writeFileSync(file, FAKE);
-  chmodSync(file, 0o755);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-pi-transport-"));
+  const file = path.join(dir, "fake-pi.js");
+  fs.writeFileSync(file, FAKE);
+  fs.chmodSync(file, 0o755);
   return file;
 }
 
@@ -125,9 +125,9 @@ layer(NodeServices.layer)("PiTransport", (it) => {
 
   it.effect("passes --session-id through to the child", () =>
     Effect.gen(function* () {
-      const dir = mkdtempSync(join(tmpdir(), "fake-pi-args-"));
-      const file = join(dir, "fake-pi.js");
-      writeFileSync(
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-pi-args-"));
+      const file = path.join(dir, "fake-pi.js");
+      fs.writeFileSync(
         file,
         `#!/usr/bin/env node
 const readline = require("node:readline");
@@ -139,7 +139,7 @@ rl.on("line", (line) => {
 });
 `,
       );
-      chmodSync(file, 0o755);
+      fs.chmodSync(file, 0o755);
       const transport = yield* makePiTransport({ executablePath: file, sessionId: "sid-42" });
       NodeAssert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
         sessionId: "sid-42",

--- a/packages/server/test/harness/probe.test.ts
+++ b/packages/server/test/harness/probe.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import { Effect, Ref } from "effect";

--- a/packages/server/test/harness/probe.test.ts
+++ b/packages/server/test/harness/probe.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import { Effect, Ref } from "effect";
@@ -38,11 +38,11 @@ it.effect("probes the directory it was asked about, grouped under the built-in p
 
     const result = yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
 
-    NodeAssert.deepStrictEqual(yield* Ref.get(seen), ["/work/app"]);
+    assert.deepStrictEqual(yield* Ref.get(seen), ["/work/app"]);
     // Models never leave their provider: the built-in provider carries the
     // harness's own id, which is the other half of every providerId/modelId pair.
-    NodeAssert.equal(result.providers[0]?.id, "claude-code");
-    NodeAssert.equal(result.providers[0]?.models[0]?.id, "sonnet");
+    assert.equal(result.providers[0]?.id, "claude-code");
+    assert.equal(result.providers[0]?.models[0]?.id, "sonnet");
   }),
 );
 
@@ -57,9 +57,9 @@ it.effect("gives concurrent callers one probe, not one each", () =>
     // Two tabs on the same directory, arriving before the first probe settles.
     const [first, second] = yield* Effect.all([ask, ask], { concurrency: "unbounded" });
 
-    NodeAssert.equal((yield* Ref.get(seen)).length, 1);
-    NodeAssert.equal(first.providers[0]?.models[0]?.id, "sonnet");
-    NodeAssert.equal(second.providers[0]?.models[0]?.id, "sonnet");
+    assert.equal((yield* Ref.get(seen)).length, 1);
+    assert.equal(first.providers[0]?.models[0]?.id, "sonnet");
+    assert.equal(second.providers[0]?.models[0]?.id, "sonnet");
   }),
 );
 
@@ -80,7 +80,7 @@ it.effect("treats two directories as two probes, and does not serialise them", (
 
     // Both ran; if the registration lock covered the probes, the second would
     // have queued behind the first rather than interleaving.
-    NodeAssert.deepStrictEqual(Array.from(yield* Ref.get(seen)).toSorted(), ["/work/a", "/work/b"]);
+    assert.deepStrictEqual(Array.from(yield* Ref.get(seen)).toSorted(), ["/work/a", "/work/b"]);
   }),
 );
 
@@ -95,7 +95,7 @@ it.effect("normalises the directory, so one answer serves its aliases", () =>
     yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app/" });
     yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/nested/../app" });
 
-    NodeAssert.equal((yield* Ref.get(seen)).length, 1);
+    assert.equal((yield* Ref.get(seen)).length, 1);
   }),
 );
 
@@ -121,12 +121,12 @@ it.effect("caches a success but retries a failure", () =>
     // A cached failure would pin "no models" for the whole TTL, so the user
     // would have to wait it out after logging back in.
     yield* Effect.result(ask);
-    NodeAssert.equal((yield* ask).providers[0]?.models[0]?.id, "sonnet");
-    NodeAssert.equal(yield* Ref.get(calls), 2);
+    assert.equal((yield* ask).providers[0]?.models[0]?.id, "sonnet");
+    assert.equal(yield* Ref.get(calls), 2);
 
     // The success, on the other hand, is worth keeping: no second spawn.
     yield* ask;
-    NodeAssert.equal(yield* Ref.get(calls), 2);
+    assert.equal(yield* Ref.get(calls), 2);
   }),
 );
 
@@ -136,7 +136,7 @@ it.effect("answers an empty provider list for a harness that has no probe", () =
 
     // Not a failure: pi genuinely has no models, and the client renders no
     // picker rather than an error.
-    NodeAssert.deepStrictEqual(yield* probe.probe({ harnessAgentId: "pi", cwd: "/work/app" }), {
+    assert.deepStrictEqual(yield* probe.probe({ harnessAgentId: "pi", cwd: "/work/app" }), {
       providers: [],
     });
   }),

--- a/packages/server/test/harness/registry.test.ts
+++ b/packages/server/test/harness/registry.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import { Effect } from "effect";

--- a/packages/server/test/harness/registry.test.ts
+++ b/packages/server/test/harness/registry.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import { Effect } from "effect";
@@ -20,8 +20,8 @@ it.effect("lists adapters and resolves them by harness agent id", () =>
   Effect.gen(function* () {
     const registry = makeHarnessAgentRegistry([claude]);
 
-    NodeAssert.deepStrictEqual(yield* registry.list, [claude.descriptor]);
-    NodeAssert.equal(yield* registry.get("claude-code"), claude);
+    assert.deepStrictEqual(yield* registry.list, [claude.descriptor]);
+    assert.equal(yield* registry.get("claude-code"), claude);
   }),
 );
 
@@ -30,7 +30,7 @@ it.effect("returns a typed error for an unregistered harness agent", () =>
     const registry = makeHarnessAgentRegistry([claude]);
     const error = yield* registry.get("codex").pipe(Effect.flip);
 
-    NodeAssert.equal(error._tag, "HarnessAgentNotFound");
-    NodeAssert.equal(error.harnessAgentId, "codex");
+    assert.equal(error._tag, "HarnessAgentNotFound");
+    assert.equal(error.harnessAgentId, "codex");
   }),
 );

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import type { ClaudeCodeUIMessageChunk, SessionEnvelopeDraft, SessionEvent } from "@vibest/harness";

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import type { ClaudeCodeUIMessageChunk, SessionEnvelopeDraft, SessionEvent } from "@vibest/harness";
@@ -142,14 +142,14 @@ it.effect("exposes the raw per-session event stream and tears down on close", ()
     yield* fixture.service.close(created.sessionId);
     const events = yield* Fiber.join(collected);
 
-    NodeAssert.deepStrictEqual(receipt, { turnId: "turn-1" });
-    NodeAssert.deepStrictEqual(Array.from(events), [
+    assert.deepStrictEqual(receipt, { turnId: "turn-1" });
+    assert.deepStrictEqual(Array.from(events), [
       "session.turn.started",
       "start",
       "session.turn.ended",
     ]);
-    NodeAssert.equal(yield* Ref.get(fixture.closeCalls), 1);
-    NodeAssert.equal(yield* isActive(fixture, created.sessionId), false);
+    assert.equal(yield* Ref.get(fixture.closeCalls), 1);
+    assert.equal(yield* isActive(fixture, created.sessionId), false);
   }),
 );
 
@@ -172,8 +172,8 @@ it.effect("single-flights resume in owner scope when the first waiter cancels", 
     yield* Deferred.succeed(fixture.resumeGate, undefined);
     yield* Fiber.join(second);
 
-    NodeAssert.equal(yield* Ref.get(fixture.resumeCalls), 1);
-    NodeAssert.equal(yield* isActive(fixture, input.sessionId), true);
+    assert.equal(yield* Ref.get(fixture.resumeCalls), 1);
+    assert.equal(yield* isActive(fixture, input.sessionId), true);
     yield* fixture.service.close(input.sessionId);
   }),
 );
@@ -200,7 +200,7 @@ it.effect("waits for an in-flight close before resuming the same session id", ()
     );
 
     yield* Effect.yieldNow;
-    NodeAssert.equal(yield* Ref.get(fixture.resumeCalls), 0);
+    assert.equal(yield* Ref.get(fixture.resumeCalls), 0);
     yield* Deferred.succeed(fixture.closeGate, undefined);
     yield* Effect.eventually(
       Ref.get(fixture.resumeCalls).pipe(
@@ -214,7 +214,7 @@ it.effect("waits for an in-flight close before resuming the same session id", ()
     yield* Fiber.join(close);
     yield* Fiber.join(resume);
 
-    NodeAssert.equal(yield* isActive(fixture, created.sessionId), true);
+    assert.equal(yield* isActive(fixture, created.sessionId), true);
     yield* fixture.service.close(created.sessionId);
   }),
 );
@@ -238,8 +238,8 @@ it.effect("closes a session that is still being resumed", () =>
     yield* Fiber.join(resume);
     yield* Fiber.join(close);
 
-    NodeAssert.equal(yield* Ref.get(fixture.closeCalls), 1);
-    NodeAssert.equal(yield* isActive(fixture, input.sessionId), false);
+    assert.equal(yield* Ref.get(fixture.closeCalls), 1);
+    assert.equal(yield* isActive(fixture, input.sessionId), false);
   }),
 );
 
@@ -252,6 +252,6 @@ it.effect("shares one idempotent close operation", () =>
 
     yield* Fiber.join(first);
     yield* Fiber.join(second);
-    NodeAssert.equal(yield* Ref.get(fixture.closeCalls), 1);
+    assert.equal(yield* Ref.get(fixture.closeCalls), 1);
   }),
 );

--- a/packages/server/test/http/listen.test.ts
+++ b/packages/server/test/http/listen.test.ts
@@ -1,14 +1,14 @@
-import { createServer } from "node:http";
+import http from "node:http";
 import type { AddressInfo } from "node:net";
 
 import { afterEach, describe, expect, it } from "vitest";
 
 import { listenServer } from "../../src/http/listen";
 
-const servers = new Set<ReturnType<typeof createServer>>();
+const servers = new Set<ReturnType<typeof http.createServer>>();
 
 const makeServer = () => {
-  const server = createServer();
+  const server = http.createServer();
   servers.add(server);
   return server;
 };

--- a/packages/server/test/mcp.test.ts
+++ b/packages/server/test/mcp.test.ts
@@ -1,4 +1,4 @@
-import nodeFs from "node:fs/promises";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -32,10 +32,10 @@ const makeLayer = (home: string) => {
 describe("McpService", () => {
   let home: string;
   beforeEach(async () => {
-    home = await nodeFs.mkdtemp(path.join(os.tmpdir(), "vibest-mcp-"));
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-mcp-"));
   });
   afterEach(async () => {
-    await nodeFs.rm(home, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
   });
 
   const run = <A, E>(program: Effect.Effect<A, E, McpService | ProviderRepository>) =>

--- a/packages/server/test/mcp.test.ts
+++ b/packages/server/test/mcp.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import nodeFs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -32,10 +32,10 @@ const makeLayer = (home: string) => {
 describe("McpService", () => {
   let home: string;
   beforeEach(async () => {
-    home = await mkdtemp(join(tmpdir(), "vibest-mcp-"));
+    home = await nodeFs.mkdtemp(path.join(os.tmpdir(), "vibest-mcp-"));
   });
   afterEach(async () => {
-    await rm(home, { recursive: true, force: true });
+    await nodeFs.rm(home, { recursive: true, force: true });
   });
 
   const run = <A, E>(program: Effect.Effect<A, E, McpService | ProviderRepository>) =>

--- a/packages/server/test/project.test.ts
+++ b/packages/server/test/project.test.ts
@@ -1,6 +1,6 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import nodePath from "node:path";
 
 import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -18,10 +18,10 @@ const makeLayer = (home: string) =>
 describe("ProjectService", () => {
   let home: string;
   beforeEach(async () => {
-    home = await mkdtemp(join(tmpdir(), "vibest-proj-"));
+    home = await fs.mkdtemp(nodePath.join(os.tmpdir(), "vibest-proj-"));
   });
   afterEach(async () => {
-    await rm(home, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
   });
 
   const run = <A, E>(program: Effect.Effect<A, E, ProjectService>) =>
@@ -80,10 +80,10 @@ describe("ProjectService", () => {
   });
 
   it("reads a pre-envelope projects.json and adopts it into envelope form", async () => {
-    const file = join(home, "storage", "projects.json");
+    const file = nodePath.join(home, "storage", "projects.json");
     const project = { id: "p1", name: "app", path: "/tmp/app", createdAt: "2026-07-16T00:00:00Z" };
-    await mkdir(dirname(file), { recursive: true });
-    await writeFile(file, JSON.stringify([project]), "utf8");
+    await fs.mkdir(nodePath.dirname(file), { recursive: true });
+    await fs.writeFile(file, JSON.stringify([project]), "utf8");
 
     const listed = await run(
       Effect.gen(function* () {
@@ -93,15 +93,15 @@ describe("ProjectService", () => {
     );
     expect(listed).toEqual([project]);
 
-    const raw = JSON.parse(await readFile(file, "utf8"));
+    const raw = JSON.parse(await fs.readFile(file, "utf8"));
     expect(raw.version).toBe(1);
     expect(raw.data).toEqual([project]);
   });
 
   it("a corrupt projects.json fails per call with StoreReadError and recovers once fixed", async () => {
-    const file = join(home, "storage", "projects.json");
-    await mkdir(dirname(file), { recursive: true });
-    await writeFile(file, "{ not json", "utf8");
+    const file = nodePath.join(home, "storage", "projects.json");
+    await fs.mkdir(nodePath.dirname(file), { recursive: true });
+    await fs.writeFile(file, "{ not json", "utf8");
 
     // The layer must still build (no startup defect); the error is per call.
     const result = await run(
@@ -109,7 +109,7 @@ describe("ProjectService", () => {
         const svc = yield* ProjectService;
         const error = yield* Effect.flip(svc.list());
         // Fix the file on disk; the next call retries the open and recovers.
-        yield* Effect.promise(() => writeFile(file, "[]", "utf8"));
+        yield* Effect.promise(() => fs.writeFile(file, "[]", "utf8"));
         const listed = yield* svc.list();
         return { error, listed };
       }),

--- a/packages/server/test/project.test.ts
+++ b/packages/server/test/project.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -18,7 +18,7 @@ const makeLayer = (home: string) =>
 describe("ProjectService", () => {
   let home: string;
   beforeEach(async () => {
-    home = await fs.mkdtemp(nodePath.join(os.tmpdir(), "vibest-proj-"));
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-proj-"));
   });
   afterEach(async () => {
     await fs.rm(home, { recursive: true, force: true });
@@ -80,9 +80,9 @@ describe("ProjectService", () => {
   });
 
   it("reads a pre-envelope projects.json and adopts it into envelope form", async () => {
-    const file = nodePath.join(home, "storage", "projects.json");
+    const file = path.join(home, "storage", "projects.json");
     const project = { id: "p1", name: "app", path: "/tmp/app", createdAt: "2026-07-16T00:00:00Z" };
-    await fs.mkdir(nodePath.dirname(file), { recursive: true });
+    await fs.mkdir(path.dirname(file), { recursive: true });
     await fs.writeFile(file, JSON.stringify([project]), "utf8");
 
     const listed = await run(
@@ -99,8 +99,8 @@ describe("ProjectService", () => {
   });
 
   it("a corrupt projects.json fails per call with StoreReadError and recovers once fixed", async () => {
-    const file = nodePath.join(home, "storage", "projects.json");
-    await fs.mkdir(nodePath.dirname(file), { recursive: true });
+    const file = path.join(home, "storage", "projects.json");
+    await fs.mkdir(path.dirname(file), { recursive: true });
     await fs.writeFile(file, "{ not json", "utf8");
 
     // The layer must still build (no startup defect); the error is per call.

--- a/packages/server/test/provider.test.ts
+++ b/packages/server/test/provider.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -29,10 +29,10 @@ const openai: ProviderConfig = {
 describe("ProviderService", () => {
   let home: string;
   beforeEach(async () => {
-    home = await mkdtemp(join(tmpdir(), "vibest-prov-"));
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-prov-"));
   });
   afterEach(async () => {
-    await rm(home, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
   });
 
   const run = <A, E>(program: Effect.Effect<A, E, ProviderService>) =>

--- a/packages/server/test/rpc-fs.test.ts
+++ b/packages/server/test/rpc-fs.test.ts
@@ -1,6 +1,6 @@
-import nodeFs from "node:fs";
+import fs from "node:fs";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -8,20 +8,20 @@ import { makeRpcTestHarness } from "./rpc-harness";
 
 describe("fs router", () => {
   it("browses sorted subdirectories with parent, hiding dotfolders and node_modules", async () => {
-    const home = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-home-"));
-    const dir = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-browse-"));
-    nodeFs.mkdirSync(nodePath.join(dir, "beta"));
-    nodeFs.mkdirSync(nodePath.join(dir, "alpha"));
-    nodeFs.mkdirSync(nodePath.join(dir, ".hidden"));
-    nodeFs.mkdirSync(nodePath.join(dir, "node_modules"));
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-home-"));
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-browse-"));
+    fs.mkdirSync(path.join(dir, "beta"));
+    fs.mkdirSync(path.join(dir, "alpha"));
+    fs.mkdirSync(path.join(dir, ".hidden"));
+    fs.mkdirSync(path.join(dir, "node_modules"));
     const h = await makeRpcTestHarness(home);
     try {
       const listing = await h.client.fs.browse({ path: dir });
       expect(listing.path).toBe(dir);
-      expect(listing.parent).toBe(nodePath.dirname(dir));
+      expect(listing.parent).toBe(path.dirname(dir));
       expect(listing.directories).toEqual([
-        { name: "alpha", path: nodePath.join(dir, "alpha") },
-        { name: "beta", path: nodePath.join(dir, "beta") },
+        { name: "alpha", path: path.join(dir, "alpha") },
+        { name: "beta", path: path.join(dir, "beta") },
       ]);
 
       const root = await h.client.fs.browse({ path: "/" });

--- a/packages/server/test/rpc-fs.test.ts
+++ b/packages/server/test/rpc-fs.test.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import nodeFs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -8,20 +8,20 @@ import { makeRpcTestHarness } from "./rpc-harness";
 
 describe("fs router", () => {
   it("browses sorted subdirectories with parent, hiding dotfolders and node_modules", async () => {
-    const home = mkdtempSync(join(tmpdir(), "vibest-home-"));
-    const dir = mkdtempSync(join(tmpdir(), "vibest-browse-"));
-    mkdirSync(join(dir, "beta"));
-    mkdirSync(join(dir, "alpha"));
-    mkdirSync(join(dir, ".hidden"));
-    mkdirSync(join(dir, "node_modules"));
+    const home = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-home-"));
+    const dir = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-browse-"));
+    nodeFs.mkdirSync(nodePath.join(dir, "beta"));
+    nodeFs.mkdirSync(nodePath.join(dir, "alpha"));
+    nodeFs.mkdirSync(nodePath.join(dir, ".hidden"));
+    nodeFs.mkdirSync(nodePath.join(dir, "node_modules"));
     const h = await makeRpcTestHarness(home);
     try {
       const listing = await h.client.fs.browse({ path: dir });
       expect(listing.path).toBe(dir);
-      expect(listing.parent).toBe(dirname(dir));
+      expect(listing.parent).toBe(nodePath.dirname(dir));
       expect(listing.directories).toEqual([
-        { name: "alpha", path: join(dir, "alpha") },
-        { name: "beta", path: join(dir, "beta") },
+        { name: "alpha", path: nodePath.join(dir, "alpha") },
+        { name: "beta", path: nodePath.join(dir, "beta") },
       ]);
 
       const root = await h.client.fs.browse({ path: "/" });

--- a/packages/server/test/rpc-project.test.ts
+++ b/packages/server/test/rpc-project.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -8,12 +8,12 @@ import { makeRpcTestHarness } from "./rpc-harness";
 
 describe("project router", () => {
   it("creates a project named after the folder, dedupes by path, and lists it", async () => {
-    const home = mkdtempSync(join(tmpdir(), "vibest-home-"));
-    const workspace = mkdtempSync(join(tmpdir(), "vibest-project-"));
+    const home = fs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-home-"));
+    const workspace = fs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-project-"));
     const h = await makeRpcTestHarness(home);
     try {
       const created = await h.client.project.create({ path: workspace });
-      expect(created).toMatchObject({ name: basename(workspace), path: workspace });
+      expect(created).toMatchObject({ name: nodePath.basename(workspace), path: workspace });
 
       const again = await h.client.project.create({ path: workspace });
       expect(again.id).toBe(created.id);

--- a/packages/server/test/rpc-project.test.ts
+++ b/packages/server/test/rpc-project.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -8,12 +8,12 @@ import { makeRpcTestHarness } from "./rpc-harness";
 
 describe("project router", () => {
   it("creates a project named after the folder, dedupes by path, and lists it", async () => {
-    const home = fs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-home-"));
-    const workspace = fs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-project-"));
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-home-"));
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-project-"));
     const h = await makeRpcTestHarness(home);
     try {
       const created = await h.client.project.create({ path: workspace });
-      expect(created).toMatchObject({ name: nodePath.basename(workspace), path: workspace });
+      expect(created).toMatchObject({ name: path.basename(workspace), path: workspace });
 
       const again = await h.client.project.create({ path: workspace });
       expect(again.id).toBe(created.id);

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { createRouterClient } from "@orpc/server";
@@ -51,16 +51,16 @@ rl.on("line", (line) => {
 `;
 
 function makeFake(): string {
-  const dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "fake-codex-"));
-  const file = nodePath.join(dir, "fake-codex.js");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-codex-"));
+  const file = path.join(dir, "fake-codex.js");
   fs.writeFileSync(file, FAKE);
   fs.chmodSync(file, 0o755);
   return file;
 }
 
 async function setup() {
-  const home = fs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-home-"));
-  const workspace = fs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-ws-"));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-home-"));
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-ws-"));
   const pathsLayer = layerPaths(home);
 
   // The fake path goes to the adapter too: `session.create` gates on

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -1,6 +1,6 @@
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { createRouterClient } from "@orpc/server";
@@ -51,16 +51,16 @@ rl.on("line", (line) => {
 `;
 
 function makeFake(): string {
-  const dir = mkdtempSync(join(tmpdir(), "fake-codex-"));
-  const file = join(dir, "fake-codex.js");
-  writeFileSync(file, FAKE);
-  chmodSync(file, 0o755);
+  const dir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "fake-codex-"));
+  const file = nodePath.join(dir, "fake-codex.js");
+  fs.writeFileSync(file, FAKE);
+  fs.chmodSync(file, 0o755);
   return file;
 }
 
 async function setup() {
-  const home = mkdtempSync(join(tmpdir(), "vibest-home-"));
-  const workspace = mkdtempSync(join(tmpdir(), "vibest-ws-"));
+  const home = fs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-home-"));
+  const workspace = fs.mkdtempSync(nodePath.join(os.tmpdir(), "vibest-ws-"));
   const pathsLayer = layerPaths(home);
 
   // The fake path goes to the adapter too: `session.create` gates on

--- a/packages/server/test/session-repository.test.ts
+++ b/packages/server/test/session-repository.test.ts
@@ -1,6 +1,6 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -23,10 +23,10 @@ const meta = (sessionId: string, projectId: string, harnessSessionId: string): S
 describe("SessionRepository", () => {
   let home: string;
   beforeEach(async () => {
-    home = await mkdtemp(join(tmpdir(), "vibest-sess-"));
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-sess-"));
   });
   afterEach(async () => {
-    await rm(home, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
   });
 
   const run = <A, E>(program: Effect.Effect<A, E, SessionRepository>) =>
@@ -53,7 +53,7 @@ describe("SessionRepository", () => {
       }),
     );
     const raw = JSON.parse(
-      await readFile(join(home, "storage", "sessions", "proj-a", "sess-1.json"), "utf8"),
+      await fs.readFile(path.join(home, "storage", "sessions", "proj-a", "sess-1.json"), "utf8"),
     );
     expect(raw.version).toBe(1);
     expect(raw.data.sessionId).toBe("sess-1");
@@ -61,9 +61,9 @@ describe("SessionRepository", () => {
   });
 
   it("reads a pre-envelope record and adopts it into envelope form", async () => {
-    const file = join(home, "storage", "sessions", "proj-a", "sess-1.json");
-    await mkdir(dirname(file), { recursive: true });
-    await writeFile(file, JSON.stringify(meta("sess-1", "proj-a", "claude-uuid-1")), "utf8");
+    const file = path.join(home, "storage", "sessions", "proj-a", "sess-1.json");
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, JSON.stringify(meta("sess-1", "proj-a", "claude-uuid-1")), "utf8");
 
     const read = await run(
       Effect.gen(function* () {
@@ -73,7 +73,7 @@ describe("SessionRepository", () => {
     );
     expect(read.harnessSessionId).toBe("claude-uuid-1");
 
-    const raw = JSON.parse(await readFile(file, "utf8"));
+    const raw = JSON.parse(await fs.readFile(file, "utf8"));
     expect(raw.version).toBe(1);
     expect(raw.data.sessionId).toBe("sess-1");
   });
@@ -141,9 +141,9 @@ describe("SessionRepository", () => {
   });
 
   it("a corrupt record in another project does not break this project's list", async () => {
-    const badFile = join(home, "storage", "sessions", "proj-b", "bad.json");
-    await mkdir(dirname(badFile), { recursive: true });
-    await writeFile(badFile, "{ not json", "utf8");
+    const badFile = path.join(home, "storage", "sessions", "proj-b", "bad.json");
+    await fs.mkdir(path.dirname(badFile), { recursive: true });
+    await fs.writeFile(badFile, "{ not json", "utf8");
 
     const result = await run(
       Effect.gen(function* () {

--- a/packages/server/test/session-runtime.test.ts
+++ b/packages/server/test/session-runtime.test.ts
@@ -1,4 +1,4 @@
-import * as NodeAssert from "node:assert/strict";
+import NodeAssert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import type { SessionRef } from "@vibest/contract";

--- a/packages/server/test/session-runtime.test.ts
+++ b/packages/server/test/session-runtime.test.ts
@@ -1,4 +1,4 @@
-import NodeAssert from "node:assert/strict";
+import assert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
 import type { SessionRef } from "@vibest/contract";
@@ -72,19 +72,19 @@ it.effect("start is idempotent for a live runtime and stamps contiguous seqs", (
       });
       const snapshot = yield* awaitCursor(manager, 3);
 
-      NodeAssert.equal(snapshot.status.phase, "idle");
+      assert.equal(snapshot.status.phase, "idle");
       // The finished turn's buffer is retained, marked complete, for recovery.
-      NodeAssert.equal(snapshot.activeTurn?.complete, true);
-      NodeAssert.deepStrictEqual(
+      assert.equal(snapshot.activeTurn?.complete, true);
+      assert.deepStrictEqual(
         snapshot.activeTurn?.chunks.map((chunk) => chunk.seq),
         [2],
       );
-      NodeAssert.equal(snapshot.status.activeTurnId, undefined);
+      assert.equal(snapshot.status.activeTurnId, undefined);
       // The losing stream was never drained.
-      NodeAssert.equal(yield* Queue.size(second), 0);
+      assert.equal(yield* Queue.size(second), 0);
       yield* Queue.offer(second, { type: "start" });
       yield* Effect.yieldNow;
-      NodeAssert.equal(yield* Queue.size(second), 1);
+      assert.equal(yield* Queue.size(second), 1);
     }),
   ),
 );
@@ -117,9 +117,9 @@ it.effect("a chunk after turn.ended is dropped without consuming a seq", () =>
       const snapshot = yield* awaitCursor(manager, 3);
       // seq 3 (not 4) proves the straggler consumed no seq; the fresh turn's
       // empty buffer proves it was not appended anywhere.
-      NodeAssert.equal(snapshot.cursor, 3);
-      NodeAssert.equal(snapshot.activeTurn?.turnId, "turn-2");
-      NodeAssert.deepStrictEqual(snapshot.activeTurn?.chunks, []);
+      assert.equal(snapshot.cursor, 3);
+      assert.equal(snapshot.activeTurn?.turnId, "turn-2");
+      assert.deepStrictEqual(snapshot.activeTurn?.chunks, []);
     }),
   ),
 );
@@ -155,8 +155,8 @@ it.effect("a crashed stream keeps the projection queryable and runs onCrash once
       );
       // The projection stays queryable until close/delete/resume.
       const snapshot = yield* manager.snapshot(ref);
-      NodeAssert.equal(snapshot.status.phase, "crashed");
-      NodeAssert.equal(snapshot.activeTurn, null);
+      assert.equal(snapshot.status.phase, "crashed");
+      assert.equal(snapshot.activeTurn, null);
     }),
   ),
 );
@@ -181,10 +181,10 @@ it.effect("start replaces a crashed runtime with a fresh projection", () =>
         turnId: "turn-2",
       });
       const snapshot = yield* awaitCursor(manager, 1);
-      NodeAssert.equal(snapshot.status.phase, "running");
+      assert.equal(snapshot.status.phase, "running");
       // seq restarts with the replacement runtime.
-      NodeAssert.equal(snapshot.cursor, 1);
-      NodeAssert.equal(snapshot.activeTurn?.turnId, "turn-2");
+      assert.equal(snapshot.cursor, 1);
+      assert.equal(snapshot.activeTurn?.turnId, "turn-2");
     }),
   ),
 );
@@ -197,7 +197,7 @@ it.effect("stop removes the runtime", () =>
       yield* manager.start(ref, streamFromQueueOne(queue));
       yield* manager.stop(ref);
       const exit = yield* Effect.exit(manager.status(ref));
-      NodeAssert.equal(Exit.isFailure(exit), true);
+      assert.equal(Exit.isFailure(exit), true);
     }),
   ),
 );

--- a/packages/server/test/session-service.test.ts
+++ b/packages/server/test/session-service.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve as resolvePath } from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import nodePath from "node:path";
 
 import { isSessionScopedEvent } from "@vibest/contract";
 import { Effect, Layer, Stream } from "effect";
@@ -66,10 +66,10 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 describe("SessionService", () => {
   let home: string;
   beforeEach(async () => {
-    home = await mkdtemp(join(tmpdir(), "vibest-svc-"));
+    home = await fs.mkdtemp(nodePath.join(os.tmpdir(), "vibest-svc-"));
   });
   afterEach(async () => {
-    await rm(home, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
   });
 
   const layers = (port: Layer.Layer<HarnessAgentSessionPort>) => {
@@ -111,7 +111,7 @@ describe("SessionService", () => {
     expect(result.ref.sessionId).toMatch(UUID_RE);
     // harness saw the resolved cwd, never a projectId
     expect(spy.create).toEqual([
-      { harnessAgentId: "claude-code", cwd: resolvePath("/tmp/vibest-app") },
+      { harnessAgentId: "claude-code", cwd: nodePath.resolve("/tmp/vibest-app") },
     ]);
     // metadata stores the native id, keyed by the server sessionId (filename)
     expect(result.stored.harnessSessionId).toBe("native-1");
@@ -169,7 +169,7 @@ describe("SessionService", () => {
       {
         harnessAgentId: "claude-code",
         harnessSessionId: "native-1",
-        cwd: resolvePath("/tmp/vibest-app"),
+        cwd: nodePath.resolve("/tmp/vibest-app"),
       },
     ]);
   });

--- a/packages/server/test/session-service.test.ts
+++ b/packages/server/test/session-service.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
-import nodePath from "node:path";
+import path from "node:path";
 
 import { isSessionScopedEvent } from "@vibest/contract";
 import { Effect, Layer, Stream } from "effect";
@@ -66,7 +66,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 describe("SessionService", () => {
   let home: string;
   beforeEach(async () => {
-    home = await fs.mkdtemp(nodePath.join(os.tmpdir(), "vibest-svc-"));
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-svc-"));
   });
   afterEach(async () => {
     await fs.rm(home, { recursive: true, force: true });
@@ -111,7 +111,7 @@ describe("SessionService", () => {
     expect(result.ref.sessionId).toMatch(UUID_RE);
     // harness saw the resolved cwd, never a projectId
     expect(spy.create).toEqual([
-      { harnessAgentId: "claude-code", cwd: nodePath.resolve("/tmp/vibest-app") },
+      { harnessAgentId: "claude-code", cwd: path.resolve("/tmp/vibest-app") },
     ]);
     // metadata stores the native id, keyed by the server sessionId (filename)
     expect(result.stored.harnessSessionId).toBe("native-1");
@@ -169,7 +169,7 @@ describe("SessionService", () => {
       {
         harnessAgentId: "claude-code",
         harnessSessionId: "native-1",
-        cwd: nodePath.resolve("/tmp/vibest-app"),
+        cwd: path.resolve("/tmp/vibest-app"),
       },
     ]);
   });

--- a/packages/services/src/git-service.ts
+++ b/packages/services/src/git-service.ts
@@ -275,8 +275,8 @@ export class GitService {
               newContents = await git.show([`:${file}`]);
             } else {
               // Get from working directory
-              const fs = await import("fs/promises");
-              const nodePath = await import("path");
+              const fs = await import("node:fs/promises");
+              const nodePath = await import("node:path");
               newContents = await fs.readFile(nodePath.join(path, file), "utf-8");
             }
           } catch {
@@ -305,8 +305,8 @@ export class GitService {
               newContents = await git.show([`:${file}`]);
             } else {
               // Get working directory version
-              const fs = await import("fs/promises");
-              const nodePath = await import("path");
+              const fs = await import("node:fs/promises");
+              const nodePath = await import("node:path");
               newContents = await fs.readFile(nodePath.join(path, file), "utf-8");
             }
           } catch {
@@ -349,8 +349,8 @@ export class GitService {
    */
   async getDiffStats(path: string): Promise<DiffStats> {
     const git = this.getGit(path);
-    const fs = await import("fs/promises");
-    const nodePath = await import("path");
+    const fs = await import("node:fs/promises");
+    const nodePath = await import("node:path");
 
     // Get status to determine file states
     const status = await git.status();
@@ -533,8 +533,8 @@ export class GitService {
    */
   async getFileDiff(repoPath: string, filePath: string, staged = false): Promise<FileDiffContent> {
     const git = this.getGit(repoPath);
-    const fs = await import("fs/promises");
-    const nodePath = await import("path");
+    const fs = await import("node:fs/promises");
+    const nodePath = await import("node:path");
 
     const MAX_SIZE = 1024 * 1024; // 1MB
 

--- a/packages/services/src/terminal/terminal-manager.ts
+++ b/packages/services/src/terminal/terminal-manager.ts
@@ -1,6 +1,6 @@
-import * as crypto from "node:crypto";
-import * as fs from "node:fs";
-import { StringDecoder } from "node:string_decoder";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import stringDecoder from "node:string_decoder";
 
 import type { IPty } from "node-pty";
 import * as pty from "node-pty";
@@ -29,7 +29,7 @@ export type TerminalEvents = {
  * Direct publisher without batching.
  */
 class DirectPublisher {
-  private decoder = new StringDecoder("utf8");
+  private decoder = new stringDecoder.StringDecoder("utf8");
 
   constructor(
     private readonly terminalId: string,

--- a/tools/oxlint/node-import-style.mjs
+++ b/tools/oxlint/node-import-style.mjs
@@ -4,28 +4,75 @@ const { isBuiltin } = module;
 
 // Enforces the repo convention for Node builtin imports:
 //   import fs from "node:fs/promises"
-// i.e. a lone default import, with call sites using property access
-// (fs.rename(...)) — named and namespace specifiers are rejected. The `node:`
+// i.e. a lone default import bound to the module's canonical name, with call
+// sites using property access (fs.rename(...)). Named and namespace specifiers
+// are rejected; so are ad-hoc local names (nodePath, NodeAssert). The `node:`
 // prefix itself is `unicorn/prefer-node-protocol`'s job. Type-only imports are
 // exempt: types have no runtime binding.
+//
+// Canonical name: the module's first path segment, camelCased ("child_process"
+// -> childProcess, "fs/promises" -> fs, "assert/strict" -> assert). Only when
+// one file imports two builtins sharing a first segment (node:fs AND
+// node:fs/promises) does the subpath import fall back to the full camelCased
+// path (fsPromises).
+
+const bareName = (source) => source.replace(/^node:/, "");
+const camelize = (s) => s.replace(/[/_](\w)/g, (_, c) => c.toUpperCase());
+const firstSegment = (source) => bareName(source).split("/")[0];
+
+const canonicalNames = (declarations) => {
+  const byFirst = new Map();
+  for (const d of declarations) {
+    const first = firstSegment(d.source);
+    if (!byFirst.has(first)) byFirst.set(first, new Set());
+    byFirst.get(first).add(bareName(d.source));
+  }
+  return (source) => {
+    const bare = bareName(source);
+    const first = firstSegment(source);
+    const contested = byFirst.get(first).size > 1 && bare !== first;
+    return camelize(contested ? bare : first);
+  };
+};
+
 const nodeImportStyle = {
   create(context) {
+    const declarations = [];
+
     return {
       ImportDeclaration(node) {
         const source = node.source.value;
         if (typeof source !== "string" || !isBuiltin(source)) return;
         if (node.importKind === "type") return;
 
+        declarations.push({ source, node });
+
+        const short = camelize(firstSegment(source));
         for (const specifier of node.specifiers) {
           if (specifier.type === "ImportSpecifier" && specifier.importKind !== "type") {
             context.report({
               node: specifier,
-              message: `Use a default import for Node builtins: import ${shortName(source)} from "node:${bareName(source)}", then call ${shortName(source)}.<member> at the use site.`,
+              message: `Use a default import for Node builtins: import ${short} from "node:${bareName(source)}", then call ${short}.<member> at the use site.`,
             });
           } else if (specifier.type === "ImportNamespaceSpecifier") {
             context.report({
               node: specifier,
-              message: `Use a default import for Node builtins, not a namespace import: import ${shortName(source)} from "node:${bareName(source)}".`,
+              message: `Use a default import for Node builtins, not a namespace import: import ${short} from "node:${bareName(source)}".`,
+            });
+          }
+        }
+      },
+
+      "Program:exit"() {
+        const expectedFor = canonicalNames(declarations);
+        for (const { source, node } of declarations) {
+          const def = node.specifiers.find((s) => s.type === "ImportDefaultSpecifier");
+          if (!def) continue;
+          const expected = expectedFor(source);
+          if (def.local.name !== expected) {
+            context.report({
+              node: def,
+              message: `Import "${source}" under its canonical name: import ${expected} from "node:${bareName(source)}".`,
             });
           }
         }
@@ -33,16 +80,6 @@ const nodeImportStyle = {
     };
   },
 };
-
-function bareName(source) {
-  return source.startsWith("node:") ? source.slice(5) : source;
-}
-
-// "node:fs/promises" -> "fs", "node:child_process" -> "childProcess"
-function shortName(source) {
-  const base = bareName(source).split("/")[0];
-  return base.replace(/_(\w)/g, (_, c) => c.toUpperCase());
-}
 
 export default {
   meta: { name: "vibest" },

--- a/tools/oxlint/node-import-style.mjs
+++ b/tools/oxlint/node-import-style.mjs
@@ -1,0 +1,52 @@
+import module from "node:module";
+
+const { isBuiltin } = module;
+
+// Enforces the repo convention for Node builtin imports:
+//   import fs from "node:fs/promises"
+// i.e. a lone default import, with call sites using property access
+// (fs.rename(...)) — named and namespace specifiers are rejected. The `node:`
+// prefix itself is `unicorn/prefer-node-protocol`'s job. Type-only imports are
+// exempt: types have no runtime binding.
+const nodeImportStyle = {
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+        if (typeof source !== "string" || !isBuiltin(source)) return;
+        if (node.importKind === "type") return;
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type === "ImportSpecifier" && specifier.importKind !== "type") {
+            context.report({
+              node: specifier,
+              message: `Use a default import for Node builtins: import ${shortName(source)} from "node:${bareName(source)}", then call ${shortName(source)}.<member> at the use site.`,
+            });
+          } else if (specifier.type === "ImportNamespaceSpecifier") {
+            context.report({
+              node: specifier,
+              message: `Use a default import for Node builtins, not a namespace import: import ${shortName(source)} from "node:${bareName(source)}".`,
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+function bareName(source) {
+  return source.startsWith("node:") ? source.slice(5) : source;
+}
+
+// "node:fs/promises" -> "fs", "node:child_process" -> "childProcess"
+function shortName(source) {
+  const base = bareName(source).split("/")[0];
+  return base.replace(/_(\w)/g, (_, c) => c.toUpperCase());
+}
+
+export default {
+  meta: { name: "vibest" },
+  rules: {
+    "node-import-style": nodeImportStyle,
+  },
+};

--- a/tools/testing/fake-claude.mjs
+++ b/tools/testing/fake-claude.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { randomUUID } from "node:crypto";
-import { appendFileSync } from "node:fs";
+import crypto from "node:crypto";
+import fs from "node:fs";
 
 const args = process.argv.slice(2);
 
@@ -10,13 +10,13 @@ function argument(name) {
   return index === -1 ? undefined : args[index + 1];
 }
 
-const sessionId = argument("--session-id") ?? argument("--resume") ?? randomUUID();
+const sessionId = argument("--session-id") ?? argument("--resume") ?? crypto.randomUUID();
 const logPath = process.env["VIBEST_E2E_CLAUDE_LOG"];
 const configuredResponse = process.env["VIBEST_E2E_CLAUDE_RESPONSE"];
 let messageSequence = 0;
 
 function log(value) {
-  if (logPath) appendFileSync(logPath, `${JSON.stringify(value)}\n`);
+  if (logPath) fs.appendFileSync(logPath, `${JSON.stringify(value)}\n`);
 }
 
 function send(value) {
@@ -59,7 +59,7 @@ function initialize(requestId) {
     output_style: "default",
     skills: [],
     plugins: [],
-    uuid: randomUUID(),
+    uuid: crypto.randomUUID(),
     session_id: sessionId,
   });
 }
@@ -117,7 +117,7 @@ function respondToUserMessage(message) {
       usage: { input_tokens: 1, output_tokens: 1 },
     },
     parent_tool_use_id: null,
-    uuid: randomUUID(),
+    uuid: crypto.randomUUID(),
     session_id: sessionId,
   });
   send({
@@ -140,7 +140,7 @@ function respondToUserMessage(message) {
     },
     modelUsage: {},
     permission_denials: [],
-    uuid: randomUUID(),
+    uuid: crypto.randomUUID(),
     session_id: sessionId,
   });
 }


### PR DESCRIPTION
## What

Locks in the import convention for Node builtins: **`node:` prefix + a lone default import, property access at the use site** — `import fs from "node:fs"` then `fs.readFile(...)`. No named imports, no namespace imports, no destructuring of builtin modules.

- `unicorn/prefer-node-protocol: error` — the `node:` prefix half (built-in rule, autofixable).
- `vibest/node-import-style: error` — a ~50-line custom oxlint jsPlugin (`tools/oxlint/node-import-style.mjs`) rejecting named/namespace specifiers on builtin imports. Type-only imports (`import type { Stats }`) are exempt: no runtime binding to access.

## Why a custom rule

oxlint's `no-restricted-imports` can't express "default only": it matches default imports by their **local name** instead of ESLint's `"default"` sentinel, so `allowImportNamePattern: "^default$"` flags the very style we want, and there is no `allowTypeImports` escape hatch. `import/no-namespace` is global-only and would hit non-builtin namespace imports.

## Sweep

All existing violations cleaned up in the same change: 154 named/namespace specifiers across 55 files (imports rewritten to default form, call sites to `mod.member(...)`), plus 8 unprefixed dynamic imports in `packages/services/src/git-service.ts`.

The desktop e2e spec also gets its type coverage back: the extensionless `./fixtures` import was any-typing every fixture under NodeNext resolution (TS2835), hiding nine `pid: number | undefined` errors and a bad `Page`→`Window` cast — fixed via a throwing `appPid()` helper and an `unknown`-mediated cast.

## Verification

- `pnpm check` (lint + format + typecheck) green; e2e tsconfig typechecks clean (was 15 errors).
- `pnpm test` green — 240 server cases exercise the rewritten `fake-claude.mjs` for real.
- Desktop e2e suite: 6/8 pass; the 2 failures (chat input timeout, server survives shutdown) reproduce identically on clean `main` — pre-existing on this machine, unrelated (e2e is not in CI).