### PR TITLE
chore(test): unify assertion style and document the rule

### DIFF
--- a/.agents/rules/toolchain.md
+++ b/.agents/rules/toolchain.md
@@ -20,3 +20,12 @@
   `harness` enable `test.typecheck`, so type errors fail the run.
   `apps/desktop/e2e/` is Playwright and not in CI. `tools/testing/fake-claude.mjs`
   is referenced by relative path from both server tests and desktop e2e.
+- **Assertions:** the runner is always vitest; only the assertion library splits.
+  Effect tests (`it.effect`, `layer`) use `node:assert/strict`, plain synchronous
+  `it` uses vitest `expect` — currently no exceptions either way. The `/strict`
+  suffix is load-bearing: bare `node:assert` is the legacy `==` mode, where
+  `assert.equal(1, "1")` passes silently. Under `/strict`, `deepEqual` _is_
+  `deepStrictEqual` and `equal` _is_ `strictEqual`, so always write the short
+  name. `@effect/vitest` re-exports all of vitest, so a test that touches no
+  Effect API can import `describe`/`expect`/`it` from it — import from `vitest`
+  instead, and keep `@effect/vitest` meaning "this test runs an Effect".

--- a/packages/harness/test/claude-code/fold.test.ts
+++ b/packages/harness/test/claude-code/fold.test.ts
@@ -57,7 +57,7 @@ describe("foldToUIMessages", () => {
         (candidate) => (candidate as { type: string }).type === "tool-Read",
       ) as { output?: unknown } | undefined;
       assert.ok(part);
-      assert.deepStrictEqual(part.output, {
+      assert.deepEqual(part.output, {
         type: "text",
         file: { filePath: "/a", content: "hi" },
       });

--- a/packages/harness/test/schema/standard.test.ts
+++ b/packages/harness/test/schema/standard.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "@effect/vitest";
 import { eventIterator, oc } from "@orpc/contract";
 import { tool } from "ai";
 import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { toStandardSchema } from "../../src/schema/standard";

--- a/packages/harness/test/types/event.test.ts
+++ b/packages/harness/test/types/event.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "@effect/vitest";
 import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
 
 import { defineEvent, TokenUsageSchema, TurnErrorSchema } from "../../src/types/event";
 

--- a/packages/harness/test/types/request.test.ts
+++ b/packages/harness/test/types/request.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "@effect/vitest";
 import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
 
 import { AgentRequestSchema, AgentResponseSchema } from "../../src/types/request";
 

--- a/packages/server/test/event-bus-overflow.test.ts
+++ b/packages/server/test/event-bus-overflow.test.ts
@@ -27,11 +27,11 @@ it.effect("terminates a slow consumer once its bounded queue overflows", () =>
       yield* bus.publish(started(3));
 
       const items = yield* Stream.runCollect(stream.pipe(Stream.take(3)));
-      assert.deepStrictEqual(
+      assert.deepEqual(
         items.map((item) => item.type),
         ["event", "event", "closed"],
       );
-      assert.deepStrictEqual(items[2], { type: "closed", reason: "slow_consumer" });
+      assert.deepEqual(items[2], { type: "closed", reason: "slow_consumer" });
     }),
   ),
 );
@@ -46,11 +46,11 @@ it.effect("closeSession ends a matching subscriber with its reason", () =>
       yield* bus.closeSession(ref, "session_closed");
 
       const items = yield* Stream.runCollect(stream);
-      assert.deepStrictEqual(
+      assert.deepEqual(
         items.map((item) => item.type),
         ["event", "closed"],
       );
-      assert.deepStrictEqual(items.at(-1), { type: "closed", reason: "session_closed" });
+      assert.deepEqual(items.at(-1), { type: "closed", reason: "session_closed" });
     }),
   ),
 );

--- a/packages/server/test/events.test.ts
+++ b/packages/server/test/events.test.ts
@@ -34,7 +34,7 @@ layer(EventBusLayer)("EventBus", (it) => {
       const seqs = items.flatMap((item) =>
         item.type === "event" && "seq" in item.event ? [item.event.seq] : [],
       );
-      assert.deepStrictEqual(seqs, [1, 2]);
+      assert.deepEqual(seqs, [1, 2]);
     }),
   );
 
@@ -49,7 +49,7 @@ layer(EventBusLayer)("EventBus", (it) => {
       yield* bus.publish({ ref: ref("a"), type: "session.created" } satisfies CollectionEvent);
 
       const items = yield* Fiber.join(collector);
-      assert.deepStrictEqual(
+      assert.deepEqual(
         items.map((item) => (item.type === "event" ? item.event.type : item.type)),
         ["session.turn.started", "session.turn.started", "session.created"],
       );

--- a/packages/server/test/harness/claude-code/agent.test.ts
+++ b/packages/server/test/harness/claude-code/agent.test.ts
@@ -140,13 +140,13 @@ describe("ClaudeCodeAgent", () => {
         /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
       );
       assert.equal(lastOptions().sessionId, sessionId);
-      assert.deepStrictEqual(yield* agent.session.getSupportedCommands(sessionId), [
+      assert.deepEqual(yield* agent.session.getSupportedCommands(sessionId), [
         { name: "read", description: "Read files", argumentHint: "<file>" },
       ]);
-      assert.deepStrictEqual(yield* agent.session.getSupportedModels(sessionId), [
+      assert.deepEqual(yield* agent.session.getSupportedModels(sessionId), [
         { value: "sonnet", displayName: "Sonnet", description: "Fast" },
       ]);
-      assert.deepStrictEqual(yield* agent.session.getMcpServers(sessionId), [
+      assert.deepEqual(yield* agent.session.getMcpServers(sessionId), [
         { name: "filesystem", status: "connected" },
       ]);
       yield* agent.session.abort(sessionId);
@@ -170,11 +170,11 @@ describe("ClaudeCodeAgent", () => {
       });
       const output = yield* Stream.runCollect(prompt.output);
 
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Array.from(output, (message) => message.type),
         ["system", "result"],
       );
-      assert.deepStrictEqual(queryInstance.setModel.mock.calls, [["opus"]]);
+      assert.deepEqual(queryInstance.setModel.mock.calls, [["opus"]]);
     }),
   );
 
@@ -233,11 +233,11 @@ describe("ClaudeCodeAgent", () => {
       const events = yield* Fiber.join(collected);
 
       assert.equal(typeof receipt.turnId, "string");
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Array.from(events, (event) => event.body.type),
         ["session.turn.started", "start", "finish", "session.turn.ended"],
       );
-      assert.deepStrictEqual(queryInstance.setModel.mock.calls, [["opus"]]);
+      assert.deepEqual(queryInstance.setModel.mock.calls, [["opus"]]);
       yield* session.close;
     }),
   );
@@ -349,7 +349,7 @@ describe("ClaudeCodeAgent", () => {
       yield* Fiber.join(requestFiber);
       yield* agent.session.abort(sessionId);
 
-      assert.deepStrictEqual(yield* Effect.tryPromise(() => permission), {
+      assert.deepEqual(yield* Effect.tryPromise(() => permission), {
         behavior: "deny",
         message: "Request aborted due to session termination",
         interrupt: true,
@@ -389,7 +389,7 @@ describe("ClaudeCodeAgent", () => {
         });
       }
 
-      assert.deepStrictEqual(yield* Effect.tryPromise(() => permission), {
+      assert.deepEqual(yield* Effect.tryPromise(() => permission), {
         behavior: "allow",
         updatedInput: { command: "pwd" },
       });

--- a/packages/server/test/harness/claude-code/sdk-executable.test.ts
+++ b/packages/server/test/harness/claude-code/sdk-executable.test.ts
@@ -22,14 +22,14 @@ it.effect("communicates with Claude Agent SDK through a fake Claude executable",
     });
     const { sessionId } = yield* agent.session.create();
 
-    assert.deepStrictEqual(yield* agent.session.getSupportedModels(sessionId), [
+    assert.deepEqual(yield* agent.session.getSupportedModels(sessionId), [
       {
         value: "fake-claude",
         displayName: "Fake Claude",
         description: "Deterministic Claude executable used by Vibest tests",
       },
     ]);
-    assert.deepStrictEqual(yield* agent.session.getMcpServers(sessionId), []);
+    assert.deepEqual(yield* agent.session.getMcpServers(sessionId), []);
 
     const turn = yield* agent.session.prompt({
       sessionId,
@@ -38,7 +38,7 @@ it.effect("communicates with Claude Agent SDK through a fake Claude executable",
     const output = yield* Stream.runCollect(turn.output);
     const assistant = Array.from(output).find((message) => message.type === "assistant");
 
-    assert.deepStrictEqual(assistant?.message.content, [
+    assert.deepEqual(assistant?.message.content, [
       { type: "text", text: "Fake Claude received: SDK integration" },
     ]);
   }),

--- a/packages/server/test/harness/codex/agent.test.ts
+++ b/packages/server/test/harness/codex/agent.test.ts
@@ -190,7 +190,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
       const prompt = yield* agent.session.prompt({ sessionId, text: "ping" });
       const chunks = yield* Stream.runCollect(prompt.output);
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "text-start", "text-delta", "text-end", "finish"],
       );
@@ -414,7 +414,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       const events = yield* Fiber.join(collected);
 
       assert.equal(receipt.turnId, "turn_1");
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Array.from(events, (event) => event.body.type),
         [
           "session.turn.started",
@@ -464,7 +464,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const prompt = yield* agent.session.prompt({ sessionId, text: "crash" });
       const chunks = yield* Stream.runCollect(prompt.output);
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "text-start", "text-delta", "error"],
       );

--- a/packages/server/test/harness/codex/transport-holder.test.ts
+++ b/packages/server/test/harness/codex/transport-holder.test.ts
@@ -62,7 +62,7 @@ it.effect("Codex transport holder starts lazily and shares concurrent startup", 
     const firstTransport = yield* Fiber.join(first);
     const secondTransport = yield* Fiber.join(second);
 
-    assert.strictEqual(firstTransport, secondTransport);
+    assert.equal(firstTransport, secondTransport);
     assert.equal(yield* holder.status, "Running");
   }),
 );
@@ -171,7 +171,7 @@ it.effect("clears a crashed generation and starts a replacement", () =>
     );
 
     const second = yield* holder.ensure;
-    assert.notStrictEqual(second, first);
+    assert.notEqual(second, first);
     assert.equal(builds.length, 2);
   }),
 );

--- a/packages/server/test/harness/codex/transport.test.ts
+++ b/packages/server/test/harness/codex/transport.test.ts
@@ -57,7 +57,7 @@ layer(NodeServices.layer)("CodexTransport", (it) => {
     Effect.gen(function* () {
       const transport = yield* makeCodexTransport({ executablePath: makeFake() });
 
-      assert.deepStrictEqual(yield* transport.request("echo", { answer: 42 }), {
+      assert.deepEqual(yield* transport.request("echo", { answer: 42 }), {
         answer: 42,
       });
 

--- a/packages/server/test/harness/errors.test.ts
+++ b/packages/server/test/harness/errors.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "@effect/vitest";
 import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
 
 import {
   AgentProcessExited,

--- a/packages/server/test/harness/list.test.ts
+++ b/packages/server/test/harness/list.test.ts
@@ -35,7 +35,7 @@ it.effect("declares each harness's availability and permission subset", () =>
 
     const { harnessAgents } = yield* makeHarnessList(registry).list;
 
-    assert.deepStrictEqual(harnessAgents[0], {
+    assert.deepEqual(harnessAgents[0], {
       id: "claude-code",
       name: "claude-code",
       available: true,
@@ -71,7 +71,7 @@ it.effect("reports every registered harness, in registration order", () =>
 
     const { harnessAgents } = yield* makeHarnessList(registry).list;
 
-    assert.deepStrictEqual(
+    assert.deepEqual(
       harnessAgents.map((harnessAgent) => harnessAgent.id),
       ["claude-code", "codex", "pi"],
     );

--- a/packages/server/test/harness/pi/agent.test.ts
+++ b/packages/server/test/harness/pi/agent.test.ts
@@ -93,7 +93,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const prompt = yield* agent.session.prompt({ sessionId, text: "ping" });
       assert.equal(prompt.started, true);
       const chunks = yield* Stream.runCollect(prompt.output);
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "text-start", "text-delta", "text-end", "finish"],
       );
@@ -129,7 +129,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
       const prompt = yield* agent.session.prompt({ sessionId, text: "tool" });
       const chunks = yield* Stream.runCollect(prompt.output);
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "tool-input-available", "tool-output-available", "finish"],
       );
@@ -150,7 +150,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const request = yield* Fiber.join(requestFiber);
       assert.equal(request._tag, "Some");
       if (request._tag !== "Some") return;
-      assert.deepStrictEqual(request.value, {
+      assert.deepEqual(request.value, {
         harnessAgentId: "pi",
         type: "question",
         id: "ui1",
@@ -241,7 +241,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
 
       const prompt = yield* agent.session.prompt({ sessionId: doomed.sessionId, text: "crash" });
       const chunks = yield* Stream.runCollect(prompt.output);
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Array.from(chunks, (chunk) => chunk.type),
         ["start", "text-start", "text-delta", "error"],
       );
@@ -285,7 +285,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       const events = yield* Fiber.join(collected);
 
       assert.equal(typeof receipt.turnId, "string");
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Array.from(events, (event) => event.body.type),
         [
           "session.turn.started",
@@ -299,7 +299,7 @@ layer(NodeServices.layer)("PiAgent", (it) => {
       );
 
       const capabilities = yield* session.getCapabilities;
-      assert.deepStrictEqual(capabilities, {
+      assert.deepEqual(capabilities, {
         supportsResume: true,
         supportsSteering: true,
         supportsPermissions: false,

--- a/packages/server/test/harness/pi/transport.test.ts
+++ b/packages/server/test/harness/pi/transport.test.ts
@@ -51,7 +51,7 @@ layer(NodeServices.layer)("PiTransport", (it) => {
     Effect.gen(function* () {
       const transport = yield* makePiTransport({ executablePath: makeFake() });
 
-      assert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
+      assert.deepEqual(yield* transport.command({ type: "get_state" }), {
         sessionId: "s1",
       });
 
@@ -69,7 +69,7 @@ layer(NodeServices.layer)("PiTransport", (it) => {
       const transport = yield* makePiTransport({ executablePath: makeFake() });
       // The banner and setStatus arrive before this response; neither must
       // fail the frame reader nor surface as an event or a blocking request.
-      assert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
+      assert.deepEqual(yield* transport.command({ type: "get_state" }), {
         sessionId: "s1",
       });
     }),
@@ -141,7 +141,7 @@ rl.on("line", (line) => {
       );
       fs.chmodSync(file, 0o755);
       const transport = yield* makePiTransport({ executablePath: file, sessionId: "sid-42" });
-      assert.deepStrictEqual(yield* transport.command({ type: "get_state" }), {
+      assert.deepEqual(yield* transport.command({ type: "get_state" }), {
         sessionId: "sid-42",
       });
     }),

--- a/packages/server/test/harness/probe.test.ts
+++ b/packages/server/test/harness/probe.test.ts
@@ -38,7 +38,7 @@ it.effect("probes the directory it was asked about, grouped under the built-in p
 
     const result = yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
 
-    assert.deepStrictEqual(yield* Ref.get(seen), ["/work/app"]);
+    assert.deepEqual(yield* Ref.get(seen), ["/work/app"]);
     // Models never leave their provider: the built-in provider carries the
     // harness's own id, which is the other half of every providerId/modelId pair.
     assert.equal(result.providers[0]?.id, "claude-code");
@@ -80,7 +80,7 @@ it.effect("treats two directories as two probes, and does not serialise them", (
 
     // Both ran; if the registration lock covered the probes, the second would
     // have queued behind the first rather than interleaving.
-    assert.deepStrictEqual(Array.from(yield* Ref.get(seen)).toSorted(), ["/work/a", "/work/b"]);
+    assert.deepEqual(Array.from(yield* Ref.get(seen)).toSorted(), ["/work/a", "/work/b"]);
   }),
 );
 
@@ -136,7 +136,7 @@ it.effect("answers an empty provider list for a harness that has no probe", () =
 
     // Not a failure: pi genuinely has no models, and the client renders no
     // picker rather than an error.
-    assert.deepStrictEqual(yield* probe.probe({ harnessAgentId: "pi", cwd: "/work/app" }), {
+    assert.deepEqual(yield* probe.probe({ harnessAgentId: "pi", cwd: "/work/app" }), {
       providers: [],
     });
   }),

--- a/packages/server/test/harness/registry.test.ts
+++ b/packages/server/test/harness/registry.test.ts
@@ -20,7 +20,7 @@ it.effect("lists adapters and resolves them by harness agent id", () =>
   Effect.gen(function* () {
     const registry = makeHarnessAgentRegistry([claude]);
 
-    assert.deepStrictEqual(yield* registry.list, [claude.descriptor]);
+    assert.deepEqual(yield* registry.list, [claude.descriptor]);
     assert.equal(yield* registry.get("claude-code"), claude);
   }),
 );

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -142,12 +142,8 @@ it.effect("exposes the raw per-session event stream and tears down on close", ()
     yield* fixture.service.close(created.sessionId);
     const events = yield* Fiber.join(collected);
 
-    assert.deepStrictEqual(receipt, { turnId: "turn-1" });
-    assert.deepStrictEqual(Array.from(events), [
-      "session.turn.started",
-      "start",
-      "session.turn.ended",
-    ]);
+    assert.deepEqual(receipt, { turnId: "turn-1" });
+    assert.deepEqual(Array.from(events), ["session.turn.started", "start", "session.turn.ended"]);
     assert.equal(yield* Ref.get(fixture.closeCalls), 1);
     assert.equal(yield* isActive(fixture, created.sessionId), false);
   }),

--- a/packages/server/test/session-runtime.test.ts
+++ b/packages/server/test/session-runtime.test.ts
@@ -75,7 +75,7 @@ it.effect("start is idempotent for a live runtime and stamps contiguous seqs", (
       assert.equal(snapshot.status.phase, "idle");
       // The finished turn's buffer is retained, marked complete, for recovery.
       assert.equal(snapshot.activeTurn?.complete, true);
-      assert.deepStrictEqual(
+      assert.deepEqual(
         snapshot.activeTurn?.chunks.map((chunk) => chunk.seq),
         [2],
       );
@@ -119,7 +119,7 @@ it.effect("a chunk after turn.ended is dropped without consuming a seq", () =>
       // empty buffer proves it was not appended anywhere.
       assert.equal(snapshot.cursor, 3);
       assert.equal(snapshot.activeTurn?.turnId, "turn-2");
-      assert.deepStrictEqual(snapshot.activeTurn?.chunks, []);
+      assert.deepEqual(snapshot.activeTurn?.chunks, []);
     }),
   ),
 );


### PR DESCRIPTION
## Why

The suite splits its assertions two ways: every `it.effect`/`layer` test asserts with `node:assert/strict`, every plain synchronous `it` uses vitest `expect`. That is a real and consistently followed convention — 25 Effect test files, zero exceptions — but it was documented nowhere, so it reads as arbitrary to anyone opening a test file for the first time.

This writes the rule down and fixes the two ways the suite had drifted from it.

## Changes

**`.agents/rules/toolchain.md`** — a new **Assertions:** entry recording: the runner is always vitest and only the assertion library splits; which style goes with which test shape; that the `/strict` suffix is load-bearing (bare `node:assert` is the legacy `==` mode, where `assert.equal(1, "1")` passes silently); and that `@effect/vitest` should mean "this test runs an Effect".

**Short assertion names, 15 files / 44 call sites** — under `/strict`, `deepEqual` *is* `deepStrictEqual` and `equal` *is* `strictEqual`, but the suite used both spellings (42 vs 38 for deep equality). Collapsed onto the short names, matching the existing 165-to-1 majority for `equal`. Same function references, so no behaviour change:

```
before: 165 equal / 42 deepStrictEqual / 38 deepEqual / 10 ok / 6 match / 1 strictEqual / 1 notStrictEqual
after:  166 equal / 80 deepEqual / 10 ok / 6 match / 1 notEqual
```

**Four imports** — `harness/errors`, `types/request`, `types/event`, `schema/standard` are plain synchronous tests that touch no Effect API, but imported `describe`/`expect`/`it` from `@effect/vitest`, which works only because that package does `export * from "vitest"`. They now import from `vitest`, so the presence of `@effect/vitest` is once again a reliable signal.

Not a style-only claim about `expect` being worse inside `Effect.gen`: both assertion libraries fail identically there (Effect logs the `AssertionError` once, vitest still renders the diff). The one substantive advantage is that `assert.ok(x)` is a TS assertion function and narrows, which `expect(x).toBeDefined()` does not.

## Verification

- `pnpm check` (lint:check `--deny-warnings` + format:check + typecheck) — 12 tasks, all pass
- `turbo run test --filter=@vibest/server --filter=@vibest/harness --force` — 41 files / 240 tests pass, no type errors

One incidental formatting change: oxfmt collapsed an array in `session-service.test.ts` that fit on one line once the assertion name got shorter.