### PR TITLE
refactor(server): stop embedding vite, proxy dev traffic from the app instead

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,29 +1,37 @@
 ---
 name: verify
-description: Build/launch/drive recipe for verifying vibest web changes at runtime (tsx dev server, dynamic port)
+description: Build/launch/drive recipe for verifying vibest web changes at runtime (two processes: vite dev + the server)
 ---
 
 # Verifying vibest at runtime
 
 ## Build + launch
 
+Dev is **two processes**: Vite serves the app, the vibest server serves the API,
+and Vite proxies `/api` + `/ws/rpc` across so the browser stays same-origin.
+
 ```bash
-# Start the dev server (run_in_background) — no prebuild needed:
+# The API server (run_in_background) — no prebuild needed:
 # workspace packages export src/*.ts directly and tsx resolves them.
-# Pin the port so the URL is deterministic (dev otherwise picks a random one):
-cd packages/vibest && VIBEST_PORT=4000 pnpm dev
+cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4000
+
+# The app (run_in_background), in a second call:
+cd apps/app && pnpm dev                   # vite on 5173, proxying to 4000
 ```
 
-This runs `NODE_ENV=development tsx src/node/cli.ts`: one server bound to
-`127.0.0.1` with Vite middleware serving **`apps/app`**, oRPC at `/api/rpc`, WS
-at `/ws/rpc`, health at `/api/health`.
+Open **the Vite URL** (`http://localhost:5173/`), not the server port — the
+server only answers `/api/*`, `/ws/rpc`, and the _built_ bundle (503 until you
+`turbo run build --filter=@vibest/app`). `pnpm dev` at the root runs both through
+turbo.
 
-**Port is dynamic in dev.** `readPort()` returns `0` under `NODE_ENV=development`
-(the OS assigns an ephemeral port) unless `VIBEST_PORT` is set. Either pin it
-with `VIBEST_PORT=4000` (recommended), or read the actual port from the dev
-output — the server prints `vibest:ready {"port":<PORT>}` then
-`vibest listening on http://127.0.0.1:<PORT>`. Health check:
-`curl http://127.0.0.1:<PORT>/api/health` → `ok`.
+Health check: `curl http://127.0.0.1:4000/api/health` → `ok`, and
+`curl http://localhost:5173/api/health` → `ok` proves the proxy.
+
+To move the API off 4000, export `VIBEST_PORT` for **both** processes —
+`vite.config.ts` reads the same variable to pick its proxy target.
+
+Restarting the server no longer reloads the browser: Vite keeps the page, the
+client reconnects over the proxied WS.
 
 Gotchas:
 
@@ -31,10 +39,10 @@ Gotchas:
   typecheck; `pnpm run format` to fix formatting. Typecheck one package with
   `turbo run typecheck --filter=@vibest/app`.
 - **TanStack Router's `routeTree.gen.ts` regenerates only when the Vite router
-  plugin runs** — on app load through the dev server, NOT on typecheck. After
-  adding/renaming/deleting route files, hit the app root once
-  (`curl -o /dev/null http://127.0.0.1:<PORT>/`) before typechecking, or
-  typecheck fails against the stale tree.
+  plugin runs** — on app load through the Vite dev server, NOT on typecheck.
+  After adding/renaming/deleting route files, hit the app root once
+  (`curl -o /dev/null http://localhost:5173/`) before typechecking, or typecheck
+  fails against the stale tree.
 
 ## Flows worth driving
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -13,22 +13,27 @@ and Vite proxies `/api` + `/ws/rpc` across so the browser stays same-origin.
 ```bash
 # The API server (run_in_background) — no prebuild needed:
 # workspace packages export src/*.ts directly and tsx resolves them.
-cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4000
+cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4100
 
 # The app (run_in_background), in a second call:
-cd apps/app && pnpm dev                   # vite on 5173, proxying to 4000
+cd apps/app && pnpm dev                   # vite on 5180 (strict), proxying to 4100
 ```
 
-Open **the Vite URL** (`http://localhost:5173/`), not the server port — the
+Open **the Vite URL** (`http://localhost:5180/`), not the server port — the
 server only answers `/api/*`, `/ws/rpc`, and the _built_ bundle (503 until you
 `turbo run build --filter=@vibest/app`). `pnpm dev` at the root runs both through
 turbo.
 
-Health check: `curl http://127.0.0.1:4000/api/health` → `ok`, and
-`curl http://localhost:5173/api/health` → `ok` proves the proxy.
+Health check: `curl http://127.0.0.1:4100/api/health` → `ok`, and
+`curl http://localhost:5180/api/health` → `ok` proves the proxy.
 
-To move the API off 4000, export `VIBEST_PORT` for **both** processes —
-`vite.config.ts` reads the same variable to pick its proxy target.
+To move the API off 4100, export `VIBEST_PORT` for **both** processes —
+`vite.config.ts` reads the same variable to pick its proxy target. Don't point
+it at **4000**: that is the daemon's port, which the desktop app spawns and
+guards with an auth token, so the app would load and then fail to connect
+(`/api/health` 200, `/api/ws-ticket` 401) instead of failing loudly. If the app
+loads but shows no data, check which process owns the proxy target first:
+`lsof -nP -iTCP:4100 -sTCP:LISTEN`.
 
 Restarting the server no longer reloads the browser: Vite keeps the page, the
 client reconnects over the proxied WS.
@@ -41,7 +46,7 @@ Gotchas:
 - **TanStack Router's `routeTree.gen.ts` regenerates only when the Vite router
   plugin runs** — on app load through the Vite dev server, NOT on typecheck.
   After adding/renaming/deleting route files, hit the app root once
-  (`curl -o /dev/null http://localhost:5173/`) before typechecking, or typecheck
+  (`curl -o /dev/null http://localhost:5180/`) before typechecking, or typecheck
   fails against the stale tree.
 
 ## Flows worth driving

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -13,27 +13,27 @@ and Vite proxies `/api` + `/ws/rpc` across so the browser stays same-origin.
 ```bash
 # The API server (run_in_background) — no prebuild needed:
 # workspace packages export src/*.ts directly and tsx resolves them.
-cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4100
+cd packages/vibest && pnpm dev            # foreground `serve` on VIBEST_PORT=4180
 
 # The app (run_in_background), in a second call:
-cd apps/app && pnpm dev                   # vite on 5180 (strict), proxying to 4100
+cd apps/app && pnpm dev                   # vite on 4190 (strict), proxying to 4180
 ```
 
-Open **the Vite URL** (`http://localhost:5180/`), not the server port — the
-server only answers `/api/*`, `/ws/rpc`, and the _built_ bundle (503 until you
-`turbo run build --filter=@vibest/app`). `pnpm dev` at the root runs both through
-turbo.
+Open **the Vite URL** (`http://localhost:4190/`), not the server port — 4180
+answers `/api/*`, `/ws/rpc`, and the _built_ bundle, so it either 503s ("not
+built") or quietly serves a stale build instead of your edits. `pnpm dev` at the
+root runs both through turbo.
 
-Health check: `curl http://127.0.0.1:4100/api/health` → `ok`, and
-`curl http://localhost:5180/api/health` → `ok` proves the proxy.
+Health check: `curl http://127.0.0.1:4180/api/health` → `ok`, and
+`curl http://localhost:4190/api/health` → `ok` proves the proxy.
 
-To move the API off 4100, export `VIBEST_PORT` for **both** processes —
+To move the API off 4180, export `VIBEST_PORT` for **both** processes —
 `vite.config.ts` reads the same variable to pick its proxy target. Don't point
 it at **4000**: that is the daemon's port, which the desktop app spawns and
 guards with an auth token, so the app would load and then fail to connect
 (`/api/health` 200, `/api/ws-ticket` 401) instead of failing loudly. If the app
 loads but shows no data, check which process owns the proxy target first:
-`lsof -nP -iTCP:4100 -sTCP:LISTEN`.
+`lsof -nP -iTCP:4180 -sTCP:LISTEN`.
 
 Restarting the server no longer reloads the browser: Vite keeps the page, the
 client reconnects over the proxied WS.
@@ -46,7 +46,7 @@ Gotchas:
 - **TanStack Router's `routeTree.gen.ts` regenerates only when the Vite router
   plugin runs** — on app load through the Vite dev server, NOT on typecheck.
   After adding/renaming/deleting route files, hit the app root once
-  (`curl -o /dev/null http://localhost:5180/`) before typechecking, or typecheck
+  (`curl -o /dev/null http://localhost:4190/`) before typechecking, or typecheck
   fails against the stale tree.
 
 ## Flows worth driving

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -11,12 +11,23 @@ import { defineConfig } from "vite";
  * so this proxies the two prefixes it owns — which also keeps the app
  * same-origin with the RPC, the way it is when the server serves the built
  * bundle. Add a prefix here whenever the server grows one.
+ *
+ * 4100, not the server's own default of 4000: that port belongs to the daemon,
+ * which the desktop app spawns and which holds an auth token this browser
+ * cannot present. Proxying there answers `/api/health` but 401s the ws-ticket,
+ * so the app loads and never connects. Keep dev on a port nothing else claims.
  */
-const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4000);
+const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4100);
 const serverTarget = `http://127.0.0.1:${SERVER_PORT}`;
 
 export default defineConfig({
   server: {
+    // Pinned, and strict: 5173 is `apps/desktop`'s electron-vite renderer, so
+    // under `pnpm dev` Vite's default would silently land on 5174 — and whoever
+    // opened 5173 would get the desktop renderer, which has no proxy and never
+    // connects. Fail to boot instead of drifting to another port.
+    port: 5180,
+    strictPort: true,
     proxy: {
       "/api": { target: serverTarget, changeOrigin: true },
       "/ws/rpc": { target: serverTarget, changeOrigin: true, ws: true },

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -6,7 +6,22 @@ import react from "@vitejs/plugin-react";
 import { codeInspectorPlugin } from "code-inspector-plugin";
 import { defineConfig } from "vite";
 
+/**
+ * The dev server the browser talks to. The vibest server no longer embeds Vite,
+ * so this proxies the two prefixes it owns — which also keeps the app
+ * same-origin with the RPC, the way it is when the server serves the built
+ * bundle. Add a prefix here whenever the server grows one.
+ */
+const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4000);
+const serverTarget = `http://127.0.0.1:${SERVER_PORT}`;
+
 export default defineConfig({
+  server: {
+    proxy: {
+      "/api": { target: serverTarget, changeOrigin: true },
+      "/ws/rpc": { target: serverTarget, changeOrigin: true, ws: true },
+    },
+  },
   resolve: {
     tsconfigPaths: true,
     alias: { "@": url.fileURLToPath(new URL("./src", import.meta.url)) },

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -12,21 +12,22 @@ import { defineConfig } from "vite";
  * same-origin with the RPC, the way it is when the server serves the built
  * bundle. Add a prefix here whenever the server grows one.
  *
- * 4100, not the server's own default of 4000: that port belongs to the daemon,
- * which the desktop app spawns and which holds an auth token this browser
- * cannot present. Proxying there answers `/api/health` but 401s the ws-ticket,
- * so the app loads and never connects. Keep dev on a port nothing else claims.
+ * 4180/4190 rather than 4000/5173, which are taken: 4000 is the daemon's
+ * default, spawned by the desktop app and guarded by an auth token this browser
+ * cannot present — proxying there answers `/api/health` but 401s the ws-ticket,
+ * so the app loads and silently never connects. 5173 is `apps/desktop`'s
+ * electron-vite renderer. 4180/4190 are claimed by no common dev tool. Open
+ * 4190: 4180 serves the last *built* bundle, so it works but shows stale UI.
  */
-const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4100);
+const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4180);
 const serverTarget = `http://127.0.0.1:${SERVER_PORT}`;
 
 export default defineConfig({
   server: {
-    // Pinned, and strict: 5173 is `apps/desktop`'s electron-vite renderer, so
-    // under `pnpm dev` Vite's default would silently land on 5174 — and whoever
-    // opened 5173 would get the desktop renderer, which has no proxy and never
-    // connects. Fail to boot instead of drifting to another port.
-    port: 5180,
+    // Strict, so a taken port fails the boot instead of silently drifting to
+    // the next one — that drift is how you end up reading someone else's dev
+    // server at the URL you expected to be ours.
+    port: 4190,
     strictPort: true,
     proxy: {
       "/api": { target: serverTarget, changeOrigin: true },

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -7,9 +7,7 @@ import { WebSocketServer } from "ws";
 import { createRpcRuntime, createWsRPCHandler } from "../rpc";
 import { bearerToken, createTicketStore, tokensMatch } from "./auth";
 import { corsHeaders, isAllowedOrigin, isLoopbackHost } from "./cors";
-import { createUIHandler, type UIHandler } from "./ui";
-
-const isDev = process.env.NODE_ENV === "development";
+import { createUIHandler } from "./ui";
 
 export type ManagedServer = Server & {
   readonly dispose: () => Promise<void>;
@@ -41,9 +39,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
   const rpcRuntime = await createRpcRuntime();
   const wsHandler = createWsRPCHandler(rpcRuntime.context);
   const tickets = createTicketStore();
-
-  let serveUI: UIHandler;
-  let closeUI = async () => {};
+  const serveUI = createUIHandler();
 
   const server = http.createServer((req, res) => {
     void handleRequest(req, res);
@@ -114,8 +110,6 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     }
   }
 
-  ({ serveUI, closeUI } = await createUIHandler(server, isDev));
-
   const wss = new WebSocketServer({ noServer: true });
 
   wss.on("connection", (ws) => {
@@ -125,13 +119,9 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     console.error(e);
   });
 
-  // Share the same HTTP server between Vite's HMR socket and our custom WebSocketServer.
+  // The only upgrade this server answers. Vite's HMR socket used to share it;
+  // now `apps/app` runs its own dev server and proxies `/ws/rpc` here instead.
   server.on("upgrade", (req, socket, head) => {
-    if (isDev) {
-      const protocol = req.headers["sec-websocket-protocol"];
-      if (protocol && ["vite-ping", "vite-hmr"].includes(protocol)) return;
-    }
-
     const requestUrl = new URL(req.url ?? "/", "http://localhost");
     if (requestUrl.pathname !== "/ws/rpc") {
       socket.write("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
@@ -180,7 +170,6 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
       for (const client of wss.clients) client.terminate();
       await new Promise<void>((resolve) => wss.close(() => resolve()));
       await serverClosed;
-      await closeUI();
       await rpcRuntime.dispose();
     })());
 

--- a/packages/server/src/http/ui.ts
+++ b/packages/server/src/http/ui.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import url from "node:url";
 
@@ -33,46 +33,21 @@ function resolveStaticDir(): string | undefined {
 }
 
 /**
- * The UI-serving half of the server, isolated from auth/CORS/routing: Vite
- * middleware in dev (its HMR socket shares the HTTP server), `sirv` over the
- * built bundle in prod, and a 503 when the bundle has not been built.
+ * The UI-serving half of the server, isolated from auth/CORS/routing: `sirv`
+ * over the built bundle, and a 503 when the bundle has not been built. There is
+ * no dev branch — `apps/app` runs its own `vite dev` and proxies `/api` and
+ * `/ws/rpc` here, so this server serves files in every mode and never hosts a
+ * bundler.
  */
-export async function createUIHandler(
-  server: Server,
-  isDev: boolean,
-): Promise<{ readonly serveUI: UIHandler; readonly closeUI: () => Promise<void> }> {
-  if (isDev) {
-    // Import vite lazily so the production bundle never depends on it
-    // (vite is a devDependency and marked external in tsdown.config.ts).
-    const { createServer: createViteDevServer } = await import("vite");
-    const vite = await createViteDevServer({
-      // Serve the standalone web app package (apps/app) through this server.
-      root: path.resolve(url.fileURLToPath(new URL("../../../../apps/app/", import.meta.url))),
-      server: {
-        middlewareMode: true,
-        hmr: { server },
-      },
-    });
-    return {
-      serveUI: (req, res) => vite.middlewares(req, res, () => notFound(res)),
-      closeUI: () => vite.close(),
-    };
-  }
-
+export function createUIHandler(): UIHandler {
   const staticDir = resolveStaticDir();
   if (!staticDir) {
-    return {
-      serveUI: (_req, res) => {
-        res.statusCode = 503;
-        res.end("Web UI not built. Run the @vibest/app build first.");
-      },
-      closeUI: async () => {},
+    return (_req, res) => {
+      res.statusCode = 503;
+      res.end("Web UI not built. Run the @vibest/app build first.");
     };
   }
 
   const assets = sirv(staticDir, { single: true });
-  return {
-    serveUI: (req, res) => assets(req, res, () => notFound(res)),
-    closeUI: async () => {},
-  };
+  return (req, res) => assets(req, res, () => notFound(res));
 }

--- a/packages/server/src/rpc/handlers.ts
+++ b/packages/server/src/rpc/handlers.ts
@@ -1,10 +1,6 @@
-import type { Buffer } from "node:buffer";
-import type * as http from "node:http";
-import type { Socket } from "node:net";
-
 import { RPCHandler as WsRPCHandler } from "@orpc/server/websocket";
 import { ManagedRuntime } from "effect";
-import { type WebSocket, WebSocketServer } from "ws";
+import type { WebSocket } from "ws";
 
 import type { RpcContext } from "./context";
 import { router } from "./router";
@@ -47,74 +43,5 @@ export function createWsRPCHandler(rpcContext: RpcContext) {
     wsHandler.upgrade(ws, {
       context: rpcContext,
     });
-  };
-}
-
-type DevWsLogger = Pick<Console, "error">;
-
-type DevWsRPCHandlerOptions = {
-  path: string;
-  logger?: DevWsLogger;
-};
-
-export type DevWsRPCHandler = {
-  handleUpgrade(request: http.IncomingMessage, socket: Socket, head: Buffer): boolean;
-  teardown(): void;
-};
-
-export function createDevWsRPCHandler(
-  { path, logger }: DevWsRPCHandlerOptions,
-  rpcContext: RpcContext,
-): DevWsRPCHandler {
-  const webSocketServer = new WebSocketServer({ noServer: true });
-  const upgradeHandler = createWsRPCHandler(rpcContext);
-
-  const connectionListener = (socket: WebSocket) => {
-    upgradeHandler(socket);
-  };
-
-  webSocketServer.on("connection", connectionListener);
-
-  function handleUpgrade(request: http.IncomingMessage, socket: Socket, head: Buffer): boolean {
-    let requestUrl: URL;
-
-    try {
-      requestUrl = new URL(request.url ?? "", "http://localhost");
-    } catch (error) {
-      logger?.error(`Failed to parse ORPC WebSocket request URL: ${(error as Error).message}`);
-      socket.destroy();
-      return false;
-    }
-
-    if (requestUrl.pathname !== path) {
-      return false;
-    }
-
-    try {
-      webSocketServer.handleUpgrade(request, socket, head, (ws) => {
-        connectionListener(ws);
-      });
-    } catch (error) {
-      logger?.error(`Failed to upgrade ORPC WebSocket connection: ${(error as Error).message}`);
-      socket.destroy();
-      return false;
-    }
-
-    return true;
-  }
-
-  function teardown() {
-    webSocketServer.off("connection", connectionListener);
-
-    for (const client of webSocketServer.clients) {
-      client.terminate();
-    }
-
-    webSocketServer.close();
-  }
-
-  return {
-    handleUpgrade,
-    teardown,
   };
 }

--- a/packages/server/src/rpc/index.ts
+++ b/packages/server/src/rpc/index.ts
@@ -1,10 +1,4 @@
 export type { RpcContext } from "./context";
 export { AgentRuntimeLayer, ClaudeCode, ClaudeCodeLayer, Codex, CodexLayer } from "./runtime";
-export {
-  createDevWsRPCHandler,
-  createRpcRuntime,
-  createWsRPCHandler,
-  type DevWsRPCHandler,
-  type RpcRuntime,
-} from "./handlers";
+export { createRpcRuntime, createWsRPCHandler, type RpcRuntime } from "./handlers";
 export { type Router, router } from "./router";

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -9,7 +9,7 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "VIBEST_PORT=4000 tsx src/node/cli.ts serve",
+    "dev": "VIBEST_PORT=4100 tsx src/node/cli.ts serve",
     "build": "tsdown",
     "start": "node dist/cli.mjs",
     "test": "vitest run --passWithNoTests",

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -9,7 +9,7 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "NODE_ENV=development tsx src/node/cli.ts",
+    "dev": "VIBEST_PORT=4000 tsx src/node/cli.ts serve",
     "build": "tsdown",
     "start": "node dist/cli.mjs",
     "test": "vitest run --passWithNoTests",

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -9,7 +9,7 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "VIBEST_PORT=4100 tsx src/node/cli.ts serve",
+    "dev": "VIBEST_PORT=4180 tsx src/node/cli.ts serve",
     "build": "tsdown",
     "start": "node dist/cli.mjs",
     "test": "vitest run --passWithNoTests",

--- a/packages/vibest/tsdown.config.ts
+++ b/packages/vibest/tsdown.config.ts
@@ -1,12 +1,9 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  // Keep `vite` external: server.ts imports it lazily in dev only, and it must
-  // never end up in the production bundle.
   entry: ["src/node/cli.ts"],
   platform: "node",
   deps: {
-    neverBundle: ["vite"],
     // The private server/harness/contract packages are compiled into the CLI.
     // Whitelist their bundled runtime dependencies so additions fail closed.
     onlyBundle: [


### PR DESCRIPTION
Re-lands the three commits from #144. That PR's base was `refactor/effect-platform`, not `main`, so it merged into a feature branch and its changes never reached `main` — and they were dropped when that branch was rewritten to hold only the Effect migration. `refactor/split-vite-dev` is preserved at `a5e8338`.

## What

The server no longer embeds Vite. `apps/app` runs its own dev server and proxies the two prefixes the server owns, which also keeps the app same-origin with the RPC — the way it already is when the server serves the built bundle.

- `http/ui.ts` loses its dev branch: `createUIHandler()` is now synchronous, takes no `server`/`isDev`, and only ever serves `sirv` over the built bundle (or a 503 when it isn't built).
- `http/server.ts` drops the `vite-ping`/`vite-hmr` protocol skip on `upgrade` and the `closeUI` teardown; `/ws/rpc` is the only upgrade it answers.
- `rpc/handlers.ts` drops `createDevWsRPCHandler`, which existed only to share the socket with Vite's HMR.
- `apps/app/vite.config.ts` gains the `/api` + `/ws/rpc` proxy.
- `packages/vibest` no longer depends on vite; `pnpm dev` runs the foreground `serve`.
- Dev ports are pinned: 4180 for the API, 4190 for the web app.

## Rebase notes

Rebased from `82a17c9` onto `main`. Three files needed re-authoring rather than a mechanical resolution, because the original commits were written against the Effect-native HTTP layer from #141/#140:

- `http/app.ts` does not exist on `main` (it arrives with the Effect migration), so its hunk is dropped.
- `http/ui.ts` and `http/server.ts` are re-expressed against the `sirv`-based versions on `main`.
- The `.agents/rules/stack.md` hunk touched a section that only exists on the Effect branch, so it is dropped here. **Follow-up:** once the Effect migration lands, its `http/server.ts` exemption row still reads "oRPC and Vite HMR share that event" — that clause is stale after this PR.

## Testing

`pnpm check` 11/11, `pnpm test` 9/9 packages (441 tests), typecheck clean.