### PR TITLE
fix: remove temporary JSON files after failed atomic writes

### DIFF
--- a/packages/effect-json-store/src/atomic.ts
+++ b/packages/effect-json-store/src/atomic.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+
+import { Effect, type FileSystem, type PlatformError } from "effect";
+
+/**
+ * Write `text` to `file` atomically: write a randomly named sibling temp file,
+ * then rename it over the target, so a concurrent reader never sees a
+ * half-written file and a failed write leaves the original bytes untouched.
+ *
+ * The temp file is an acquired resource: whether the write succeeds, fails, is
+ * interrupted, or dies, the release step removes whatever is still at the temp
+ * path. After a successful rename the path is already gone, so removal runs
+ * with `force` and a missing file counts as completed cleanup; any other
+ * cleanup failure is logged and swallowed so it never masks the write's own
+ * outcome.
+ */
+export const writeFileAtomic = (
+  fs: FileSystem.FileSystem,
+  file: string,
+  text: string,
+  options?: { readonly mode?: number },
+): Effect.Effect<void, PlatformError.PlatformError> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => `${file}.${crypto.randomUUID()}.tmp`),
+    (tmp) =>
+      Effect.gen(function* () {
+        yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+        yield* fs.writeFileString(tmp, text, options);
+        if (options?.mode !== undefined) {
+          // `mode` on the write is masked by the process umask; chmod pins the
+          // exact permissions.
+          yield* fs.chmod(tmp, options.mode);
+        }
+        yield* fs.rename(tmp, file);
+      }),
+    (tmp) =>
+      fs
+        .remove(tmp, { force: true })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning(`failed to remove temp file ${tmp}`, cause),
+          ),
+        ),
+  );

--- a/packages/effect-json-store/src/codec.ts
+++ b/packages/effect-json-store/src/codec.ts
@@ -1,7 +1,6 @@
-import path from "node:path";
-
 import { Effect, type FileSystem, Option, Schema } from "effect";
 
+import { writeFileAtomic } from "./atomic";
 import {
   JsonStoreDecodeError,
   JsonStoreEncodeError,
@@ -81,10 +80,7 @@ export const makeFileCodec = (
         try: () => `${JSON.stringify(envelope, null, 2)}\n`,
         catch: (cause) => cause,
       });
-      yield* fs.makeDirectory(path.dirname(file), { recursive: true });
-      const tmp = `${file}.${crypto.randomUUID()}.tmp`;
-      yield* fs.writeFileString(tmp, text);
-      yield* fs.rename(tmp, file);
+      yield* writeFileAtomic(fs, file, text);
     }).pipe(Effect.mapError((cause) => new JsonStoreWriteError({ file, cause })));
 
   const save: FileCodec["save"] = (file, value) =>

--- a/packages/effect-json-store/src/index.ts
+++ b/packages/effect-json-store/src/index.ts
@@ -7,6 +7,7 @@
  * - `makeJsonDocument` — a standalone file: seeded defaults, eager load, cache.
  * - `makeJsonCollection` — a directory of keyed entries: get/put/remove/list.
  */
+export { writeFileAtomic } from "./atomic";
 export type { AnySchema, MigrationStep } from "./codec";
 export {
   type JsonCollection,

--- a/packages/effect-json-store/test/atomic.test.ts
+++ b/packages/effect-json-store/test/atomic.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import { it } from "@effect/vitest";
+import { Deferred, Effect, Fiber, FileSystem, PlatformError } from "effect";
+
+import { writeFileAtomic } from "../src";
+import { withTmp } from "./helpers";
+
+const renameError = PlatformError.systemError({
+  _tag: "PermissionDenied",
+  module: "FileSystem",
+  method: "rename",
+});
+
+it.effect("replaces the destination atomically and leaves no temp file", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      yield* fs.writeFileString(file, "old");
+      yield* writeFileAtomic(fs, file, "new");
+      assert.equal(yield* fs.readFileString(file), "new");
+      assert.deepEqual(yield* fs.readDirectory(dir), ["config.json"]);
+    }),
+  ),
+);
+
+it.effect("rename failure keeps the original bytes and removes the temp file", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const real = yield* FileSystem.FileSystem;
+      const failing: FileSystem.FileSystem = {
+        ...real,
+        rename: () => Effect.fail(renameError),
+      };
+      const file = path.join(dir, "config.json");
+      yield* real.writeFileString(file, "original");
+      const error = yield* Effect.flip(writeFileAtomic(failing, file, "next"));
+      assert.equal(error.reason._tag, "PermissionDenied");
+      assert.equal(yield* real.readFileString(file), "original");
+      assert.deepEqual(yield* real.readDirectory(dir), ["config.json"]);
+    }),
+  ),
+);
+
+it.effect("interruption after the temp write leaves no temp file", () =>
+  Effect.gen(function* () {
+    const real = yield* FileSystem.FileSystem;
+    const dir = yield* Effect.orDie(real.makeTempDirectoryScoped());
+    const renameStarted = yield* Deferred.make<void>();
+    // Rename never completes; by the time it starts, the temp file is on disk.
+    const hanging: FileSystem.FileSystem = {
+      ...real,
+      rename: () => Effect.andThen(Deferred.succeed(renameStarted, undefined), Effect.never),
+    };
+    const file = path.join(dir, "config.json");
+    const fiber = yield* Effect.forkScoped(writeFileAtomic(hanging, file, "next"));
+    yield* Deferred.await(renameStarted);
+    yield* Fiber.interrupt(fiber);
+    assert.deepEqual(yield* real.readDirectory(dir), []);
+  }).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer)),
+);

--- a/packages/effect-json-store/test/errors.test.ts
+++ b/packages/effect-json-store/test/errors.test.ts
@@ -89,6 +89,36 @@ it.effect("fails with JsonStoreWriteError when the encoded value is not JSON-ser
   ),
 );
 
+it.effect("fails with JsonStoreWriteError on rename failure, leaving no temp file", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const real = yield* FileSystem.FileSystem;
+      const file = path.join(dir, "config.json");
+      const original = JSON.stringify({ version: 1, data: { theme: "dark" } });
+      yield* real.writeFileString(file, original);
+      const failingRename: FileSystem.FileSystem = {
+        ...real,
+        rename: () =>
+          Effect.fail(
+            PlatformError.systemError({
+              _tag: "PermissionDenied",
+              module: "FileSystem",
+              method: "rename",
+            }),
+          ),
+      };
+      const store = yield* makeJsonDocument({ path: file, schema, defaults }).pipe(
+        Effect.provideService(FileSystem.FileSystem, failingRename),
+      );
+      const error = yield* Effect.flip(store.set({ theme: "light" }));
+      assert.equal(error._tag, "JsonStoreWriteError");
+      // The original document is untouched and the failed write's temp file is gone.
+      assert.equal(yield* real.readFileString(file), original);
+      assert.deepEqual(yield* real.readDirectory(dir), ["config.json"]);
+    }),
+  ),
+);
+
 /** Real filesystem for reads, but every write fails — for write-error injection. */
 const failingWrites = Layer.effect(
   FileSystem.FileSystem,

--- a/packages/server/src/daemon/record.ts
+++ b/packages/server/src/daemon/record.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 
+import { writeFileAtomic } from "@vibest/effect-json-store";
 import { Effect, FileSystem, type PlatformError } from "effect";
 
 /**
@@ -52,25 +53,18 @@ export const readRecord = (
   });
 
 /**
- * Atomically write the record with `0600` perms (token is a secret): write a
- * sibling temp file, chmod, then rename over the target so a concurrent reader
- * never sees a half-written file.
+ * Atomically write the record with `0600` perms (token is a secret). The
+ * shared writer renames a sibling temp file over the target so a concurrent
+ * reader never sees a half-written file, and removes the temp file when the
+ * write fails or is interrupted.
  */
 export const writeRecord = (
   home: string,
   record: DaemonRecord,
 ): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    yield* fs.makeDirectory(home, { recursive: true });
-    const target = recordPath(home);
-    const tmp = `${target}.${process.pid}.tmp`;
-    yield* fs.writeFileString(tmp, JSON.stringify(record), { mode: 0o600 });
-    // `mode` only applies when the write creates the file, so a leftover temp
-    // from a crashed launcher would otherwise keep its old perms.
-    yield* fs.chmod(tmp, 0o600);
-    yield* fs.rename(tmp, target);
-  });
+  FileSystem.FileSystem.use((fs) =>
+    writeFileAtomic(fs, recordPath(home), JSON.stringify(record), { mode: 0o600 }),
+  );
 
 /** Remove the record; a missing file is not an error. */
 export const removeRecord = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>

--- a/packages/server/test/daemon/record.test.ts
+++ b/packages/server/test/daemon/record.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
-import { Effect, FileSystem } from "effect";
+import { Effect, FileSystem, PlatformError } from "effect";
 
 import {
   type DaemonRecord,
@@ -73,6 +73,34 @@ layer(NodeServices.layer)("daemon record", (it) => {
 
       yield* fs.writeFileString(recordPath(home), JSON.stringify({ pid: 1 }));
       assert.equal(yield* readRecord(home), undefined);
+    }),
+  );
+
+  it.effect("a failed rename keeps the old record and leaves no temp file", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
+      yield* writeRecord(home, record);
+      const original = yield* fs.readFileString(recordPath(home));
+      const failingRename: FileSystem.FileSystem = {
+        ...fs,
+        rename: () =>
+          Effect.fail(
+            PlatformError.systemError({
+              _tag: "PermissionDenied",
+              module: "FileSystem",
+              method: "rename",
+            }),
+          ),
+      };
+      const error = yield* Effect.flip(
+        writeRecord(home, { ...record, pid: 9999 }).pipe(
+          Effect.provideService(FileSystem.FileSystem, failingRename),
+        ),
+      );
+      assert.equal(error.reason._tag, "PermissionDenied");
+      assert.equal(yield* fs.readFileString(recordPath(home)), original);
+      assert.deepEqual(yield* fs.readDirectory(home), ["daemon.pid"]);
     }),
   );
 


### PR DESCRIPTION
Fixes #157

## Problem

Both atomic JSON writers — `packages/effect-json-store`'s codec and the daemon record writer in `packages/server/src/daemon/record.ts` — wrote a randomly named sibling `.tmp` file and renamed it over the target. When the rename failed or the fiber was interrupted after the temp write, the temp file was left behind, accumulating orphaned files next to the real document.

## Fix

- Add a shared `writeFileAtomic` helper to `@vibest/effect-json-store`, built on `Effect.acquireUseRelease`: the temp path is acquired up front, write/chmod/rename run in the use phase, and the release step removes whatever is still at the temp path — on typed failure, defect, and interruption alike.
- Cleanup uses `fs.remove(tmp, { force: true })`, so an already-missing temp file (the success path, where rename consumed it) counts as completed cleanup; any other cleanup failure is logged at warning level and swallowed so it never masks the write's own outcome.
- The json-store codec and `writeRecord` (daemon.pid, still written with `0600` perms via the helper's `mode` option) now share this single implementation, so both paths follow the same cleanup policy.
- The original destination is untouched until the rename succeeds.

## Tests

- `writeFileAtomic`: successful atomic replace leaves no temp file; rename failure preserves the original bytes and removes the temp file; interruption after the temp write leaves no temp file.
- Document path: `store.set` under an injected rename failure fails with `JsonStoreWriteError`, keeps the file byte-identical, and leaves the directory clean.
- Daemon record: a failed rename keeps the old `daemon.pid` intact with no temp file left in `$VIBEST_HOME`.

Verified with `turbo run test typecheck --filter=@vibest/effect-json-store --filter=@vibest/server` plus root `lint:check` / `format:check`.