### PR TITLE
feat(ci): add compatibility gate for the Effect v4 beta family

### DIFF
--- a/.agents/rules/toolchain.md
+++ b/.agents/rules/toolchain.md
@@ -6,7 +6,10 @@
   `vitest`, `effect`, or `@effect/*` does nothing. Several pins are caret-free
   because a caret breaks the runtime. The reasons are commented inline; read them
   before changing versions. `packages/server` pins the Claude SDK as a literal
-  while `packages/vibest` uses `catalog:` — bump both together.
+  while `packages/vibest` uses `catalog:` — bump both together. The Effect
+  family (`effect`, `@effect/platform-node`, `@effect/vitest`) moves as one
+  exact-pinned set: `tools/effect/compat-gate.mjs` gates it in CI, and the
+  upgrade procedure is `docs/effect-upgrade.md`.
 - **Lint:** `lint:check` runs `--deny-warnings`, so the whole `suspicious`
   category fails CI while only warning locally. oxfmt reorders imports.
 - **Commits rewrite files:** pre-commit runs lint-staged (`oxlint --fix` + `oxfmt`)

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,6 +23,11 @@ jobs:
           node-version-file: ".node-version"
           cache: pnpm
 
+      # Effect compatibility gate: fails when the lockfile resolves more than
+      # one Effect runtime or the family drifts out of its pinned set. Pure
+      # file parsing, so it runs before install to fail fast.
+      - run: node tools/effect/compat-gate.mjs
+
       - run: pnpm install --frozen-lockfile
 
       # All three declare `dependsOn: ["^build"]`, so Turborepo builds the

--- a/docs/effect-upgrade.md
+++ b/docs/effect-upgrade.md
@@ -1,0 +1,70 @@
+# Effect upgrade checklist
+
+The app depends on an exact Effect v4 beta and uses two unstable modules in
+production (`effect/unstable/cli`, `effect/unstable/process`). Beta bumps can
+compile clean and break only at runtime — server startup, child-process
+lifecycle, or the packaged desktop app — so upgrades are deliberate, grouped,
+and gated (issue #161).
+
+## The compatibility set
+
+| package                 | where it is pinned              |
+| ----------------------- | ------------------------------- |
+| `effect`                | `catalog:` exact pin + override |
+| `@effect/platform-node` | `catalog:` exact pin + override |
+| `@effect/vitest`        | `catalog:` exact pin + override |
+
+The three move together, to the same version, in one PR. No automated or
+independent bumps: `taze`/bots must never float them, and a caret is never
+added — prerelease caret ranges admit newer betas and split the runtime.
+`@effect/platform-node-shared` is transitive and may resolve one beta ahead
+(the `effect` override keeps it on our runtime; the install-time peer warning
+for it is the known, accepted state — see the comment in
+`pnpm-workspace.yaml`). `@orpc/experimental-effect` rides `catalog:orpc` but
+peer-depends on `effect`; read its peer warning on every Effect bump.
+
+## The gate
+
+`node tools/effect/compat-gate.mjs` (also `pnpm run check:effect`) fails when:
+
+- any of the three is missing, range-versioned, or version-mismatched in the
+  catalog;
+- any of the three lacks its `"catalog:"` override;
+- a workspace `package.json` declares an Effect-family dependency outside
+  `catalog:`;
+- the lockfile resolves more than one `effect` runtime, a runtime other than
+  the pinned one, or multiple versions of any `@effect/*` package.
+
+CI runs it before `pnpm install` on every push and PR, so drift is a
+dependency-policy failure instead of a runtime surprise.
+
+## Upgrade procedure
+
+1. Bump all three catalog entries in `pnpm-workspace.yaml` to the same new
+   beta. Nothing else in the same PR.
+2. `pnpm install` — read the peer warnings. New warnings beyond the known
+   `platform-node-shared` one (especially from `@orpc/experimental-effect`)
+   mean the set is not compatible yet; stop.
+3. `pnpm run check:effect` — must pass on the new lockfile.
+4. `pnpm turbo run build test typecheck` — the lockfile change invalidates
+   every package's cache, so the full suite actually runs. The focused
+   compatibility surfaces are:
+   - unstable CLI parsing: `packages/server/test/http/cli-flags.test.ts`
+   - scoped child-process shutdown:
+     `packages/server/test/harness/child-process.test.ts`
+   - daemon lifecycle: `packages/server/test/daemon/*.test.ts`
+   - RPC context execution (`@orpc/experimental-effect`):
+     `packages/server/test/rpc-*.test.ts`
+   - desktop runtime disposal:
+     `apps/desktop/src/main/desktop-runtime-glue.test.ts`,
+     `apps/desktop/src/main/application/desktop-application.test.ts`
+5. `pnpm run lint:check && pnpm run format:check`.
+6. Runtime smoke — the failures this doc exists for surface here, not in
+   typecheck:
+   - server: launch per `.claude/skills/verify` and drive a session;
+   - CLI: `vibest daemon` start/status/stop round-trip (spawn + detach +
+     signal handling exercise `effect/unstable/process` for real);
+   - packaged desktop, whenever `effect/unstable/*` or `@effect/platform-*`
+     imports changed: `pnpm --filter desktop e2e` (Playwright, not in CI).
+7. Land the version bump plus any required code adaptations as one PR titled
+   as an Effect upgrade, and note behavioural changes in the PR body.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "check": "pnpm run lint:check && pnpm run format:check && pnpm run typecheck",
+    "check:effect": "node tools/effect/compat-gate.mjs",
     "clean": "turbo run clean && git clean -xdf node_modules dist .turbo",
     "bump": "pnpm taze",
     "sherif": "pnpm dlx sherif --fix",

--- a/packages/server/test/http/cli-flags.test.ts
+++ b/packages/server/test/http/cli-flags.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { layer } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import { CliError, Command } from "effect/unstable/cli";
+
+import { serveFlags } from "../../src/http/serve";
+
+type ServeInput = {
+  readonly port: Option.Option<number>;
+  readonly corsOrigin: ReadonlyArray<string>;
+};
+
+/**
+ * Compatibility smoke test for `effect/unstable/cli` (issue #161): the CLI
+ * builds `vibest serve` from these exact flags, and the unstable module can
+ * change parsing behaviour across Effect beta bumps without a compile error.
+ */
+layer(NodeServices.layer)("serveFlags parsing via effect/unstable/cli", (it) => {
+  const parse = (argv: ReadonlyArray<string>) =>
+    Effect.gen(function* () {
+      const seen: ServeInput[] = [];
+      const command = Command.make("serve", serveFlags, (input) =>
+        Effect.sync(() => {
+          seen.push(input);
+        }),
+      );
+      yield* Command.runWith(command, { version: "0.0.0" })(argv);
+      const input = seen[0];
+      assert.ok(input !== undefined, "the command handler never ran");
+      return input;
+    });
+
+  it.effect("parses --port and repeated --cors-origin", () =>
+    Effect.gen(function* () {
+      const input = yield* parse([
+        "--port",
+        "4123",
+        "--cors-origin",
+        "https://a.test",
+        "--cors-origin",
+        "https://b.test",
+      ]);
+      assert.deepEqual(input.port, Option.some(4123));
+      assert.deepEqual(input.corsOrigin, ["https://a.test", "https://b.test"]);
+    }),
+  );
+
+  it.effect("yields none / empty when no flags are given", () =>
+    Effect.gen(function* () {
+      const input = yield* parse([]);
+      assert.deepEqual(input.port, Option.none());
+      assert.deepEqual(input.corsOrigin, []);
+    }),
+  );
+
+  it.effect("fails with a CliError when --port is not an integer", () =>
+    Effect.gen(function* () {
+      const command = Command.make("serve", serveFlags, () => Effect.void);
+      const error = yield* Command.runWith(command, { version: "0.0.0" })([
+        "--port",
+        "not-a-port",
+      ]).pipe(Effect.flip);
+      assert.ok(CliError.isCliError(error));
+    }),
+  );
+});

--- a/tools/effect/compat-gate.mjs
+++ b/tools/effect/compat-gate.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// Effect compatibility gate (issue #161). The app runs on an exact Effect v4
+// beta and uses unstable modules in production, so version drift compiles fine
+// and only fails at runtime. This script makes drift a dependency-policy
+// failure instead: it verifies that the catalog, the overrides, every
+// workspace manifest, and the lockfile agree on exactly one Effect runtime.
+//
+// Checks, in order:
+//   1. `effect`, `@effect/platform-node`, `@effect/vitest` are catalog-pinned
+//      to one identical exact version (no ranges) — the compatibility set.
+//   2. Each of them has a `catalog:` override, so transitive resolutions
+//      cannot introduce a second runtime (see the comment in
+//      pnpm-workspace.yaml).
+//   3. No workspace package.json declares an Effect-family dependency outside
+//      `catalog:`.
+//   4. The lockfile resolves exactly one `effect` version — the pinned one —
+//      across snapshots and peer suffixes, and every other `@effect/*`
+//      package resolves to a single version.
+//
+// Runs from a bare checkout (no install needed): `node tools/effect/compat-gate.mjs`.
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import url from "node:url";
+
+const root = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "..", "..");
+
+/** The pinned family: exact catalog pin + override, moved together in one PR. */
+const PINNED_FAMILY = ["effect", "@effect/platform-node", "@effect/vitest"];
+
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+const errors = [];
+
+function read(relative) {
+  return fs.readFileSync(path.join(root, relative), "utf8");
+}
+
+/** Entries of a flat top-level block ("catalog:", "overrides:") in pnpm-workspace.yaml. */
+function topLevelEntries(yamlText, blockKey) {
+  const lines = yamlText.split("\n");
+  const start = lines.indexOf(`${blockKey}:`);
+  const entries = new Map();
+  if (start === -1) return entries;
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    if (!line.startsWith("  ")) break;
+    const match = line.match(/^ {2}"?([^":]+)"?:\s*(?:"([^"]*)"|(\S+))\s*$/);
+    if (match) entries.set(match[1], match[2] ?? match[3]);
+  }
+  return entries;
+}
+
+const workspaceYaml = read("pnpm-workspace.yaml");
+const catalog = topLevelEntries(workspaceYaml, "catalog");
+const overrides = topLevelEntries(workspaceYaml, "overrides");
+
+// 1. Exact, identical catalog pins.
+const pins = new Map();
+for (const name of PINNED_FAMILY) {
+  const version = catalog.get(name);
+  if (version === undefined) {
+    errors.push(`${name} is missing from the catalog in pnpm-workspace.yaml`);
+  } else if (!EXACT_VERSION.test(version)) {
+    errors.push(
+      `${name} catalog entry "${version}" is a range — the Effect family needs an exact pin`,
+    );
+  } else {
+    pins.set(name, version);
+  }
+}
+const distinctPins = new Set(pins.values());
+if (distinctPins.size > 1) {
+  const listed = [...pins].map(([name, version]) => `${name}@${version}`).join(", ");
+  errors.push(`the Effect family must share one version, got: ${listed}`);
+}
+const pinned = distinctPins.size === 1 ? [...distinctPins][0] : undefined;
+
+// 2. Overrides force transitive resolutions onto the catalog.
+for (const name of PINNED_FAMILY) {
+  if (overrides.get(name) !== "catalog:") {
+    errors.push(`${name} needs an override to "catalog:" in pnpm-workspace.yaml`);
+  }
+}
+
+// 3. Workspace manifests declare the family only via catalog:.
+const packageDirs = ["apps", "packages", "tools"].flatMap((group) => {
+  const groupDir = path.join(root, group);
+  if (!fs.existsSync(groupDir)) return [];
+  return fs
+    .readdirSync(groupDir)
+    .map((entry) => path.join(group, entry, "package.json"))
+    .filter((manifest) => fs.existsSync(path.join(root, manifest)));
+});
+for (const manifestPath of packageDirs) {
+  const manifest = JSON.parse(read(manifestPath));
+  for (const field of [
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+  ]) {
+    for (const [name, spec] of Object.entries(manifest[field] ?? {})) {
+      const isFamily = name === "effect" || name.startsWith("@effect/");
+      if (isFamily && spec !== "catalog:") {
+        errors.push(
+          `${manifestPath} declares ${name}: "${spec}" — Effect-family deps must use "catalog:"`,
+        );
+      }
+    }
+  }
+}
+
+// 4. The lockfile installs exactly one Effect runtime.
+const lockfile = read("pnpm-lock.yaml");
+
+/** Every resolved `effect@<version>` occurrence: snapshot/package keys and peer suffixes. */
+function collectVersions(text, pattern) {
+  const versions = new Map();
+  for (const match of text.matchAll(pattern)) {
+    const [, , name, version] = match;
+    const key = name === "" ? "effect" : name;
+    if (!versions.has(key)) versions.set(key, new Set());
+    versions.get(key).add(version);
+  }
+  return versions;
+}
+
+const runtimeVersions =
+  collectVersions(lockfile, /(^|[\s'"(])()effect@([^\s'"():]+)/gm).get("effect") ?? new Set();
+if (runtimeVersions.size === 0) {
+  errors.push("no resolved effect version found in pnpm-lock.yaml");
+} else if (runtimeVersions.size > 1) {
+  errors.push(`multiple effect runtimes in pnpm-lock.yaml: ${[...runtimeVersions].join(", ")}`);
+} else if (pinned !== undefined && !runtimeVersions.has(pinned)) {
+  errors.push(
+    `lockfile resolves effect@${[...runtimeVersions][0]} but the catalog pins ${pinned} — reinstall`,
+  );
+}
+
+const familyVersions = collectVersions(
+  lockfile,
+  /(^|[\s'"(])(@effect\/[A-Za-z0-9._-]+)@([^\s'"():]+)/gm,
+);
+for (const [name, versions] of familyVersions) {
+  if (versions.size > 1) {
+    errors.push(`multiple versions of ${name} in pnpm-lock.yaml: ${[...versions].join(", ")}`);
+  }
+}
+for (const name of PINNED_FAMILY) {
+  const versions = familyVersions.get(name);
+  if (name === "effect" || versions === undefined) continue;
+  const [resolved] = [...versions];
+  if (pinned !== undefined && versions.size === 1 && resolved !== pinned) {
+    errors.push(`lockfile resolves ${name}@${resolved} but the catalog pins ${pinned} — reinstall`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Effect compatibility gate failed:");
+  for (const error of errors) console.error(`  - ${error}`);
+  console.error("Upgrade procedure: docs/effect-upgrade.md");
+  process.exit(1);
+}
+
+console.log(
+  `Effect compatibility gate passed: one runtime (effect@${[...runtimeVersions][0]}), ` +
+    `${familyVersions.size} @effect/* packages in lockstep`,
+);


### PR DESCRIPTION
## Summary

The app depends on an exact Effect v4 beta and uses `effect/unstable/cli` and `effect/unstable/process` in production, so Effect version drift compiles clean and surfaces only at runtime. This PR makes drift a dependency-policy failure and documents the grouped upgrade path.

- **`tools/effect/compat-gate.mjs`** — runs from a bare checkout (no install) and fails when:
  - `effect`, `@effect/platform-node`, or `@effect/vitest` is missing from the catalog, range-versioned, or out of lockstep with the others;
  - any of the three lacks its `"catalog:"` override (the mechanism that prevents a second transitive runtime);
  - a workspace `package.json` declares an Effect-family dependency outside `catalog:`;
  - the lockfile resolves more than one `effect` runtime, a runtime other than the pin, or multiple versions of any `@effect/*` package.
- **CI** — the gate runs in `quality.yml` before `pnpm install`, so a bad lockfile fails fast; locally it is `pnpm run check:effect`.
- **`packages/server/test/http/cli-flags.test.ts`** — compatibility smoke test for `effect/unstable/cli` parsing via `Command.runWith` over the real `serveFlags`. Scoped child-process shutdown, daemon lifecycle, RPC context execution, and desktop runtime disposal already had focused suites; unstable-CLI parsing was the gap.
- **`docs/effect-upgrade.md`** — the grouped upgrade checklist: bump all three catalog pins together in one PR, read peer warnings, run the gate, full turbo suite (a lockfile change invalidates every cache, so the compat suites actually re-run), and runtime/packaged-desktop smoke steps. `.agents/rules/toolchain.md` now points at the gate and the doc.

The exact beta pin stays until a deliberate move; the gate detects drift rather than floating to newer prereleases.

## Acceptance criteria mapping

- CI fails on >1 Effect runtime in the lockfile → gate check 4
- CI fails when the family doesn't match the compatibility set → gate checks 1–3
- Grouped updates → mechanically enforced by the identical-version check; procedure documented
- CLI / process lifecycle / RPC / desktop-disposal smoke tests on Effect upgrades → new CLI parsing test + existing suites, all re-run on any lockfile change; packaged-desktop smoke documented as a manual step
- Documented procedure → `docs/effect-upgrade.md`

## Verification

- Gate passes on the current tree; negative-tested against a mutated lockfile (second `effect@beta.98` snapshot), a caret catalog entry, a removed override, and a literal-versioned manifest dep — each fails with a targeted message.
- `turbo run test typecheck --filter=@vibest/server`: 315 passed, type errors none.
- `pnpm run lint:check` / `format:check` clean.

Fixes #161