### PR TITLE
fix: narrow blanket error-to-defect conversions to explicit invariants

### DIFF
--- a/packages/effect-json-store/src/codec.ts
+++ b/packages/effect-json-store/src/codec.ts
@@ -113,7 +113,9 @@ export const makeFileCodec = (
       const toVersion = fromVersion + 1;
       const next = versionSchema(toVersion);
       if (next === undefined) {
-        return yield* Effect.die(new Error(`missing schema for v${toVersion}`));
+        return yield* Effect.die(
+          new Error(`invariant: missing schema for v${toVersion} while migrating ${file}`),
+        );
       }
       const output = yield* Effect.try({
         try: () => step.migrate(input),
@@ -179,13 +181,19 @@ export const makeFileCodec = (
         );
         value = yield* migrateStep(file, legacy, legacyValue, 0);
       } else {
-        return yield* Effect.die(new Error("unreachable: none implies legacy"));
+        return yield* Effect.die(
+          new Error(
+            `invariant: ${file} missed the envelope decode with no legacy schema configured`,
+          ),
+        );
       }
 
       for (let from = Math.max(version, 1); from < latestVersion; from++) {
         const step = migrations[from - 1];
         if (step === undefined) {
-          return yield* Effect.die(new Error(`missing migration for v${from}`));
+          return yield* Effect.die(
+            new Error(`invariant: missing migration for v${from} while migrating ${file}`),
+          );
         }
         value = yield* migrateStep(file, step, value, from);
       }

--- a/packages/effect-json-store/src/collection.ts
+++ b/packages/effect-json-store/src/collection.ts
@@ -122,7 +122,7 @@ export const makeJsonCollection = <
     const fileOf = (id: string): Effect.Effect<string> =>
       isValidId(id)
         ? Effect.succeed(path.join(dir, `${id}.json`))
-        : Effect.die(new Error(`invalid collection id: ${JSON.stringify(id)}`));
+        : Effect.die(new Error(`invariant: invalid collection id ${JSON.stringify(id)}`));
 
     // One mutex per id, created on first touch. Grows with the number of
     // distinct ids used over the instance's lifetime — fine for file-backed
@@ -152,7 +152,9 @@ export const makeJsonCollection = <
       Effect.suspend(() => {
         const under = listOptions?.under;
         if (under !== undefined && !isValidId(under)) {
-          return Effect.die(new Error(`invalid collection id prefix: ${JSON.stringify(under)}`));
+          return Effect.die(
+            new Error(`invariant: invalid collection id prefix ${JSON.stringify(under)}`),
+          );
         }
         const root = under === undefined ? dir : path.join(dir, under);
         return fs.readDirectory(root, { recursive: true }).pipe(

--- a/packages/effect-json-store/test/collection.test.ts
+++ b/packages/effect-json-store/test/collection.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 
 import { it } from "@effect/vitest";
-import { Effect, FileSystem, Option, Schema } from "effect";
+import { Cause, Effect, Exit, FileSystem, Option, Schema } from "effect";
 
 import { makeJsonCollection } from "../src";
 import { withTmp } from "./helpers";
@@ -200,6 +200,29 @@ it.effect("a corrupt entry fails get and list loudly", () =>
       assert.equal(getError._tag, "JsonStoreParseError");
       const listError = yield* Effect.flip(sessions.list());
       assert.equal(listError._tag, "JsonStoreParseError");
+    }),
+  ),
+);
+
+it.effect("an invalid id dies with the id in the defect, never as a typed failure", () =>
+  withTmp((dir) =>
+    Effect.gen(function* () {
+      const sessions = yield* makeJsonCollection({ dir: path.join(dir, "sessions"), schema: V2 });
+
+      // The documented defect boundary: ids are the caller's responsibility,
+      // so an unsanitized id is a caller bug — a defect that names the id,
+      // never a typed store error a caller could mistake for a disk problem.
+      const getExit = yield* Effect.exit(sessions.get("../escape"));
+      assert.equal(Exit.isFailure(getExit) && Cause.hasDies(getExit.cause), true);
+      assert.equal(Exit.isFailure(getExit) && Cause.hasFails(getExit.cause), false);
+      const defect = Exit.isFailure(getExit) ? Cause.squash(getExit.cause) : undefined;
+      assert.ok(defect instanceof Error && defect.message.includes("../escape"));
+
+      const putExit = yield* Effect.exit(sessions.put("", { title: "x", starred: false }));
+      assert.equal(Exit.isFailure(putExit) && Cause.hasDies(putExit.cause), true);
+
+      const idsExit = yield* Effect.exit(sessions.ids({ under: "/absolute" }));
+      assert.equal(Exit.isFailure(idsExit) && Cause.hasDies(idsExit.cause), true);
     }),
   ),
 );

--- a/packages/server/src/harness/claude-code/agent.ts
+++ b/packages/server/src/harness/claude-code/agent.ts
@@ -178,7 +178,14 @@ export const makeClaudeCodeAgent = ({
     // `listModels` ask, so an uncached Effect re-walks PATH on every session.
     const claudeExecutable = yield* Effect.cached(
       resolveClaudeExecutable({ env }).pipe(
-        Effect.orDie,
+        Effect.catchTag("ClaudeExecutableNotFound", (cause) =>
+          Effect.die(
+            new Error(
+              "invariant: the claude executable vanished after the availability check gated on it",
+              { cause },
+            ),
+          ),
+        ),
         Effect.provideService(FileSystem.FileSystem, fileSystem),
       ),
     );

--- a/packages/server/src/harness/list.ts
+++ b/packages/server/src/harness/list.ts
@@ -36,8 +36,17 @@ export const makeHarnessList = (registry: HarnessAgentRegistryShape) => ({
         descriptors,
         (descriptor) =>
           Effect.gen(function* () {
-            // `descriptor.id` came from `registry.list`, so the lookup can't miss.
-            const adapter = yield* registry.get(descriptor.id).pipe(Effect.orDie);
+            // `descriptor.id` came from `registry.list`, so the lookup can't
+            // miss — a miss is a registry invariant violation, not a failure.
+            const adapter = yield* registry.get(descriptor.id).pipe(
+              Effect.catchTag("HarnessAgentNotFound", (cause) =>
+                Effect.die(
+                  new Error(`invariant: registry listed '${descriptor.id}' but get missed it`, {
+                    cause,
+                  }),
+                ),
+              ),
+            );
             const availability = yield* adapter.checkAvailability;
             return {
               id: descriptor.id,

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -523,7 +523,14 @@ export const makeHarnessAgentSessionService = (deps: {
         Effect.flatMap((session) =>
           // The session is open, so its adapter is registered by construction.
           checkPermissionMode(session.harnessAgentId, permissionMode).pipe(
-            Effect.catchTag("HarnessAgentNotFound", (cause) => Effect.die(cause)),
+            Effect.catchTag("HarnessAgentNotFound", (cause) =>
+              Effect.die(
+                new Error(
+                  `invariant: open session '${session.sessionId}' has an unregistered adapter '${session.harnessAgentId}'`,
+                  { cause },
+                ),
+              ),
+            ),
             Effect.andThen(session.setPermissionMode(permissionMode)),
           ),
         ),
@@ -590,8 +597,13 @@ export const HarnessAgentSessionServiceLayer: Layer.Layer<
       repo,
       bus,
       // A platform RNG that cannot produce a uuid is a defect, not a domain
-      // failure — keep it out of the service's error channel.
-      newSessionId: crypto.randomUUIDv4.pipe(Effect.orDie),
+      // failure — keep it out of the service's error channel. Tag-specific so
+      // a future recoverable error on this channel stays typed instead of dying.
+      newSessionId: crypto.randomUUIDv4.pipe(
+        Effect.catchTag("PlatformError", (cause) =>
+          Effect.die(new Error("invariant: platform RNG failed minting a session id", { cause })),
+        ),
+      ),
     });
   }),
 );

--- a/packages/server/src/http/ui.ts
+++ b/packages/server/src/http/ui.ts
@@ -73,7 +73,17 @@ export const createUIHandler = (): Effect.Effect<
     // global, and `HttpStaticServer` reuses `serveFile` for the SPA fallback
     // (`HttpStaticServer.js:104`), so `immutable` would pin `index.html` too
     // and strand clients on a stale app. Per-asset headers need a wrapper.
-    const assets = yield* HttpStaticServer.make({ root: staticDir, spa: true }).pipe(Effect.orDie);
+    const assets = yield* HttpStaticServer.make({ root: staticDir, spa: true }).pipe(
+      // `resolveStaticDir` just proved `index.html` exists here, so a platform
+      // failure opening the same directory is a defect, not a served error.
+      Effect.catchTag("PlatformError", (cause) =>
+        Effect.die(
+          new Error(`invariant: static server could not open verified UI bundle at ${staticDir}`, {
+            cause,
+          }),
+        ),
+      ),
+    );
 
     // A path that matches no file is a 404; anything else went wrong on our
     // side. `RouteNotFound` covers both a missing asset and a deep link the

--- a/packages/server/src/project/service.ts
+++ b/packages/server/src/project/service.ts
@@ -38,8 +38,13 @@ export const ProjectServiceLayer: Layer.Layer<
     const repo = yield* ProjectRepository;
     const crypto = yield* Crypto.Crypto;
     // A platform RNG that cannot produce a uuid is a defect, not a domain
-    // failure — keep it out of the service's error channel.
-    const newId = crypto.randomUUIDv4.pipe(Effect.orDie);
+    // failure — keep it out of the service's error channel. Tag-specific so a
+    // future recoverable error on this channel stays typed instead of dying.
+    const newId = crypto.randomUUIDv4.pipe(
+      Effect.catchTag("PlatformError", (cause) =>
+        Effect.die(new Error("invariant: platform RNG failed minting a project id", { cause })),
+      ),
+    );
 
     return {
       list: () => repo.list(),

--- a/packages/server/test/harness/list.test.ts
+++ b/packages/server/test/harness/list.test.ts
@@ -1,11 +1,15 @@
 import assert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Cause, Effect, Exit } from "effect";
 
 import type { HarnessAgentAdapter } from "../../src/harness/adapter";
+import { HarnessAgentNotFound } from "../../src/harness/errors";
 import { makeHarnessList } from "../../src/harness/list";
-import { makeHarnessAgentRegistry } from "../../src/harness/registry";
+import {
+  makeHarnessAgentRegistry,
+  type HarnessAgentRegistryShape,
+} from "../../src/harness/registry";
 import { NodePlatformLayer } from "../platform";
 
 const adapter = (over: {
@@ -82,5 +86,26 @@ it.effect("reports every registered harness, in registration order", () =>
       harnessAgents.map((harnessAgent) => harnessAgent.id),
       ["claude-code", "codex", "pi"],
     );
+  }),
+);
+
+it.effect("a registry get that misses a listed id dies with the id in the defect", () =>
+  Effect.gen(function* () {
+    // A registry violating its own invariant: `list` announces an id that
+    // `get` cannot resolve. Listing must die naming the id — never drop the
+    // harness silently or surface the miss as a recoverable failure.
+    const broken: HarnessAgentRegistryShape = {
+      list: Effect.succeed([{ id: "claude-code", name: "claude-code" }]),
+      get: (harnessAgentId) => Effect.fail(new HarnessAgentNotFound({ harnessAgentId })),
+    };
+
+    const exit = yield* makeHarnessList(broken).list.pipe(
+      Effect.provide(NodePlatformLayer),
+      Effect.exit,
+    );
+    assert.equal(Exit.isFailure(exit) && Cause.hasDies(exit.cause), true);
+    assert.equal(Exit.isFailure(exit) && Cause.hasFails(exit.cause), false);
+    const defect = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;
+    assert.ok(defect instanceof Error && defect.message.includes("claude-code"));
   }),
 );

--- a/packages/server/test/project.test.ts
+++ b/packages/server/test/project.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 
 import { layer } from "@effect/vitest";
-import { Context, Effect, FileSystem, Layer } from "effect";
+import { Cause, Context, Crypto, Effect, Exit, FileSystem, Layer, PlatformError } from "effect";
 
 import {
   layerPaths,
@@ -119,6 +119,42 @@ layer(NodePlatformLayer)("ProjectService", (it) => {
       const svc = yield* projects;
       const error = yield* Effect.flip(svc.remove("nope"));
       assert.equal(error._tag, "ProjectNotFound");
+    }),
+  );
+
+  it.effect("an RNG failure minting a project id is a contextual defect, not a typed error", () =>
+    Effect.gen(function* () {
+      // The real Crypto with only `randomUUIDv4` broken: the service treats a
+      // platform RNG failure as an invariant violation, so it must die with
+      // the operation named — never leak into the typed error channel.
+      const brokenCrypto = Layer.effect(
+        Crypto.Crypto,
+        Effect.gen(function* () {
+          const real = yield* Crypto.Crypto;
+          return {
+            ...real,
+            randomUUIDv4: Effect.fail(
+              PlatformError.badArgument({ module: "Crypto", method: "randomUUIDv4" }),
+            ),
+          };
+        }),
+      ).pipe(Layer.provide(NodePlatformLayer));
+
+      const home = yield* tempHome;
+      const svc = yield* Layer.build(
+        ProjectServiceLayer.pipe(
+          Layer.provide(ProjectRepositoryLayer),
+          Layer.provide(layerPaths(home)),
+          Layer.provide(brokenCrypto),
+          Layer.provide(NodePlatformLayer),
+        ),
+      ).pipe(Effect.map((context) => Context.get(context, ProjectService)));
+
+      const exit = yield* Effect.exit(svc.create({ name: "app", path: "/tmp/app" }));
+      assert.equal(Exit.isFailure(exit) && Cause.hasDies(exit.cause), true);
+      assert.equal(Exit.isFailure(exit) && Cause.hasFails(exit.cause), false);
+      const defect = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;
+      assert.ok(defect instanceof Error && defect.message.includes("project id"));
     }),
   );
 });


### PR DESCRIPTION
Fixes #158

## What

Replaces every production `Effect.orDie` with tag-specific `Effect.catchTag` handling that dies only on the exact failure documented as impossible, wrapped in a contextual invariant `Error` carrying the operation, the identity involved, and the original cause. Adding a new recoverable error to any of these channels now keeps it in the typed error channel by default — the services' `never`-error shapes make a widened channel a compile error instead of a silent defect conversion.

## Narrowed boundaries

- **Project/session id minting** (`project/service.ts`, `harness/session-service.ts`): only `PlatformError` from the platform RNG dies, naming which id was being minted.
- **Harness listing** (`harness/list.ts`): only `HarnessAgentNotFound` dies, naming the id the registry listed but `get` missed.
- **setPermissionMode** (`harness/session-service.ts`): the existing tag-specific defect now records the open session and the unregistered adapter id.
- **Claude executable resolution** (`harness/claude-code/agent.ts`): only `ClaudeExecutableNotFound` dies, documenting that the availability check already gated on it.
- **Static UI serving** (`http/ui.ts`): only `PlatformError` dies, naming the verified bundle directory.
- **effect-json-store internals**: codec migration-chain defects now name the file; collection invalid-id defects keep naming the id.

## Validation before defect-only APIs

`session-repository.ts` already refines RPC-supplied `projectId`/`sessionId` (`isSafeId`) into typed `SessionNotFound`/`SessionRefNotFound` results before they reach the collection's defect-only id contract, with existing coverage ("malformed ids yield typed results, never defects").

## Tests

- `collection.test.ts`: invalid ids die with the id in the defect and never surface as typed store failures (get/put/ids).
- `list.test.ts`: a registry whose `get` misses a listed id dies with the harness id in the defect, not a recoverable failure.
- `project.test.ts`: an RNG failure minting a project id is a contextual defect, not a typed error, via a broken-`Crypto` layer.

Verified with `turbo run typecheck test --filter=@vibest/server --filter=@vibest/effect-json-store` (all green) plus `lint:check`/`format:check`.