### PR TITLE
fix(server): dispose partially initialized resources when startup fails

### DIFF
--- a/packages/server/src/http/index.ts
+++ b/packages/server/src/http/index.ts
@@ -1,4 +1,4 @@
-export { createServer } from "./server";
+export { createServer, ServerStartupError } from "./server";
 export type { CreateServerOptions, ManagedServer } from "./server";
 export { listenServer } from "./listen";
 export { formatReadyLine, parseReadyLine, READY_PREFIX } from "./handshake";

--- a/packages/server/src/http/serve.ts
+++ b/packages/server/src/http/serve.ts
@@ -3,7 +3,7 @@ import { Command, Flag } from "effect/unstable/cli";
 
 import { formatReadyLine } from "./handshake";
 import { listenServer } from "./listen";
-import { createServer } from "./server";
+import { createServer, ServerStartupError } from "./server";
 
 const DEFAULT_PORT = 4000;
 
@@ -76,11 +76,22 @@ export const runServe = (input: ServeInput) =>
     const { port: requestedPort, corsOrigins } = resolveServeConfig(input);
 
     const server = yield* Effect.acquireRelease(
-      Effect.promise(() => createServer({ authToken, corsOrigins })),
-      (managed) => Effect.promise(() => managed.dispose()),
+      Effect.tryPromise({
+        try: () => createServer({ authToken, corsOrigins }),
+        catch: (cause) => new ServerStartupError({ phase: "create", cause }),
+      }),
+      // A shutdown failure is logged, not thrown: the process is exiting, and
+      // a defect here would mask whatever caused the exit in the first place.
+      (managed) =>
+        Effect.tryPromise(() => managed.dispose()).pipe(
+          Effect.catch((error) => Effect.logWarning("server shutdown failed", error)),
+        ),
     );
 
-    const port = yield* Effect.tryPromise(() => listenServer(server, requestedPort));
+    const port = yield* Effect.tryPromise({
+      try: () => listenServer(server, requestedPort),
+      catch: (cause) => new ServerStartupError({ phase: "listen", cause }),
+    });
 
     // Machine-readable first, for the desktop supervisor; human-readable second.
     // Both go to stdout — Effect's logger writes to stderr, so it never mixes in.

--- a/packages/server/src/http/server.ts
+++ b/packages/server/src/http/server.ts
@@ -1,16 +1,16 @@
-import type { Server } from "node:http";
+import type { RequestListener, Server } from "node:http";
 import http from "node:http";
 
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
-import { Effect, Exit, Scope } from "effect";
+import { Cause, Data, Effect, Exit, Scope } from "effect";
 import type { WebSocket } from "ws";
 import { WebSocketServer } from "ws";
 
-import { createRpcRuntime, createWsRPCHandler } from "../rpc";
+import { createRpcRuntime, createWsRPCHandler, type RpcRuntime } from "../rpc";
 import { makeRequestApp } from "./app";
-import { createTicketStore } from "./auth";
+import { createTicketStore, type TicketStore } from "./auth";
 import { isAllowedOrigin, isLoopbackHost } from "./cors";
-import { createUIHandler } from "./ui";
+import { createUIHandler, type UIApp } from "./ui";
 
 export type ManagedServer = Server & {
   readonly dispose: () => Promise<void>;
@@ -31,27 +31,53 @@ export type CreateServerOptions = {
   corsOrigins?: readonly string[] | undefined;
 };
 
-export async function createServer(options: CreateServerOptions = {}): Promise<ManagedServer> {
-  const { authToken, corsOrigins = [] } = options;
+/** Startup failed for an operational reason: building the server or binding. */
+export class ServerStartupError extends Data.TaggedError("ServerStartupError")<{
+  readonly phase: "create" | "listen";
+  readonly cause: unknown;
+}> {}
 
-  const rpcRuntime = await createRpcRuntime();
-  const wsHandler = createWsRPCHandler(rpcRuntime.context);
-  const tickets = createTicketStore();
+/**
+ * The effectful startup stages, injectable so a test can fail any one of them
+ * and assert that every earlier stage's finalizer still runs (issue #155).
+ */
+export type ServerStages = {
+  readonly createRpcRuntime: () => Promise<RpcRuntime>;
+  readonly createUI: (runtime: RpcRuntime) => Promise<UIApp>;
+  readonly createRequestHandler: (
+    runtime: RpcRuntime,
+    app: ReturnType<typeof makeRequestApp>,
+    requestScope: Scope.Scope,
+  ) => Promise<RequestListener>;
+};
 
-  const server = http.createServer();
-
+const defaultStages: ServerStages = {
+  createRpcRuntime: () => createRpcRuntime(),
+  createUI: (runtime) => runtime.run(createUIHandler()),
   // The request half is Effect-native and runs on the RPC runtime, which
   // already carries FileSystem/Path/HttpPlatform. `makeHandler` gives back a
   // plain node `request` listener, which is the whole point: it leaves the
-  // `upgrade` event below untouched. (`HttpServer.serve` would register its own
+  // `upgrade` event untouched. (`HttpServer.serve` would register its own
   // upgrade handler and fight oRPC for it.)
-  const ui = await rpcRuntime.run(createUIHandler());
-  const requestScope = Scope.makeUnsafe();
-  const handleRequest = await rpcRuntime.run(
-    NodeHttpServer.makeHandler(makeRequestApp({ authToken, corsOrigins, tickets, ui }), {
-      scope: requestScope,
-    }),
-  );
+  createRequestHandler: (runtime, app, requestScope) =>
+    runtime.run(NodeHttpServer.makeHandler(app, { scope: requestScope })),
+};
+
+type WiredServer = {
+  readonly server: Server;
+  readonly wss: WebSocketServer;
+};
+
+function wireServer(options: {
+  readonly authToken: string | undefined;
+  readonly corsOrigins: readonly string[];
+  readonly tickets: TicketStore;
+  readonly wsHandler: (ws: WebSocket) => void;
+  readonly handleRequest: RequestListener;
+}): WiredServer {
+  const { authToken, corsOrigins, tickets, wsHandler, handleRequest } = options;
+
+  const server = http.createServer();
   server.on("request", handleRequest);
 
   const wss = new WebSocketServer({ noServer: true });
@@ -102,24 +128,91 @@ export async function createServer(options: CreateServerOptions = {}): Promise<M
     });
   });
 
+  return { server, wss };
+}
+
+const closeWiredServer = ({ server, wss }: WiredServer) =>
+  Effect.promise(async () => {
+    const serverClosed = server.listening
+      ? new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+          server.closeAllConnections();
+        })
+      : Promise.resolve();
+
+    for (const client of wss.clients) client.terminate();
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+    await serverClosed;
+  });
+
+/**
+ * Staged, scoped construction: every resource registers its finalizer in the
+ * scope immediately after it is acquired, so a failure in any later stage
+ * releases everything acquired before it, and normal disposal releases the
+ * stages in reverse acquisition order. A finalizer that fails does not stop
+ * the ones behind it — the scope runs them all and aggregates the causes.
+ */
+const buildServer = (
+  options: CreateServerOptions,
+  stages: ServerStages,
+): Effect.Effect<Server, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const { authToken, corsOrigins = [] } = options;
+
+    const rpcRuntime = yield* Effect.acquireRelease(
+      Effect.promise(() => stages.createRpcRuntime()),
+      (runtime) => Effect.promise(() => runtime.dispose()),
+    );
+    const wsHandler = createWsRPCHandler(rpcRuntime.context);
+    const tickets = createTicketStore();
+
+    const ui = yield* Effect.promise(() => stages.createUI(rpcRuntime));
+
+    // Closing this scope interrupts any request fiber still in flight; its
+    // release sits between the listeners stopping and the runtime going.
+    const requestScope = yield* Effect.acquireRelease(
+      Effect.sync(() => Scope.makeUnsafe()),
+      (scope) => Scope.close(scope, Exit.void),
+    );
+    const handleRequest = yield* Effect.promise(() =>
+      stages.createRequestHandler(
+        rpcRuntime,
+        makeRequestApp({ authToken, corsOrigins, tickets, ui }),
+        requestScope,
+      ),
+    );
+
+    // Last stage, so its release runs first: stop accepting connections and
+    // drain both socket populations before anything behind them is torn down.
+    const { server } = yield* Effect.acquireRelease(
+      Effect.sync(() => wireServer({ authToken, corsOrigins, tickets, wsHandler, handleRequest })),
+      closeWiredServer,
+    );
+    return server;
+  });
+
+export async function createServer(
+  options: CreateServerOptions = {},
+  stages: ServerStages = defaultStages,
+): Promise<ManagedServer> {
+  const scope = Scope.makeUnsafe();
   let disposing: Promise<void> | undefined;
-  const dispose = () =>
-    (disposing ??= (async () => {
-      const serverClosed = server.listening
-        ? new Promise<void>((resolve, reject) => {
-            server.close((error) => (error ? reject(error) : resolve()));
-            server.closeAllConnections();
-          })
-        : Promise.resolve();
+  const dispose = () => (disposing ??= Effect.runPromise(Scope.close(scope, Exit.void)));
 
-      for (const client of wss.clients) client.terminate();
-      await new Promise<void>((resolve) => wss.close(() => resolve()));
-      await serverClosed;
-      // Interrupts any request fiber still in flight before the runtime goes.
-      await Effect.runPromise(Scope.close(requestScope, Exit.void));
-      await rpcRuntime.dispose();
-    })());
+  const built = await Effect.runPromiseExit(
+    buildServer(options, stages).pipe(Scope.provide(scope)),
+  );
+  if (Exit.isFailure(built)) {
+    // A later stage failed: release every stage that already succeeded, then
+    // surface the original failure. A cleanup failure must not mask it.
+    const cleanup = await Effect.runPromiseExit(Scope.close(scope, built));
+    if (Exit.isFailure(cleanup)) {
+      console.error("[server] cleanup after failed startup", Cause.squash(cleanup.cause));
+    }
+    throw Cause.squash(built.cause);
+  }
 
+  const server = built.value;
   server.once("close", () => {
     void dispose();
   });

--- a/packages/server/test/http/serve.test.ts
+++ b/packages/server/test/http/serve.test.ts
@@ -1,7 +1,11 @@
-import { Option } from "effect";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+
+import { Cause, Effect, Exit, Option } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { resolveServeConfig } from "../../src/http/serve";
+import { resolveServeConfig, runServe } from "../../src/http/serve";
+import { ServerStartupError } from "../../src/http/server";
 
 const ENV_KEYS = ["VIBEST_PORT", "VIBEST_CORS_ORIGINS", "NODE_ENV"] as const;
 
@@ -51,5 +55,26 @@ describe("resolveServeConfig", () => {
       "https://a.test",
       "https://b.test",
     ]);
+  });
+});
+
+describe("runServe", () => {
+  it("fails with a typed startup error when binding the port fails", async () => {
+    // Occupy a port so runServe's listen stage fails after the server (and its
+    // runtime) has been built; the scope then releases what was acquired.
+    const blocker = net.createServer();
+    await new Promise<void>((resolve) => blocker.listen(0, "127.0.0.1", resolve));
+    const { port } = blocker.address() as AddressInfo;
+
+    try {
+      const exit = await Effect.runPromiseExit(
+        Effect.scoped(runServe({ port: Option.some(port), corsOrigin: [] })),
+      );
+      const error = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;
+      expect(error).toBeInstanceOf(ServerStartupError);
+      expect((error as ServerStartupError).phase).toBe("listen");
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
   });
 });

--- a/packages/server/test/http/server.test.ts
+++ b/packages/server/test/http/server.test.ts
@@ -1,10 +1,14 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 
+import { Context, Effect, Scope } from "effect";
+import { HttpServerResponse } from "effect/unstable/http";
 import { afterEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
 
 import { createServer, type ManagedServer } from "../../src/http/server";
+import type { UIApp } from "../../src/http/ui";
+import type { RpcRuntime } from "../../src/rpc";
 
 const TOKEN = "test-token-0000";
 
@@ -169,5 +173,86 @@ describe("createServer WebSocket ticket", () => {
   it("rejects a browser Origin outside the allowlist, even in browser mode", async () => {
     const base = await start({});
     expect(await connect(base, "", "/ws/rpc", { origin: "https://evil.example" })).toBe(403);
+  });
+});
+
+describe("createServer staged startup", () => {
+  const ui: UIApp = Effect.succeed(HttpServerResponse.text("ok"));
+
+  /** Records its disposal so a test can assert it ran, and ran exactly once. */
+  function fakeRuntime(released: string[]): RpcRuntime {
+    return {
+      context: { "effect/context": Context.empty() } as unknown as RpcRuntime["context"],
+      run: () => Promise.reject(new Error("fake runtime cannot run effects")),
+      dispose: async () => {
+        released.push("rpcRuntime");
+      },
+    };
+  }
+
+  it("disposes the RPC runtime exactly once when UI creation fails", async () => {
+    const released: string[] = [];
+    await expect(
+      createServer(
+        {},
+        {
+          createRpcRuntime: async () => fakeRuntime(released),
+          createUI: () => Promise.reject(new Error("ui failed")),
+          createRequestHandler: () => Promise.reject(new Error("unreachable")),
+        },
+      ),
+    ).rejects.toThrow("ui failed");
+    expect(released).toEqual(["rpcRuntime"]);
+  });
+
+  it("closes the request scope and the runtime when the request handler fails", async () => {
+    const released: string[] = [];
+    await expect(
+      createServer(
+        {},
+        {
+          createRpcRuntime: async () => fakeRuntime(released),
+          createUI: async () => ui,
+          createRequestHandler: async (_runtime, _app, requestScope) => {
+            await Effect.runPromise(
+              Scope.addFinalizer(
+                requestScope,
+                Effect.sync(() => released.push("requestScope")),
+              ),
+            );
+            throw new Error("handler failed");
+          },
+        },
+      ),
+    ).rejects.toThrow("handler failed");
+    expect(released).toEqual(["requestScope", "rpcRuntime"]);
+  });
+
+  it("releases the stages in reverse acquisition order, exactly once, on dispose", async () => {
+    const released: string[] = [];
+    const managed = await createServer(
+      {},
+      {
+        createRpcRuntime: async () => fakeRuntime(released),
+        createUI: async () => ui,
+        createRequestHandler: async (_runtime, _app, requestScope) => {
+          await Effect.runPromise(
+            Scope.addFinalizer(
+              requestScope,
+              Effect.sync(() => released.push("requestScope")),
+            ),
+          );
+          return () => {};
+        },
+      },
+    );
+    await new Promise<void>((resolve) => managed.listen(0, "127.0.0.1", resolve));
+    managed.once("close", () => released.push("http"));
+
+    await managed.dispose();
+    await managed.dispose();
+
+    expect(managed.listening).toBe(false);
+    expect(released).toEqual(["http", "requestScope", "rpcRuntime"]);
   });
 });


### PR DESCRIPTION
Fixes #155

## Problem

`createServer` acquired the RPC runtime, UI handler, request scope, and HTTP/WebSocket listeners one after another inside a single opaque promise. If any later stage failed (e.g. UI initialization after the runtime was created), startup rejected before the managed server value was returned, so no release action existed for resources that were already alive — leaking the runtime, its fibers, and any listeners.

The old `dispose` had the same shape of problem on the shutdown path: a rejection from `server.close` aborted the rest of the teardown, skipping the request-scope close and runtime disposal.

## Fix

- Rebuild `createServer` as staged, scoped acquisitions: each resource registers its finalizer in a `Scope` via `Effect.acquireRelease` immediately after it is acquired. A failure in any later stage closes the scope, releasing every earlier stage; normal disposal releases the stages in reverse acquisition order (HTTP/WS listeners → in-flight request scope → RPC runtime); a failing finalizer no longer prevents the ones behind it from running (the scope runs them all and aggregates causes).
- On failed startup, cleanup runs before the original error is surfaced, and a cleanup failure is logged rather than allowed to mask it.
- `runServe` now has a typed operational error channel: construction and bind failures become a tagged `ServerStartupError` instead of `Effect.promise` defects, and a shutdown failure during process exit is logged instead of becoming a defect that masks the exit cause.
- The startup stages are injectable (defaulting to the real implementations), so tests can fail each stage and observe the finalizers.

## Tests

- Failure during UI creation → RPC runtime disposed exactly once.
- Failure during request-handler creation → request scope closed, then runtime disposed.
- Normal dispose → stages released in reverse order (`http` → `requestScope` → `rpcRuntime`), exactly once, idempotent across a second `dispose()`.
- `runServe` against an occupied port → fails with `ServerStartupError` (`phase: "listen"`), with the scope releasing the already-built server.

`pnpm check` and `turbo run test --filter=@vibest/server` pass (316 tests).