### PR TITLE
Improve first-project onboarding and daemon state layout

### DIFF
--- a/.agents/rules/architecture.md
+++ b/.agents/rules/architecture.md
@@ -46,8 +46,13 @@ app-server generate-ts`) and is in the lint/format ignore lists. Don't hand-edit
   forbidden imports per directory, single composition root, `ipcRenderer` only in
   `src/preload/`). Read it before touching `apps/desktop/src`.
 - Port binding, auth, CORS, ticketing, static serving → `packages/server/src/http`,
-  not the CLI. `resolveVibestHome` in `packages/server/src/config/paths.ts` is the
-  only definition of `$VIBEST_HOME`; the one-daemon-per-home invariant rests on it.
+  not the CLI. `packages/server/src/config/paths.ts` holds the only definitions of
+  both locations: `resolveVibestHome` for `$VIBEST_HOME` (Projects and Sessions)
+  and `resolveDaemonDirectory` for `$VIBEST_DAEMON_DIR` (`daemon.pid`, `.lock`,
+  `.log`, `.stopped`, defaulting to `$VIBEST_HOME/daemon`). The single-daemon
+  invariant is keyed on the daemon directory, so every front door resolves it
+  there and passes it down — `packages/server/src/daemon/paths.ts` names files
+  inside a directory it is handed and deliberately has no default of its own.
 - `HarnessAgentIdSchema` in `packages/contract/src/domain.ts` is the whitelist:
   `claude-code`, `codex`, `pi` and nothing else. A fourth harness needs a literal
   there, a `packages/server/src/harness/<agent>/` transform, and a server adapter

--- a/apps/app/src/routes/draft.tsx
+++ b/apps/app/src/routes/draft.tsx
@@ -15,6 +15,15 @@ import {
   PromptInputTools,
 } from "@vibest/ui/ai-elements/prompt-input";
 import { Button } from "@vibest/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@vibest/ui/components/empty";
+import { FolderPlusIcon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -239,11 +248,22 @@ function DraftRoute() {
   // rather than showing a composer that can't submit.
   if (projects.data.length === 0) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-3 p-4">
-        <p className="text-muted-foreground text-sm">Import a project to start a session.</p>
-        <Button onClick={() => setImportOpen(true)} size="sm">
-          Import project
-        </Button>
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <FolderPlusIcon aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>
+            <h1>Import your first project</h1>
+          </EmptyTitle>
+          <EmptyDescription>
+            Choose a local folder for your coding agent to work in. You can start a chat right after
+            importing.
+          </EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <Button onClick={() => setImportOpen(true)}>Import project</Button>
+        </EmptyContent>
         {importOpen && (
           <ImportProjectDialog
             // The first project is the only one there is — land on a composer
@@ -254,7 +274,7 @@ function DraftRoute() {
             }
           />
         )}
-      </div>
+      </Empty>
     );
   }
 

--- a/apps/app/src/routes/draft.tsx
+++ b/apps/app/src/routes/draft.tsx
@@ -253,6 +253,12 @@ function DraftRoute() {
           <EmptyMedia variant="icon">
             <FolderPlusIcon aria-hidden="true" />
           </EmptyMedia>
+          {/*
+            The nested `h1` is deliberate: `EmptyTitle` is vendored from the coss
+            registry (docs/adr/0001), renders a plain `div`, and takes no `render`
+            prop — so this is the only way to keep both its `data-slot` styling
+            hook and a real page heading. Don't flatten it.
+          */}
           <EmptyTitle>
             <h1>Import your first project</h1>
           </EmptyTitle>

--- a/apps/desktop/src/main/server/daemon-server-process.test.ts
+++ b/apps/desktop/src/main/server/daemon-server-process.test.ts
@@ -36,19 +36,20 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
     const workspace = Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const home = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-daemon-desktop-" });
+      const daemonDir = path.join(home, "isolated-daemon");
       const entry = path.join(home, "fake-server.mjs");
       yield* fs.writeFileString(entry, FAKE_SERVER);
-      yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(home)));
+      yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(home, daemonDir)));
       const config: ServerProcessConfig = {
         entry,
-        environment: { ...process.env, VIBEST_HOME: home },
+        environment: { ...process.env, VIBEST_HOME: home, VIBEST_DAEMON_DIR: daemonDir },
       };
-      return { home, config };
+      return { home, daemonDir, config };
     });
 
     it.effect("spawns the shared daemon and reports its endpoint, then attaches on respawn", () =>
       Effect.gen(function* () {
-        const { home, config } = yield* workspace;
+        const { home, daemonDir, config } = yield* workspace;
 
         const endpoint = yield* Effect.scoped(
           Effect.gen(function* () {
@@ -58,7 +59,7 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
           }),
         );
 
-        const record = yield* readRecord(home);
+        const record = yield* readRecord(home, daemonDir);
         assert.ok(record);
         // The endpoint carries the daemon's own minted token, read from the record.
         assert.deepEqual(endpoint, {
@@ -74,20 +75,20 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
           }),
         );
         assert.deepEqual(again, endpoint);
-        assert.equal((yield* readRecord(home))?.pid, record.pid);
+        assert.equal((yield* readRecord(home, daemonDir))?.pid, record.pid);
       }),
     );
 
     it.effect("resolves awaitExit when the daemon dies", () =>
       Effect.gen(function* () {
-        const { home, config } = yield* workspace;
+        const { home, daemonDir, config } = yield* workspace;
 
         const exit = yield* Effect.scoped(
           Effect.gen(function* () {
             const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 50 });
             const running = yield* spawn(config, 0);
             yield* running.ready;
-            yield* stopDaemon(home);
+            yield* stopDaemon(home, daemonDir);
             return yield* running.awaitExit;
           }),
         );

--- a/apps/desktop/src/main/server/daemon-server-process.test.ts
+++ b/apps/desktop/src/main/server/daemon-server-process.test.ts
@@ -39,17 +39,17 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
       const daemonDir = path.join(home, "isolated-daemon");
       const entry = path.join(home, "fake-server.mjs");
       yield* fs.writeFileString(entry, FAKE_SERVER);
-      yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(home, daemonDir)));
+      yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(daemonDir)));
       const config: ServerProcessConfig = {
         entry,
         environment: { ...process.env, VIBEST_HOME: home, VIBEST_DAEMON_DIR: daemonDir },
       };
-      return { home, daemonDir, config };
+      return { daemonDir, config };
     });
 
     it.effect("spawns the shared daemon and reports its endpoint, then attaches on respawn", () =>
       Effect.gen(function* () {
-        const { home, daemonDir, config } = yield* workspace;
+        const { daemonDir, config } = yield* workspace;
 
         const endpoint = yield* Effect.scoped(
           Effect.gen(function* () {
@@ -59,7 +59,7 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
           }),
         );
 
-        const record = yield* readRecord(home, daemonDir);
+        const record = yield* readRecord(daemonDir);
         assert.ok(record);
         // The endpoint carries the daemon's own minted token, read from the record.
         assert.deepEqual(endpoint, {
@@ -75,20 +75,20 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
           }),
         );
         assert.deepEqual(again, endpoint);
-        assert.equal((yield* readRecord(home, daemonDir))?.pid, record.pid);
+        assert.equal((yield* readRecord(daemonDir))?.pid, record.pid);
       }),
     );
 
     it.effect("resolves awaitExit when the daemon dies", () =>
       Effect.gen(function* () {
-        const { home, daemonDir, config } = yield* workspace;
+        const { daemonDir, config } = yield* workspace;
 
         const exit = yield* Effect.scoped(
           Effect.gen(function* () {
             const spawn = yield* makeDaemonServerProcess({ pollIntervalMs: 50 });
             const running = yield* spawn(config, 0);
             yield* running.ready;
-            yield* stopDaemon(home, daemonDir);
+            yield* stopDaemon(daemonDir);
             return yield* running.awaitExit;
           }),
         );

--- a/apps/desktop/src/main/server/daemon-server-process.ts
+++ b/apps/desktop/src/main/server/daemon-server-process.ts
@@ -3,6 +3,7 @@ import {
   type DaemonPlatform,
   healthy,
   pidAlive,
+  resolveDaemonDirectory,
   resolveOrSpawnDaemon,
   resolveVibestHome,
 } from "@vibest/server/daemon";
@@ -20,9 +21,10 @@ export type DaemonServerProcessOptions = {
 
 /**
  * The daemon-backed `SpawnServer`: instead of forking a die-with-app child,
- * attach the one `$VIBEST_HOME` daemon (spawning it detached if absent) via the
- * shared launcher — the same attach-or-spawn the CLI runs, so desktop and CLI
- * always converge on a single backend. Consequences the supervisor inherits:
+ * attach the daemon selected by `$VIBEST_DAEMON_DIR` (defaulting under
+ * `$VIBEST_HOME`) via the shared launcher — the same attach-or-spawn the CLI
+ * runs, so desktop and CLI with the same environment converge on one backend.
+ * Consequences the supervisor inherits:
  *
  * - The daemon outlives the app: closing this process's scope kills nothing.
  * - "Exit" has no child handle to wait on, so it is detected by polling the
@@ -53,6 +55,9 @@ export function makeDaemonServerProcess(
 
         const handle = yield* resolveOrSpawnDaemon({
           home: resolveVibestHome(config.environment),
+          ...(config.environment.VIBEST_DAEMON_DIR === undefined
+            ? {}
+            : { daemonDir: resolveDaemonDirectory(config.environment) }),
           serverArgv: [process.execPath, config.entry],
           // 0 means "no preference" on the first attempt; afterwards the
           // supervisor pins the port it saw, which we pass as preferred.

--- a/apps/desktop/src/main/server/daemon-server-process.ts
+++ b/apps/desktop/src/main/server/daemon-server-process.ts
@@ -3,9 +3,8 @@ import {
   type DaemonPlatform,
   healthy,
   pidAlive,
-  resolveDaemonDirectory,
+  resolveDaemonLocation,
   resolveOrSpawnDaemon,
-  resolveVibestHome,
 } from "@vibest/server/daemon";
 import { Effect } from "effect";
 
@@ -54,10 +53,7 @@ export function makeDaemonServerProcess(
         };
 
         const handle = yield* resolveOrSpawnDaemon({
-          home: resolveVibestHome(config.environment),
-          ...(config.environment.VIBEST_DAEMON_DIR === undefined
-            ? {}
-            : { daemonDir: resolveDaemonDirectory(config.environment) }),
+          ...resolveDaemonLocation(config.environment),
           serverArgv: [process.execPath, config.entry],
           // 0 means "no preference" on the first attempt; afterwards the
           // supervisor pins the port it saw, which we pass as preferred.

--- a/apps/desktop/src/main/server/local-server-live.ts
+++ b/apps/desktop/src/main/server/local-server-live.ts
@@ -15,8 +15,8 @@ export const LocalServerLive = Layer.effect(
       ? resolveLoginShellEnvironmentWith(spawner)
       : Effect.sync(() => ({ ...process.env }));
 
-    // Attach the shared $VIBEST_HOME daemon (the same one the CLI uses)
-    // instead of forking a private die-with-app child — one backend per home.
+    // Attach the daemon selected by VIBEST_DAEMON_DIR (the same one the CLI
+    // uses) instead of forking a private die-with-app child.
     return yield* makeLocalServer(
       {
         entry: config.serverEntry,

--- a/apps/desktop/turbo.json
+++ b/apps/desktop/turbo.json
@@ -23,7 +23,9 @@
         "NODE_EXTRA_CA_CERTS",
         "SSL_CERT_FILE",
         "SSL_CERT_DIR",
-        "VIBEST_CLAUDE_EXECUTABLE"
+        "VIBEST_CLAUDE_EXECUTABLE",
+        "VIBEST_HOME",
+        "VIBEST_DAEMON_DIR"
       ]
     },
     "build:unpack": {

--- a/docs/2026-07-19-server-daemon-topology-design.md
+++ b/docs/2026-07-19-server-daemon-topology-design.md
@@ -96,12 +96,20 @@ as just another `RunningServerProcess` to the same supervisor.
 
 ### Discovery and single-instance (local plane)
 
-The daemon binds `127.0.0.1:<port>` and atomically writes `$VIBEST_HOME/daemon.pid`
-(`0600`) — the local mirror of the remote `ssh-launch/<stateKey>/{pid,port,token}`:
+The daemon binds `127.0.0.1:<port>` and atomically writes
+`$VIBEST_HOME/daemon/daemon.pid` (`0600`) — the local mirror of the remote
+`ssh-launch/<stateKey>/{pid,port,token}`:
 
 ```jsonc
 { "pid": 12345, "address": "http://127.0.0.1:41234", "token": "…", "startedAt": … }
 ```
+
+Daemon lifecycle files live together under `$VIBEST_HOME/daemon/`. During the
+mixed-version migration, the launcher also mirrors the discovery record,
+launch lock, and stop tombstone at their former root-level paths so older CLI
+and Desktop processes still converge on the same daemon. The nested files are
+the long-term layout; the root mirrors can be removed after old launchers are
+no longer supported.
 
 It holds a single-instance lock keyed on `$VIBEST_HOME`. Every local front-door
 runs the same `resolveOrSpawnServer()`:
@@ -242,8 +250,9 @@ _additional plane_, added when wanted, with no rework of the current work.
    electron-builder asar path — needs a packaged-build check.**
 2. **✅ Landed (CLI) — Add the daemon launcher (a layer above the server, not inside
    it).** A shared `resolveOrSpawnDaemon` (`@vibest/server/daemon`) that reads/writes
-   `$VIBEST_HOME/daemon.pid`, does the pid-alive + health-check reuse, spawns the
-   foreground server detached (streamed to `daemon.log`), and applies two-signal
+   `$VIBEST_HOME/daemon/daemon.pid`, does the pid-alive + health-check reuse,
+   spawns the foreground server detached (streamed to
+   `$VIBEST_HOME/daemon/daemon.log`), and applies two-signal
    readiness (pid alive + `/api/health`) and the `:4000 → :0` fallback. The local twin
    of the SSH launch script; the server itself is untouched. The daemon process is
    `vibest serve` re-launched from this same CLI argv — no second bundle. Bare `vibest`

--- a/docs/2026-07-19-server-daemon-topology-design.md
+++ b/docs/2026-07-19-server-daemon-topology-design.md
@@ -47,9 +47,10 @@ So the topology principle is not new — it is **already implemented remotely** 
 merely missing locally:
 
 > **Every vibest server — local or remote — is a single-instance daemon per
-> `$VIBEST_HOME`, discovered through a file, and attached-to rather than
-> re-spawned.** "Reach" is a separate concern layered on top: loopback for local,
-> `ssh -L` for remote.
+> daemon directory, discovered through a file, and attached-to rather than
+> re-spawned.** Locally that directory is `$VIBEST_DAEMON_DIR`, defaulting to
+> `$VIBEST_HOME/daemon`. "Reach" is a separate concern layered on top: loopback
+> for local, `ssh -L` for remote.
 
 The local plane is the one that's behind. This design brings desktop and CLI up to
 the discipline the remote path already has, and unifies the launch seam so
@@ -62,7 +63,7 @@ remote server" are the same shape.
                          one oRPC/WS handler + harness runtime per server
                          ┌───────────────────────────────────────────┐
                          │            @vibest/server (daemon)          │
-   local reach           │  single-instance lock on $VIBEST_HOME       │   remote reach
+   local reach           │  lock on $VIBEST_DAEMON_DIR                 │   remote reach
  127.0.0.1:<port> ─────▶ │  writes discovery file (pid/addr/token)     │ ◀───── ssh -L
    discovery: daemon.pid│  auth token + CORS + WS ticket (existing)   │        (existing
                          └───────────────────────────────────────────┘         SSH design)
@@ -97,21 +98,26 @@ as just another `RunningServerProcess` to the same supervisor.
 ### Discovery and single-instance (local plane)
 
 The daemon binds `127.0.0.1:<port>` and atomically writes
-`$VIBEST_HOME/daemon/daemon.pid` (`0600`) — the local mirror of the remote
+`$VIBEST_DAEMON_DIR/daemon.pid` (`0600`) — by default
+`$VIBEST_HOME/daemon/daemon.pid` — the local mirror of the remote
 `ssh-launch/<stateKey>/{pid,port,token}`:
 
 ```jsonc
 { "pid": 12345, "address": "http://127.0.0.1:41234", "token": "…", "startedAt": … }
 ```
 
-Daemon lifecycle files live together under `$VIBEST_HOME/daemon/`. During the
-mixed-version migration, the launcher also mirrors the discovery record,
-launch lock, and stop tombstone at their former root-level paths so older CLI
-and Desktop processes still converge on the same daemon. The nested files are
-the long-term layout; the root mirrors can be removed after old launchers are
-no longer supported.
+Daemon lifecycle files live together under `$VIBEST_DAEMON_DIR`. When the
+variable is absent, the default `$VIBEST_HOME/daemon/` layout also mirrors the
+discovery record, launch lock, and stop tombstone at their former root-level
+paths during the mixed-version migration. An explicit `VIBEST_DAEMON_DIR` is an
+isolated namespace and never writes those `$VIBEST_HOME` mirrors.
 
-It holds a single-instance lock keyed on `$VIBEST_HOME`. Every local front-door
+The override is primarily a development escape hatch. Pointing multiple daemon
+directories at the same `$VIBEST_HOME` preserves Projects and Sessions, but the
+current JSON repositories do not provide cross-process transactions; concurrent
+mutations remain the caller's responsibility.
+
+It holds a single-instance lock keyed on `$VIBEST_DAEMON_DIR`. Every local front-door
 runs the same `resolveOrSpawnServer()`:
 
 1. Read `daemon.pid` → health-check `address`.
@@ -147,8 +153,9 @@ instead of over SSH.
   and containers (systemd, Docker), for the SSH remote runner
   (`nohup vibest serve`), and for debugging. Interactive local use just never runs it
   directly — the launcher does.
-- **Desktop must attach the same daemon**, not spawn a die-with-app child, or the
-  `$VIBEST_HOME` split-brain returns the moment the CLI is used alongside it.
+- **Desktop must attach the same daemon directory as the CLI** for the normal
+  topology, rather than spawning a die-with-app child. An explicit
+  `VIBEST_DAEMON_DIR` deliberately selects a separate daemon namespace.
   Consequence: **the local server survives quitting the desktop app** (agents keep
   running) — consistent with the remote/CLI semantics, but a behavior change from
   today's managed child.
@@ -250,9 +257,10 @@ _additional plane_, added when wanted, with no rework of the current work.
    electron-builder asar path — needs a packaged-build check.**
 2. **✅ Landed (CLI) — Add the daemon launcher (a layer above the server, not inside
    it).** A shared `resolveOrSpawnDaemon` (`@vibest/server/daemon`) that reads/writes
-   `$VIBEST_HOME/daemon/daemon.pid`, does the pid-alive + health-check reuse,
+   `$VIBEST_DAEMON_DIR/daemon.pid` (default
+   `$VIBEST_HOME/daemon/daemon.pid`), does the pid-alive + health-check reuse,
    spawns the foreground server detached (streamed to
-   `$VIBEST_HOME/daemon/daemon.log`), and applies two-signal
+   `$VIBEST_DAEMON_DIR/daemon.log`), and applies two-signal
    readiness (pid alive + `/api/health`) and the `:4000 → :0` fallback. The local twin
    of the SSH launch script; the server itself is untouched. The daemon process is
    `vibest serve` re-launched from this same CLI argv — no second bundle. Bare `vibest`

--- a/docs/2026-07-19-server-daemon-topology-design.md
+++ b/docs/2026-07-19-server-daemon-topology-design.md
@@ -107,18 +107,16 @@ The daemon binds `127.0.0.1:<port>` and atomically writes
 ```
 
 Daemon lifecycle files live together under `$VIBEST_DAEMON_DIR`. When the
-variable is absent, the default `$VIBEST_HOME/daemon/` layout also mirrors the
-discovery record, launch lock, and stop tombstone at their former root-level
-paths during the mixed-version migration. An explicit `VIBEST_DAEMON_DIR` is an
-isolated namespace and never writes those `$VIBEST_HOME` mirrors.
+variable is absent, the directory defaults to `$VIBEST_HOME/daemon/`. No daemon
+lifecycle files are written directly under `$VIBEST_HOME`.
 
 The override is primarily a development escape hatch. Pointing multiple daemon
 directories at the same `$VIBEST_HOME` preserves Projects and Sessions, but the
 current JSON repositories do not provide cross-process transactions; concurrent
 mutations remain the caller's responsibility.
 
-It holds a single-instance lock keyed on `$VIBEST_DAEMON_DIR`. Every local front-door
-runs the same `resolveOrSpawnServer()`:
+It holds a single-instance lock keyed on `$VIBEST_DAEMON_DIR`. Every local
+front-door runs the same `resolveOrSpawnServer()`:
 
 1. Read `daemon.pid` → health-check `address`.
 2. Alive → **attach** (use its `address` + `token`).

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -45,6 +45,16 @@ export function resolveVibestHome(env: NodeJS.ProcessEnv = process.env): string 
   );
 }
 
+/**
+ * Daemon discovery, lock, log, and tombstone directory. An explicit
+ * `$VIBEST_DAEMON_DIR` lets multiple daemon processes use separate lifecycle
+ * state while keeping their server data under the same `$VIBEST_HOME`.
+ * Defaults to `$VIBEST_HOME/daemon` (`~/.vibest/daemon` in production).
+ */
+export function resolveDaemonDirectory(env: NodeJS.ProcessEnv = process.env): string {
+  return env.VIBEST_DAEMON_DIR ?? path.join(resolveVibestHome(env), "daemon");
+}
+
 /** Point the runtime at an explicit home directory (used in tests). */
 export const layerPaths = (home: string): Layer.Layer<Paths> => Layer.succeed(Paths, resolve(home));
 

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -26,12 +26,21 @@ const resolve = (home: string) => ({
 });
 
 /**
+ * An unset variable and one set to the empty string mean the same thing here.
+ * Without this, `VIBEST_DAEMON_DIR=""` resolves every lifecycle file to a bare
+ * relative path under whatever cwd the process happens to have — `stop` and
+ * `status` would silently read the wrong daemon instead of failing.
+ */
+const explicitPath = (value: string | undefined): string | undefined =>
+  value === undefined || value.trim() === "" ? undefined : value;
+
+/**
  * `$VIBEST_HOME`, falling back to `~/.vibest-dev` under
  * `NODE_ENV=development` and `~/.vibest` otherwise — the single home every
  * client (server Paths, CLI, desktop, daemon launcher) resolves through, so
- * the one-daemon-per-home invariant can never drift on a second definition.
+ * Project and Session storage can never drift on a second definition.
  * The dev split keeps `pnpm dev` / `electron-vite dev` sessions from sharing
- * storage (and a daemon) with the production install.
+ * storage (and, by default, a daemon) with the production install.
  *
  * A plain function, not an Effect: an env lookup and a string join perform no
  * effectful work (`.agents/rules/stack.md`, "Where the boundary is"). Not
@@ -40,19 +49,41 @@ const resolve = (home: string) => ({
  */
 export function resolveVibestHome(env: NodeJS.ProcessEnv = process.env): string {
   return (
-    env.VIBEST_HOME ??
+    explicitPath(env.VIBEST_HOME) ??
     path.join(os.homedir(), env.NODE_ENV === "development" ? ".vibest-dev" : ".vibest")
   );
 }
 
+/** The two directories a daemon front door needs, resolved together. */
+export type DaemonLocation = {
+  /** `$VIBEST_HOME` — Projects and Sessions. Handed to the daemon process. */
+  readonly home: string;
+  /** `$VIBEST_DAEMON_DIR` — `daemon.pid`, `.lock`, `.log`, `.stopped`. */
+  readonly daemonDir: string;
+};
+
 /**
- * Daemon discovery, lock, log, and tombstone directory. An explicit
- * `$VIBEST_DAEMON_DIR` lets multiple daemon processes use separate lifecycle
- * state while keeping their server data under the same `$VIBEST_HOME`.
- * Defaults to `$VIBEST_HOME/daemon` (`~/.vibest/daemon` in production).
+ * Where a daemon keeps its data and its lifecycle files. Every front door (CLI,
+ * desktop, and any future one) resolves the pair here rather than pairing them
+ * itself: `stop` must find what `start` wrote, and the desktop must find what
+ * the CLI started, which only holds while there is one pairing rule.
+ *
+ * An explicit `$VIBEST_DAEMON_DIR` lets multiple daemon processes use separate
+ * lifecycle state while keeping their server data under the same
+ * `$VIBEST_HOME`; unset, it is `$VIBEST_HOME/daemon` (`~/.vibest/daemon` in
+ * production). This is the one place that default is spelled — the
+ * single-instance invariant is keyed on the daemon directory, so a second
+ * definition would be a second daemon. `daemon/paths.ts` names files inside a
+ * directory it is handed and never re-derives the directory itself.
  */
+export function resolveDaemonLocation(env: NodeJS.ProcessEnv = process.env): DaemonLocation {
+  const home = resolveVibestHome(env);
+  return { home, daemonDir: explicitPath(env.VIBEST_DAEMON_DIR) ?? path.join(home, "daemon") };
+}
+
+/** `resolveDaemonLocation().daemonDir`, for callers that need only the directory. */
 export function resolveDaemonDirectory(env: NodeJS.ProcessEnv = process.env): string {
-  return env.VIBEST_DAEMON_DIR ?? path.join(resolveVibestHome(env), "daemon");
+  return resolveDaemonLocation(env).daemonDir;
 }
 
 /** Point the runtime at an explicit home directory (used in tests). */

--- a/packages/server/src/daemon/index.ts
+++ b/packages/server/src/daemon/index.ts
@@ -1,4 +1,4 @@
-export { resolveVibestHome } from "../config/paths";
+export { resolveDaemonDirectory, resolveVibestHome } from "../config/paths";
 export { DaemonLaunchError, DaemonStoppedError } from "./errors";
 export {
   type DaemonHandle,

--- a/packages/server/src/daemon/index.ts
+++ b/packages/server/src/daemon/index.ts
@@ -1,4 +1,9 @@
-export { resolveDaemonDirectory, resolveVibestHome } from "../config/paths";
+export {
+  type DaemonLocation,
+  resolveDaemonDirectory,
+  resolveDaemonLocation,
+  resolveVibestHome,
+} from "../config/paths";
 export { DaemonLaunchError, DaemonStoppedError } from "./errors";
 export {
   type DaemonHandle,

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -6,7 +6,7 @@ import { Clock, Crypto, Effect, Encoding, FileSystem, type PlatformError } from 
 import { DaemonLaunchError, DaemonStoppedError } from "./errors";
 import { daemonAlive, healthy, pidAlive } from "./liveness";
 import { lockExists, readLockPid, releaseLock, tryAcquireLock } from "./lock";
-import { daemonDirectory, logPath } from "./paths";
+import { daemonDirectory, daemonLogPath } from "./paths";
 import { reservePort } from "./port";
 import { type DaemonRecord, readRecords, removeRecord, writeRecord } from "./record";
 import { clearTombstone, hasTombstone, writeTombstone } from "./tombstone";
@@ -27,8 +27,10 @@ export type DaemonHandle = {
 };
 
 export type ResolveDaemonOptions = {
-  /** `$VIBEST_HOME` — owns storage plus lifecycle state under `daemon/`. */
+  /** `$VIBEST_HOME` — persistent Project and Session data. */
   readonly home: string;
+  /** Explicit `$VIBEST_DAEMON_DIR`; omitted means `$VIBEST_HOME/daemon`. */
+  readonly daemonDir?: string;
   /**
    * argv that launches the plain foreground server, e.g.
    * `[process.execPath, ...process.execArgv, cliEntry, "serve"]`. The daemon is
@@ -66,7 +68,7 @@ export type DaemonPlatform = FileSystem.FileSystem | Crypto.Crypto;
  * `daemon/daemon.pid`; if a healthy daemon is there, attach; otherwise spawn the
  * foreground server detached, wait for it to answer health, and record it. Both
  * the CLI and the desktop go through here so there is exactly one daemon per
- * `$VIBEST_HOME` — concurrent launchers are serialized by an exclusive-create
+ * daemon directory — concurrent launchers are serialized by an exclusive-create
  * launch lock, and the loser attaches to the winner's daemon.
  *
  * Effect-based orchestration around one deliberately-raw seam: the detached
@@ -81,7 +83,7 @@ export const resolveOrSpawnDaemon = (
   options: ResolveDaemonOptions,
 ): Effect.Effect<DaemonHandle, DaemonLauncherError, DaemonPlatform> =>
   Effect.gen(function* () {
-    const records = yield* readRecords(options.home);
+    const records = yield* readRecords(options.home, options.daemonDir);
     const healthyRecords: DaemonRecord[] = [];
     for (const record of records) {
       if (yield* daemonAlive(record)) healthyRecords.push(record);
@@ -90,7 +92,7 @@ export const resolveOrSpawnDaemon = (
     if (healthyRecords.length > 1) {
       return yield* Effect.fail(
         new DaemonLaunchError({
-          message: `Multiple vibest daemons are running for the same home (${healthyRecords.map((record) => record.pid).join(", ")}); stop them before starting another`,
+          message: `Multiple vibest daemons are running for the same daemon directory (${healthyRecords.map((record) => record.pid).join(", ")}); stop them before starting another`,
         }),
       );
     }
@@ -100,18 +102,18 @@ export const resolveOrSpawnDaemon = (
       if (records.length > 1) {
         return yield* Effect.fail(
           new DaemonLaunchError({
-            message: `Conflicting vibest daemon records exist for the same home (${records.map((record) => record.pid).join(", ")}); run \`vibest daemon stop\` before starting another`,
+            message: `Conflicting vibest daemon records exist for the same daemon directory (${records.map((record) => record.pid).join(", ")}); run \`vibest daemon stop\` before starting another`,
           }),
         );
       }
       // A live daemon makes any tombstone stale (someone started it again).
-      yield* clearTombstone(options.home);
+      yield* clearTombstone(options.home, options.daemonDir);
       // Do not migrate a live legacy record in place: an older launcher could
       // race that repair. The next spawn publishes root-first to both paths.
       return attach(existing, true);
     }
 
-    if (options.autoRespawn === true && (yield* hasTombstone(options.home))) {
+    if (options.autoRespawn === true && (yield* hasTombstone(options.home, options.daemonDir))) {
       return yield* Effect.fail(
         new DaemonStoppedError({
           message:
@@ -119,14 +121,14 @@ export const resolveOrSpawnDaemon = (
         }),
       );
     }
-    yield* clearTombstone(options.home);
+    yield* clearTombstone(options.home, options.daemonDir);
 
     if (records.length > 0) {
       // Wedged (pid alive but unhealthy) daemons must die before we replace
       // them, or they leak as orphans still holding their port. Dead pids are
       // no-ops here.
       for (const record of records) yield* killPid(record.pid);
-      yield* removeRecord(options.home);
+      yield* removeRecord(options.home, options.daemonDir);
     }
     return yield* spawnLocked(options);
   });
@@ -134,6 +136,7 @@ export const resolveOrSpawnDaemon = (
 /** Read the current daemon's status without starting one. */
 export const statusDaemon = (
   home: string,
+  daemonDir?: string,
 ): Effect.Effect<
   | { readonly running: false }
   | { readonly running: true; readonly record: DaemonRecord }
@@ -142,7 +145,7 @@ export const statusDaemon = (
   FileSystem.FileSystem
 > =>
   Effect.gen(function* () {
-    const records = yield* readRecords(home);
+    const records = yield* readRecords(home, daemonDir);
     const healthyRecords: DaemonRecord[] = [];
     for (const record of records) {
       if (yield* daemonAlive(record)) healthyRecords.push(record);
@@ -162,18 +165,19 @@ export const statusDaemon = (
  */
 export const stopDaemon = (
   home: string,
+  daemonDir?: string,
 ): Effect.Effect<"stopped" | "not-running", PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const records = yield* readRecords(home);
+    const records = yield* readRecords(home, daemonDir);
     const running = records.filter((record) => pidAlive(record.pid));
     if (running.length === 0) {
-      yield* removeRecord(home);
+      yield* removeRecord(home, daemonDir);
       return "not-running";
     }
 
-    yield* writeTombstone(home);
+    yield* writeTombstone(home, daemonDir);
     for (const record of running) yield* killPid(record.pid);
-    yield* removeRecord(home);
+    yield* removeRecord(home, daemonDir);
     return "stopped";
   });
 
@@ -191,7 +195,7 @@ const killPid = (pid: number): Effect.Effect<void> =>
 
 /**
  * Serialize spawns with the launch lock (see `lock.ts`) so two launchers racing
- * an empty `$VIBEST_HOME` (or a respawn window) cannot both spawn a daemon —
+ * an empty daemon directory (or a respawn window) cannot both spawn a daemon —
  * the loser waits for the winner's record and attaches. A lock whose holder pid
  * died is reclaimed. `ensuring` releases the lock even when the spawn is
  * interrupted.
@@ -202,7 +206,7 @@ const spawnLocked = (
   Effect.gen(function* () {
     const { home } = options;
     const fileSystem = yield* FileSystem.FileSystem;
-    const directory = daemonDirectory(home);
+    const directory = options.daemonDir ?? daemonDirectory(home);
     yield* fileSystem.makeDirectory(directory, { recursive: true }).pipe(
       Effect.mapError(
         (cause) =>
@@ -220,7 +224,7 @@ const spawnLocked = (
       // spawn, and every other branch below already assumes the file state can
       // change under it (a reclaim can lose its race, and the retry loop is
       // what covers that).
-      const acquired = yield* tryAcquireLock(home).pipe(
+      const acquired = yield* tryAcquireLock(home, options.daemonDir).pipe(
         Effect.mapError(
           (cause) =>
             new DaemonLaunchError({
@@ -231,21 +235,23 @@ const spawnLocked = (
       );
 
       if (!acquired) {
-        const holder = yield* readLockPid(home);
+        const holder = yield* readLockPid(home, options.daemonDir);
         if (holder !== undefined && !pidAlive(holder)) {
           // The locking launcher died mid-spawn; reclaim and try again.
-          yield* releaseLock(home);
+          yield* releaseLock(home, options.daemonDir);
           continue;
         }
         // Another launcher is spawning right now: wait for its daemon, then
         // re-enter the full resolve so this caller attaches to the winner's
         // daemon (which by then is recorded and healthy).
-        const winner = yield* waitForRecord(home, timeoutMs);
+        const winner = yield* waitForRecord(home, options.daemonDir, timeoutMs);
         if (winner) return yield* resolveOrSpawnDaemon(options);
         continue;
       }
 
-      return yield* spawnDaemon(options).pipe(Effect.ensuring(releaseLock(home)));
+      return yield* spawnDaemon(options).pipe(
+        Effect.ensuring(releaseLock(home, options.daemonDir)),
+      );
     }
     return yield* Effect.fail(
       new DaemonLaunchError({ message: "Could not acquire the vibest daemon launch lock" }),
@@ -255,16 +261,17 @@ const spawnLocked = (
 /** Poll for a healthy record to appear (a concurrent launcher is spawning). */
 const waitForRecord = (
   home: string,
+  daemonDir: string | undefined,
   timeoutMs: number,
 ): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
     while ((yield* Clock.currentTimeMillis) < deadline) {
-      const records = yield* readRecords(home);
+      const records = yield* readRecords(home, daemonDir);
       for (const record of records) {
         if (yield* daemonAlive(record)) return record;
       }
-      if (!(yield* lockExists(home))) return undefined;
+      if (!(yield* lockExists(home, daemonDir))) return undefined;
       yield* Effect.sleep(HEALTH_POLL_INTERVAL_MS);
     }
     return undefined;
@@ -299,7 +306,7 @@ const spawnDaemon = (
       signal(pid, "SIGTERM");
       return yield* Effect.fail(
         new DaemonLaunchError({
-          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${logPath(home)}`,
+          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${daemonLogPath(options.daemonDir ?? daemonDirectory(home))}`,
         }),
       );
     }
@@ -310,7 +317,7 @@ const spawnDaemon = (
       token,
       startedAt: yield* Clock.currentTimeMillis,
     };
-    yield* writeRecord(home, record).pipe(
+    yield* writeRecord(home, record, options.daemonDir).pipe(
       Effect.mapError(
         (cause) =>
           new DaemonLaunchError({
@@ -318,7 +325,7 @@ const spawnDaemon = (
             cause,
           }),
       ),
-      Effect.tapError(() => Effect.andThen(killPid(pid), removeRecord(home))),
+      Effect.tapError(() => Effect.andThen(killPid(pid), removeRecord(home, options.daemonDir))),
     );
     return attach(record, false);
   });
@@ -332,7 +339,8 @@ const spawnDaemon = (
  */
 function spawnDetached(options: ResolveDaemonOptions, port: number, token: string): number {
   const { home } = options;
-  const logFd = fs.openSync(logPath(home), "a", 0o600);
+  const daemonDir = options.daemonDir ?? daemonDirectory(home);
+  const logFd = fs.openSync(daemonLogPath(daemonDir), "a", 0o600);
   try {
     const [command, ...args] = options.serverArgv;
     if (command === undefined) throw new Error("serverArgv must not be empty");
@@ -346,6 +354,7 @@ function spawnDetached(options: ResolveDaemonOptions, port: number, token: strin
         // set, since the daemon's policy is otherwise static.
         ...(options.environment ?? process.env),
         VIBEST_HOME: home,
+        VIBEST_DAEMON_DIR: daemonDir,
         VIBEST_PORT: String(port),
         VIBEST_AUTH_TOKEN: token,
       },

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -8,7 +8,7 @@ import { daemonAlive, healthy, pidAlive } from "./liveness";
 import { lockExists, readLockPid, releaseLock, tryAcquireLock } from "./lock";
 import { daemonDirectory, daemonLogPath } from "./paths";
 import { reservePort } from "./port";
-import { type DaemonRecord, readRecords, removeRecord, writeRecord } from "./record";
+import { type DaemonRecord, readRecord, removeRecord, writeRecord } from "./record";
 import { clearTombstone, hasTombstone, writeTombstone } from "./tombstone";
 
 const DEFAULT_PORT = 4000;
@@ -83,33 +83,10 @@ export const resolveOrSpawnDaemon = (
   options: ResolveDaemonOptions,
 ): Effect.Effect<DaemonHandle, DaemonLauncherError, DaemonPlatform> =>
   Effect.gen(function* () {
-    const records = yield* readRecords(options.home, options.daemonDir);
-    const healthyRecords: DaemonRecord[] = [];
-    for (const record of records) {
-      if (yield* daemonAlive(record)) healthyRecords.push(record);
-    }
-
-    if (healthyRecords.length > 1) {
-      return yield* Effect.fail(
-        new DaemonLaunchError({
-          message: `Multiple vibest daemons are running for the same daemon directory (${healthyRecords.map((record) => record.pid).join(", ")}); stop them before starting another`,
-        }),
-      );
-    }
-
-    const existing = healthyRecords[0];
-    if (existing !== undefined) {
-      if (records.length > 1) {
-        return yield* Effect.fail(
-          new DaemonLaunchError({
-            message: `Conflicting vibest daemon records exist for the same daemon directory (${records.map((record) => record.pid).join(", ")}); run \`vibest daemon stop\` before starting another`,
-          }),
-        );
-      }
+    const existing = yield* readRecord(options.home, options.daemonDir);
+    if (existing !== undefined && (yield* daemonAlive(existing))) {
       // A live daemon makes any tombstone stale (someone started it again).
       yield* clearTombstone(options.home, options.daemonDir);
-      // Do not migrate a live legacy record in place: an older launcher could
-      // race that repair. The next spawn publishes root-first to both paths.
       return attach(existing, true);
     }
 
@@ -123,11 +100,11 @@ export const resolveOrSpawnDaemon = (
     }
     yield* clearTombstone(options.home, options.daemonDir);
 
-    if (records.length > 0) {
+    if (existing !== undefined) {
       // Wedged (pid alive but unhealthy) daemons must die before we replace
-      // them, or they leak as orphans still holding their port. Dead pids are
-      // no-ops here.
-      for (const record of records) yield* killPid(record.pid);
+      // them, or they leak as orphans still holding their port. A dead pid is
+      // a no-op here.
+      yield* killPid(existing.pid);
       yield* removeRecord(options.home, options.daemonDir);
     }
     return yield* spawnLocked(options);
@@ -138,23 +115,15 @@ export const statusDaemon = (
   home: string,
   daemonDir?: string,
 ): Effect.Effect<
-  | { readonly running: false }
-  | { readonly running: true; readonly record: DaemonRecord }
-  | { readonly running: false; readonly conflict: ReadonlyArray<DaemonRecord> },
+  { readonly running: false } | { readonly running: true; readonly record: DaemonRecord },
   never,
   FileSystem.FileSystem
 > =>
   Effect.gen(function* () {
-    const records = yield* readRecords(home, daemonDir);
-    const healthyRecords: DaemonRecord[] = [];
-    for (const record of records) {
-      if (yield* daemonAlive(record)) healthyRecords.push(record);
-    }
-    if (healthyRecords.length > 1 || (healthyRecords.length === 1 && records.length > 1)) {
-      return { running: false, conflict: records };
-    }
-    const record = healthyRecords[0];
-    return record === undefined ? { running: false } : { running: true, record };
+    const record = yield* readRecord(home, daemonDir);
+    return record === undefined || !(yield* daemonAlive(record))
+      ? { running: false }
+      : { running: true, record };
   });
 
 /**
@@ -168,15 +137,14 @@ export const stopDaemon = (
   daemonDir?: string,
 ): Effect.Effect<"stopped" | "not-running", PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const records = yield* readRecords(home, daemonDir);
-    const running = records.filter((record) => pidAlive(record.pid));
-    if (running.length === 0) {
+    const record = yield* readRecord(home, daemonDir);
+    if (record === undefined || !pidAlive(record.pid)) {
       yield* removeRecord(home, daemonDir);
       return "not-running";
     }
 
     yield* writeTombstone(home, daemonDir);
-    for (const record of running) yield* killPid(record.pid);
+    yield* killPid(record.pid);
     yield* removeRecord(home, daemonDir);
     return "stopped";
   });
@@ -267,10 +235,8 @@ const waitForRecord = (
   Effect.gen(function* () {
     const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
     while ((yield* Clock.currentTimeMillis) < deadline) {
-      const records = yield* readRecords(home, daemonDir);
-      for (const record of records) {
-        if (yield* daemonAlive(record)) return record;
-      }
+      const record = yield* readRecord(home, daemonDir);
+      if (record !== undefined && (yield* daemonAlive(record))) return record;
       if (!(yield* lockExists(home, daemonDir))) return undefined;
       yield* Effect.sleep(HEALTH_POLL_INTERVAL_MS);
     }

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -6,7 +6,7 @@ import { Clock, Crypto, Effect, Encoding, FileSystem, type PlatformError } from 
 import { DaemonLaunchError, DaemonStoppedError } from "./errors";
 import { daemonAlive, healthy, pidAlive } from "./liveness";
 import { lockExists, readLockPid, releaseLock, tryAcquireLock } from "./lock";
-import { daemonDirectory, daemonLogPath } from "./paths";
+import { daemonLogPath } from "./paths";
 import { reservePort } from "./port";
 import { type DaemonRecord, readRecord, removeRecord, writeRecord } from "./record";
 import { clearTombstone, hasTombstone, writeTombstone } from "./tombstone";
@@ -27,10 +27,18 @@ export type DaemonHandle = {
 };
 
 export type ResolveDaemonOptions = {
-  /** `$VIBEST_HOME` — persistent Project and Session data. */
+  /**
+   * `$VIBEST_HOME` — persistent Project and Session data. Only passed on to the
+   * spawned daemon; no lifecycle file is derived from it.
+   */
   readonly home: string;
-  /** Explicit `$VIBEST_DAEMON_DIR`; omitted means `$VIBEST_HOME/daemon`. */
-  readonly daemonDir?: string;
+  /**
+   * `$VIBEST_DAEMON_DIR` — where the four lifecycle files live and what the
+   * single-instance invariant is keyed on. Required; front doors get it from
+   * `resolveDaemonLocation` (`config/paths.ts`), which explains why there is no
+   * default here.
+   */
+  readonly daemonDir: string;
   /**
    * argv that launches the plain foreground server, e.g.
    * `[process.execPath, ...process.execArgv, cliEntry, "serve"]`. The daemon is
@@ -83,14 +91,14 @@ export const resolveOrSpawnDaemon = (
   options: ResolveDaemonOptions,
 ): Effect.Effect<DaemonHandle, DaemonLauncherError, DaemonPlatform> =>
   Effect.gen(function* () {
-    const existing = yield* readRecord(options.home, options.daemonDir);
+    const existing = yield* readRecord(options.daemonDir);
     if (existing !== undefined && (yield* daemonAlive(existing))) {
       // A live daemon makes any tombstone stale (someone started it again).
-      yield* clearTombstone(options.home, options.daemonDir);
+      yield* clearTombstone(options.daemonDir);
       return attach(existing, true);
     }
 
-    if (options.autoRespawn === true && (yield* hasTombstone(options.home, options.daemonDir))) {
+    if (options.autoRespawn === true && (yield* hasTombstone(options.daemonDir))) {
       return yield* Effect.fail(
         new DaemonStoppedError({
           message:
@@ -98,29 +106,28 @@ export const resolveOrSpawnDaemon = (
         }),
       );
     }
-    yield* clearTombstone(options.home, options.daemonDir);
+    yield* clearTombstone(options.daemonDir);
 
     if (existing !== undefined) {
       // Wedged (pid alive but unhealthy) daemons must die before we replace
       // them, or they leak as orphans still holding their port. A dead pid is
       // a no-op here.
       yield* killPid(existing.pid);
-      yield* removeRecord(options.home, options.daemonDir);
+      yield* removeRecord(options.daemonDir);
     }
     return yield* spawnLocked(options);
   });
 
 /** Read the current daemon's status without starting one. */
 export const statusDaemon = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<
   { readonly running: false } | { readonly running: true; readonly record: DaemonRecord },
   never,
   FileSystem.FileSystem
 > =>
   Effect.gen(function* () {
-    const record = yield* readRecord(home, daemonDir);
+    const record = yield* readRecord(daemonDir);
     return record === undefined || !(yield* daemonAlive(record))
       ? { running: false }
       : { running: true, record };
@@ -133,19 +140,18 @@ export const statusDaemon = (
  * sees it. Returns whether anything was running.
  */
 export const stopDaemon = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<"stopped" | "not-running", PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const record = yield* readRecord(home, daemonDir);
+    const record = yield* readRecord(daemonDir);
     if (record === undefined || !pidAlive(record.pid)) {
-      yield* removeRecord(home, daemonDir);
+      yield* removeRecord(daemonDir);
       return "not-running";
     }
 
-    yield* writeTombstone(home, daemonDir);
+    yield* writeTombstone(daemonDir);
     yield* killPid(record.pid);
-    yield* removeRecord(home, daemonDir);
+    yield* removeRecord(daemonDir);
     return "stopped";
   });
 
@@ -172,14 +178,13 @@ const spawnLocked = (
   options: ResolveDaemonOptions,
 ): Effect.Effect<DaemonHandle, DaemonLauncherError, DaemonPlatform> =>
   Effect.gen(function* () {
-    const { home } = options;
+    const { daemonDir } = options;
     const fileSystem = yield* FileSystem.FileSystem;
-    const directory = options.daemonDir ?? daemonDirectory(home);
-    yield* fileSystem.makeDirectory(directory, { recursive: true }).pipe(
+    yield* fileSystem.makeDirectory(daemonDir, { recursive: true }).pipe(
       Effect.mapError(
         (cause) =>
           new DaemonLaunchError({
-            message: `Unable to create ${directory}: ${cause.message}`,
+            message: `Unable to create ${daemonDir}: ${cause.message}`,
             cause,
           }),
       ),
@@ -192,7 +197,7 @@ const spawnLocked = (
       // spawn, and every other branch below already assumes the file state can
       // change under it (a reclaim can lose its race, and the retry loop is
       // what covers that).
-      const acquired = yield* tryAcquireLock(home, options.daemonDir).pipe(
+      const acquired = yield* tryAcquireLock(daemonDir).pipe(
         Effect.mapError(
           (cause) =>
             new DaemonLaunchError({
@@ -203,23 +208,21 @@ const spawnLocked = (
       );
 
       if (!acquired) {
-        const holder = yield* readLockPid(home, options.daemonDir);
+        const holder = yield* readLockPid(daemonDir);
         if (holder !== undefined && !pidAlive(holder)) {
           // The locking launcher died mid-spawn; reclaim and try again.
-          yield* releaseLock(home, options.daemonDir);
+          yield* releaseLock(daemonDir);
           continue;
         }
         // Another launcher is spawning right now: wait for its daemon, then
         // re-enter the full resolve so this caller attaches to the winner's
         // daemon (which by then is recorded and healthy).
-        const winner = yield* waitForRecord(home, options.daemonDir, timeoutMs);
+        const winner = yield* waitForRecord(daemonDir, timeoutMs);
         if (winner) return yield* resolveOrSpawnDaemon(options);
         continue;
       }
 
-      return yield* spawnDaemon(options).pipe(
-        Effect.ensuring(releaseLock(home, options.daemonDir)),
-      );
+      return yield* spawnDaemon(options).pipe(Effect.ensuring(releaseLock(daemonDir)));
     }
     return yield* Effect.fail(
       new DaemonLaunchError({ message: "Could not acquire the vibest daemon launch lock" }),
@@ -228,16 +231,15 @@ const spawnLocked = (
 
 /** Poll for a healthy record to appear (a concurrent launcher is spawning). */
 const waitForRecord = (
-  home: string,
-  daemonDir: string | undefined,
+  daemonDir: string,
   timeoutMs: number,
 ): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
     while ((yield* Clock.currentTimeMillis) < deadline) {
-      const record = yield* readRecord(home, daemonDir);
+      const record = yield* readRecord(daemonDir);
       if (record !== undefined && (yield* daemonAlive(record))) return record;
-      if (!(yield* lockExists(home, daemonDir))) return undefined;
+      if (!(yield* lockExists(daemonDir))) return undefined;
       yield* Effect.sleep(HEALTH_POLL_INTERVAL_MS);
     }
     return undefined;
@@ -247,7 +249,6 @@ const spawnDaemon = (
   options: ResolveDaemonOptions,
 ): Effect.Effect<DaemonHandle, DaemonLaunchError, DaemonPlatform> =>
   Effect.gen(function* () {
-    const { home } = options;
     const crypto = yield* Crypto.Crypto;
     const port = yield* reservePort(options.port ?? DEFAULT_PORT);
     const token = yield* crypto.randomBytes(32).pipe(
@@ -272,7 +273,7 @@ const spawnDaemon = (
       signal(pid, "SIGTERM");
       return yield* Effect.fail(
         new DaemonLaunchError({
-          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${daemonLogPath(options.daemonDir ?? daemonDirectory(home))}`,
+          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${daemonLogPath(options.daemonDir)}`,
         }),
       );
     }
@@ -283,7 +284,7 @@ const spawnDaemon = (
       token,
       startedAt: yield* Clock.currentTimeMillis,
     };
-    yield* writeRecord(home, record, options.daemonDir).pipe(
+    yield* writeRecord(options.daemonDir, record).pipe(
       Effect.mapError(
         (cause) =>
           new DaemonLaunchError({
@@ -291,7 +292,7 @@ const spawnDaemon = (
             cause,
           }),
       ),
-      Effect.tapError(() => Effect.andThen(killPid(pid), removeRecord(home, options.daemonDir))),
+      Effect.tapError(() => Effect.andThen(killPid(pid), removeRecord(options.daemonDir))),
     );
     return attach(record, false);
   });
@@ -304,8 +305,7 @@ const spawnDaemon = (
  * — the local `nohup vibest serve > log`.
  */
 function spawnDetached(options: ResolveDaemonOptions, port: number, token: string): number {
-  const { home } = options;
-  const daemonDir = options.daemonDir ?? daemonDirectory(home);
+  const { home, daemonDir } = options;
   const logFd = fs.openSync(daemonLogPath(daemonDir), "a", 0o600);
   try {
     const [command, ...args] = options.serverArgv;

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -1,14 +1,14 @@
 import childProcess from "node:child_process";
 import fs from "node:fs";
-import path from "node:path";
 
 import { Clock, Crypto, Effect, Encoding, FileSystem, type PlatformError } from "effect";
 
 import { DaemonLaunchError, DaemonStoppedError } from "./errors";
 import { daemonAlive, healthy, pidAlive } from "./liveness";
 import { lockExists, readLockPid, releaseLock, tryAcquireLock } from "./lock";
+import { daemonDirectory, logPath } from "./paths";
 import { reservePort } from "./port";
-import { type DaemonRecord, readRecord, removeRecord, writeRecord } from "./record";
+import { type DaemonRecord, readRecords, removeRecord, writeRecord } from "./record";
 import { clearTombstone, hasTombstone, writeTombstone } from "./tombstone";
 
 const DEFAULT_PORT = 4000;
@@ -27,7 +27,7 @@ export type DaemonHandle = {
 };
 
 export type ResolveDaemonOptions = {
-  /** `$VIBEST_HOME` — owns `daemon.pid`, `daemon.log`, and the launch lock. */
+  /** `$VIBEST_HOME` — owns storage plus lifecycle state under `daemon/`. */
   readonly home: string;
   /**
    * argv that launches the plain foreground server, e.g.
@@ -63,7 +63,7 @@ export type DaemonPlatform = FileSystem.FileSystem | Crypto.Crypto;
 
 /**
  * The shared launcher (the local twin of the SSH launch script): read
- * `daemon.pid`; if a healthy daemon is there, attach; otherwise spawn the
+ * `daemon/daemon.pid`; if a healthy daemon is there, attach; otherwise spawn the
  * foreground server detached, wait for it to answer health, and record it. Both
  * the CLI and the desktop go through here so there is exactly one daemon per
  * `$VIBEST_HOME` — concurrent launchers are serialized by an exclusive-create
@@ -81,11 +81,33 @@ export const resolveOrSpawnDaemon = (
   options: ResolveDaemonOptions,
 ): Effect.Effect<DaemonHandle, DaemonLauncherError, DaemonPlatform> =>
   Effect.gen(function* () {
-    const existing = yield* readRecord(options.home);
+    const records = yield* readRecords(options.home);
+    const healthyRecords: DaemonRecord[] = [];
+    for (const record of records) {
+      if (yield* daemonAlive(record)) healthyRecords.push(record);
+    }
 
-    if (existing && (yield* daemonAlive(existing))) {
+    if (healthyRecords.length > 1) {
+      return yield* Effect.fail(
+        new DaemonLaunchError({
+          message: `Multiple vibest daemons are running for the same home (${healthyRecords.map((record) => record.pid).join(", ")}); stop them before starting another`,
+        }),
+      );
+    }
+
+    const existing = healthyRecords[0];
+    if (existing !== undefined) {
+      if (records.length > 1) {
+        return yield* Effect.fail(
+          new DaemonLaunchError({
+            message: `Conflicting vibest daemon records exist for the same home (${records.map((record) => record.pid).join(", ")}); run \`vibest daemon stop\` before starting another`,
+          }),
+        );
+      }
       // A live daemon makes any tombstone stale (someone started it again).
       yield* clearTombstone(options.home);
+      // Do not migrate a live legacy record in place: an older launcher could
+      // race that repair. The next spawn publishes root-first to both paths.
       return attach(existing, true);
     }
 
@@ -99,11 +121,11 @@ export const resolveOrSpawnDaemon = (
     }
     yield* clearTombstone(options.home);
 
-    if (existing) {
+    if (records.length > 0) {
       // Wedged (pid alive but unhealthy) daemons must die before we replace
-      // them, or they leak as orphans still holding their port. A dead pid is
-      // a no-op here.
-      yield* killPid(existing.pid);
+      // them, or they leak as orphans still holding their port. Dead pids are
+      // no-ops here.
+      for (const record of records) yield* killPid(record.pid);
       yield* removeRecord(options.home);
     }
     return yield* spawnLocked(options);
@@ -113,14 +135,23 @@ export const resolveOrSpawnDaemon = (
 export const statusDaemon = (
   home: string,
 ): Effect.Effect<
-  { readonly running: boolean; readonly record?: DaemonRecord },
+  | { readonly running: false }
+  | { readonly running: true; readonly record: DaemonRecord }
+  | { readonly running: false; readonly conflict: ReadonlyArray<DaemonRecord> },
   never,
   FileSystem.FileSystem
 > =>
   Effect.gen(function* () {
-    const record = yield* readRecord(home);
-    if (record && (yield* daemonAlive(record))) return { running: true, record };
-    return { running: false };
+    const records = yield* readRecords(home);
+    const healthyRecords: DaemonRecord[] = [];
+    for (const record of records) {
+      if (yield* daemonAlive(record)) healthyRecords.push(record);
+    }
+    if (healthyRecords.length > 1 || (healthyRecords.length === 1 && records.length > 1)) {
+      return { running: false, conflict: records };
+    }
+    const record = healthyRecords[0];
+    return record === undefined ? { running: false } : { running: true, record };
   });
 
 /**
@@ -133,14 +164,15 @@ export const stopDaemon = (
   home: string,
 ): Effect.Effect<"stopped" | "not-running", PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const record = yield* readRecord(home);
-    if (!record || !pidAlive(record.pid)) {
+    const records = yield* readRecords(home);
+    const running = records.filter((record) => pidAlive(record.pid));
+    if (running.length === 0) {
       yield* removeRecord(home);
       return "not-running";
     }
 
     yield* writeTombstone(home);
-    yield* killPid(record.pid);
+    for (const record of running) yield* killPid(record.pid);
     yield* removeRecord(home);
     return "stopped";
   });
@@ -170,14 +202,16 @@ const spawnLocked = (
   Effect.gen(function* () {
     const { home } = options;
     const fileSystem = yield* FileSystem.FileSystem;
-    yield* fileSystem
-      .makeDirectory(home, { recursive: true })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new DaemonLaunchError({ message: `Unable to create ${home}: ${cause.message}`, cause }),
-        ),
-      );
+    const directory = daemonDirectory(home);
+    yield* fileSystem.makeDirectory(directory, { recursive: true }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DaemonLaunchError({
+            message: `Unable to create ${directory}: ${cause.message}`,
+            cause,
+          }),
+      ),
+    );
     const timeoutMs = options.readyTimeoutMs ?? READY_TIMEOUT_MS;
 
     for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt += 1) {
@@ -226,8 +260,10 @@ const waitForRecord = (
   Effect.gen(function* () {
     const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
     while ((yield* Clock.currentTimeMillis) < deadline) {
-      const record = yield* readRecord(home);
-      if (record && (yield* daemonAlive(record))) return record;
+      const records = yield* readRecords(home);
+      for (const record of records) {
+        if (yield* daemonAlive(record)) return record;
+      }
       if (!(yield* lockExists(home))) return undefined;
       yield* Effect.sleep(HEALTH_POLL_INTERVAL_MS);
     }
@@ -263,7 +299,7 @@ const spawnDaemon = (
       signal(pid, "SIGTERM");
       return yield* Effect.fail(
         new DaemonLaunchError({
-          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${path.join(home, "daemon.log")}`,
+          message: `vibest daemon did not become healthy within ${timeoutMs}ms; see ${logPath(home)}`,
         }),
       );
     }
@@ -282,6 +318,7 @@ const spawnDaemon = (
             cause,
           }),
       ),
+      Effect.tapError(() => Effect.andThen(killPid(pid), removeRecord(home))),
     );
     return attach(record, false);
   });
@@ -295,7 +332,7 @@ const spawnDaemon = (
  */
 function spawnDetached(options: ResolveDaemonOptions, port: number, token: string): number {
   const { home } = options;
-  const logFd = fs.openSync(path.join(home, "daemon.log"), "a", 0o600);
+  const logFd = fs.openSync(logPath(home), "a", 0o600);
   try {
     const [command, ...args] = options.serverArgv;
     if (command === undefined) throw new Error("serverArgv must not be empty");

--- a/packages/server/src/daemon/lock.ts
+++ b/packages/server/src/daemon/lock.ts
@@ -1,6 +1,6 @@
 import { Effect, FileSystem, type PlatformError } from "effect";
 
-import { legacyLockPath, lockPath } from "./paths";
+import { daemonDirectory, daemonLockPath, legacyLockPath } from "./paths";
 
 /**
  * The launch lock — an exclusive-create `$VIBEST_HOME/daemon/daemon.lock` holding the
@@ -21,16 +21,14 @@ import { legacyLockPath, lockPath } from "./paths";
  */
 export const tryAcquireLock = (
   home: string,
+  daemonHome?: string,
 ): Effect.Effect<boolean, PlatformError.PlatformError, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
     Effect.gen(function* () {
-      // The root-level lock remains canonical during the compatibility window:
-      // old launchers see it, so mixed old/new clients cannot spawn twice.
+      const configuredLock = daemonLockPath(daemonHome ?? daemonDirectory(home));
+      const canonicalLock = daemonHome === undefined ? legacyLockPath(home) : configuredLock;
       const acquired = yield* fs
-        .writeFileString(legacyLockPath(home), String(process.pid), {
-          flag: "wx",
-          mode: 0o600,
-        })
+        .writeFileString(canonicalLock, String(process.pid), { flag: "wx", mode: 0o600 })
         .pipe(
           Effect.as(true),
           Effect.catchIf(
@@ -39,12 +37,13 @@ export const tryAcquireLock = (
           ),
         );
       if (!acquired) return false;
+      if (daemonHome !== undefined) return true;
 
-      // Nested copy is diagnostic state only; the root lock owns exclusivity.
-      // If it cannot be written, give the canonical lock back before failing.
+      // Default layout: mirror the canonical root lock for diagnostics. If the
+      // mirror fails, give the compatibility lock back before failing.
       yield* fs
-        .writeFileString(lockPath(home), String(process.pid), { mode: 0o600 })
-        .pipe(Effect.tapError(() => fs.remove(legacyLockPath(home), { force: true })));
+        .writeFileString(configuredLock, String(process.pid), { mode: 0o600 })
+        .pipe(Effect.tapError(() => fs.remove(canonicalLock, { force: true })));
       return true;
     }),
   );
@@ -52,10 +51,14 @@ export const tryAcquireLock = (
 /** The pid recorded in the lock, or `undefined` if missing/garbage. */
 export const readLockPid = (
   home: string,
+  daemonHome?: string,
 ): Effect.Effect<number | undefined, never, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
     Effect.gen(function* () {
-      for (const file of [legacyLockPath(home), lockPath(home)]) {
+      const configuredLock = daemonLockPath(daemonHome ?? daemonDirectory(home));
+      const files =
+        daemonHome === undefined ? [legacyLockPath(home), configuredLock] : [configuredLock];
+      for (const file of files) {
         const raw = yield* fs.readFileString(file).pipe(Effect.orElseSucceed(() => ""));
         const pid = Number.parseInt(raw, 10);
         if (Number.isInteger(pid) && pid > 0) return pid;
@@ -65,19 +68,29 @@ export const readLockPid = (
   );
 
 /** Whether the lock still exists (a concurrent launcher is still spawning). */
-export const lockExists = (home: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+export const lockExists = (
+  home: string,
+  daemonHome?: string,
+): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
     Effect.gen(function* () {
-      if (yield* fs.exists(legacyLockPath(home))) return true;
-      return yield* fs.exists(lockPath(home));
+      const configuredLock = daemonLockPath(daemonHome ?? daemonDirectory(home));
+      if (daemonHome === undefined && (yield* fs.exists(legacyLockPath(home)))) return true;
+      return yield* fs.exists(configuredLock);
     }),
   ).pipe(Effect.orElseSucceed(() => false));
 
-/** Release current and legacy locks; missing files are not errors. */
-export const releaseLock = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) =>
-    Effect.all(
-      [lockPath(home), legacyLockPath(home)].map((file) => fs.remove(file, { force: true })),
+/** Release configured and compatibility locks; missing files are not errors. */
+export const releaseLock = (
+  home: string,
+  daemonHome?: string,
+): Effect.Effect<void, never, FileSystem.FileSystem> =>
+  FileSystem.FileSystem.use((fs) => {
+    const configuredLock = daemonLockPath(daemonHome ?? daemonDirectory(home));
+    const files =
+      daemonHome === undefined ? [configuredLock, legacyLockPath(home)] : [configuredLock];
+    return Effect.all(
+      files.map((file) => fs.remove(file, { force: true })),
       { discard: true },
-    ),
-  ).pipe(Effect.ignore);
+    );
+  }).pipe(Effect.ignore);

--- a/packages/server/src/daemon/lock.ts
+++ b/packages/server/src/daemon/lock.ts
@@ -1,21 +1,15 @@
 import { Effect, FileSystem, type PlatformError } from "effect";
 
-import { daemonDirectory, daemonLockPath } from "./paths";
-
-const lockPath = (home: string, daemonDir?: string): string =>
-  daemonLockPath(daemonDir ?? daemonDirectory(home));
+import { daemonLockPath } from "./paths";
 
 /**
- * The launch lock — an exclusive-create `$VIBEST_DAEMON_DIR/daemon.lock`
- * holding the acquiring launcher's pid. It serializes spawns so two launchers
- * racing an empty daemon directory (or a respawn window) cannot both spawn a
- * daemon; the loser waits for the winner's record and attaches. A lock whose
- * holder pid has died is reclaimable. This is the file-state seam; the
+ * Create the launch lock atomically — an exclusive-create
+ * `$VIBEST_DAEMON_DIR/daemon.lock` holding the acquiring launcher's pid. True
+ * when acquired; false when someone holds it. It serializes spawns so two
+ * launchers racing an empty daemon directory (or a respawn window) cannot both
+ * spawn a daemon; the loser waits for the winner's record and attaches. A lock
+ * whose holder pid has died is reclaimable. This file is the state seam; the
  * retry/wait orchestration lives in the launcher.
- */
-
-/**
- * Create the lock atomically. True when acquired; false when someone holds it.
  *
  * The exclusivity is the OS's, not ours: `wx` is `O_CREAT | O_EXCL`, so exactly
  * one racing launcher can win however the writes are scheduled. Anything other
@@ -23,11 +17,10 @@ const lockPath = (home: string, daemonDir?: string): string =>
  * failure and stays in the error channel.
  */
 export const tryAcquireLock = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<boolean, PlatformError.PlatformError, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
-    fs.writeFileString(lockPath(home, daemonDir), String(process.pid), {
+    fs.writeFileString(daemonLockPath(daemonDir), String(process.pid), {
       flag: "wx",
       mode: 0o600,
     }),
@@ -41,10 +34,9 @@ export const tryAcquireLock = (
 
 /** The pid recorded in the lock, or `undefined` if missing/garbage. */
 export const readLockPid = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<number | undefined, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.readFileString(lockPath(home, daemonDir))).pipe(
+  FileSystem.FileSystem.use((fs) => fs.readFileString(daemonLockPath(daemonDir))).pipe(
     Effect.orElseSucceed(() => ""),
     Effect.map((raw) => {
       const pid = Number.parseInt(raw, 10);
@@ -54,18 +46,14 @@ export const readLockPid = (
 
 /** Whether the lock still exists (a concurrent launcher is still spawning). */
 export const lockExists = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.exists(lockPath(home, daemonDir))).pipe(
+  FileSystem.FileSystem.use((fs) => fs.exists(daemonLockPath(daemonDir))).pipe(
     Effect.orElseSucceed(() => false),
   );
 
 /** Release the lock; a missing lock (or a lost reclaim race) is not an error. */
-export const releaseLock = (
-  home: string,
-  daemonDir?: string,
-): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.remove(lockPath(home, daemonDir), { force: true })).pipe(
+export const releaseLock = (daemonDir: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
+  FileSystem.FileSystem.use((fs) => fs.remove(daemonLockPath(daemonDir), { force: true })).pipe(
     Effect.ignore,
   );

--- a/packages/server/src/daemon/lock.ts
+++ b/packages/server/src/daemon/lock.ts
@@ -1,16 +1,15 @@
-import path from "node:path";
-
 import { Effect, FileSystem, type PlatformError } from "effect";
 
+import { legacyLockPath, lockPath } from "./paths";
+
 /**
- * The launch lock — an exclusive-create `$VIBEST_HOME/daemon.lock` holding the
+ * The launch lock — an exclusive-create `$VIBEST_HOME/daemon/daemon.lock` holding the
  * acquiring launcher's pid. It serializes spawns so two launchers racing an
  * empty home (or a respawn window) cannot both spawn a daemon; the loser waits
  * for the winner's record and attaches. A lock whose holder pid has died is
  * reclaimable. This is the file-state seam; the retry/wait orchestration lives
  * in the launcher.
  */
-const lockPath = (home: string): string => path.join(home, "daemon.lock");
 
 /**
  * Create the lock atomically. True when acquired; false when someone holds it.
@@ -24,33 +23,61 @@ export const tryAcquireLock = (
   home: string,
 ): Effect.Effect<boolean, PlatformError.PlatformError, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
-    fs.writeFileString(lockPath(home), String(process.pid), { flag: "wx", mode: 0o600 }),
-  ).pipe(
-    Effect.as(true),
-    Effect.catchIf(
-      (error) => error.reason._tag === "AlreadyExists",
-      () => Effect.succeed(false),
-    ),
+    Effect.gen(function* () {
+      // The root-level lock remains canonical during the compatibility window:
+      // old launchers see it, so mixed old/new clients cannot spawn twice.
+      const acquired = yield* fs
+        .writeFileString(legacyLockPath(home), String(process.pid), {
+          flag: "wx",
+          mode: 0o600,
+        })
+        .pipe(
+          Effect.as(true),
+          Effect.catchIf(
+            (error) => error.reason._tag === "AlreadyExists",
+            () => Effect.succeed(false),
+          ),
+        );
+      if (!acquired) return false;
+
+      // Nested copy is diagnostic state only; the root lock owns exclusivity.
+      // If it cannot be written, give the canonical lock back before failing.
+      yield* fs
+        .writeFileString(lockPath(home), String(process.pid), { mode: 0o600 })
+        .pipe(Effect.tapError(() => fs.remove(legacyLockPath(home), { force: true })));
+      return true;
+    }),
   );
 
 /** The pid recorded in the lock, or `undefined` if missing/garbage. */
 export const readLockPid = (
   home: string,
 ): Effect.Effect<number | undefined, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.readFileString(lockPath(home))).pipe(
-    Effect.orElseSucceed(() => ""),
-    Effect.map((raw) => {
-      const pid = Number.parseInt(raw, 10);
-      return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+  FileSystem.FileSystem.use((fs) =>
+    Effect.gen(function* () {
+      for (const file of [legacyLockPath(home), lockPath(home)]) {
+        const raw = yield* fs.readFileString(file).pipe(Effect.orElseSucceed(() => ""));
+        const pid = Number.parseInt(raw, 10);
+        if (Number.isInteger(pid) && pid > 0) return pid;
+      }
+      return undefined;
     }),
   );
 
 /** Whether the lock still exists (a concurrent launcher is still spawning). */
 export const lockExists = (home: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.exists(lockPath(home))).pipe(
-    Effect.orElseSucceed(() => false),
-  );
+  FileSystem.FileSystem.use((fs) =>
+    Effect.gen(function* () {
+      if (yield* fs.exists(legacyLockPath(home))) return true;
+      return yield* fs.exists(lockPath(home));
+    }),
+  ).pipe(Effect.orElseSucceed(() => false));
 
-/** Release the lock; a missing lock (or a lost reclaim race) is not an error. */
+/** Release current and legacy locks; missing files are not errors. */
 export const releaseLock = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.remove(lockPath(home), { force: true })).pipe(Effect.ignore);
+  FileSystem.FileSystem.use((fs) =>
+    Effect.all(
+      [lockPath(home), legacyLockPath(home)].map((file) => fs.remove(file, { force: true })),
+      { discard: true },
+    ),
+  ).pipe(Effect.ignore);

--- a/packages/server/src/daemon/lock.ts
+++ b/packages/server/src/daemon/lock.ts
@@ -1,14 +1,17 @@
 import { Effect, FileSystem, type PlatformError } from "effect";
 
-import { daemonDirectory, daemonLockPath, legacyLockPath } from "./paths";
+import { daemonDirectory, daemonLockPath } from "./paths";
+
+const lockPath = (home: string, daemonDir?: string): string =>
+  daemonLockPath(daemonDir ?? daemonDirectory(home));
 
 /**
- * The launch lock — an exclusive-create `$VIBEST_HOME/daemon/daemon.lock` holding the
- * acquiring launcher's pid. It serializes spawns so two launchers racing an
- * empty home (or a respawn window) cannot both spawn a daemon; the loser waits
- * for the winner's record and attaches. A lock whose holder pid has died is
- * reclaimable. This is the file-state seam; the retry/wait orchestration lives
- * in the launcher.
+ * The launch lock — an exclusive-create `$VIBEST_DAEMON_DIR/daemon.lock`
+ * holding the acquiring launcher's pid. It serializes spawns so two launchers
+ * racing an empty daemon directory (or a respawn window) cannot both spawn a
+ * daemon; the loser waits for the winner's record and attaches. A lock whose
+ * holder pid has died is reclaimable. This is the file-state seam; the
+ * retry/wait orchestration lives in the launcher.
  */
 
 /**
@@ -16,81 +19,53 @@ import { daemonDirectory, daemonLockPath, legacyLockPath } from "./paths";
  *
  * The exclusivity is the OS's, not ours: `wx` is `O_CREAT | O_EXCL`, so exactly
  * one racing launcher can win however the writes are scheduled. Anything other
- * than "already there" (unwritable home, full disk) is a real launch failure
- * and stays in the error channel.
+ * than "already there" (unwritable directory, full disk) is a real launch
+ * failure and stays in the error channel.
  */
 export const tryAcquireLock = (
   home: string,
-  daemonHome?: string,
+  daemonDir?: string,
 ): Effect.Effect<boolean, PlatformError.PlatformError, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
-    Effect.gen(function* () {
-      const configuredLock = daemonLockPath(daemonHome ?? daemonDirectory(home));
-      const canonicalLock = daemonHome === undefined ? legacyLockPath(home) : configuredLock;
-      const acquired = yield* fs
-        .writeFileString(canonicalLock, String(process.pid), { flag: "wx", mode: 0o600 })
-        .pipe(
-          Effect.as(true),
-          Effect.catchIf(
-            (error) => error.reason._tag === "AlreadyExists",
-            () => Effect.succeed(false),
-          ),
-        );
-      if (!acquired) return false;
-      if (daemonHome !== undefined) return true;
-
-      // Default layout: mirror the canonical root lock for diagnostics. If the
-      // mirror fails, give the compatibility lock back before failing.
-      yield* fs
-        .writeFileString(configuredLock, String(process.pid), { mode: 0o600 })
-        .pipe(Effect.tapError(() => fs.remove(canonicalLock, { force: true })));
-      return true;
+    fs.writeFileString(lockPath(home, daemonDir), String(process.pid), {
+      flag: "wx",
+      mode: 0o600,
     }),
+  ).pipe(
+    Effect.as(true),
+    Effect.catchIf(
+      (error) => error.reason._tag === "AlreadyExists",
+      () => Effect.succeed(false),
+    ),
   );
 
 /** The pid recorded in the lock, or `undefined` if missing/garbage. */
 export const readLockPid = (
   home: string,
-  daemonHome?: string,
+  daemonDir?: string,
 ): Effect.Effect<number | undefined, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) =>
-    Effect.gen(function* () {
-      const configuredLock = daemonLockPath(daemonHome ?? daemonDirectory(home));
-      const files =
-        daemonHome === undefined ? [legacyLockPath(home), configuredLock] : [configuredLock];
-      for (const file of files) {
-        const raw = yield* fs.readFileString(file).pipe(Effect.orElseSucceed(() => ""));
-        const pid = Number.parseInt(raw, 10);
-        if (Number.isInteger(pid) && pid > 0) return pid;
-      }
-      return undefined;
+  FileSystem.FileSystem.use((fs) => fs.readFileString(lockPath(home, daemonDir))).pipe(
+    Effect.orElseSucceed(() => ""),
+    Effect.map((raw) => {
+      const pid = Number.parseInt(raw, 10);
+      return Number.isInteger(pid) && pid > 0 ? pid : undefined;
     }),
   );
 
 /** Whether the lock still exists (a concurrent launcher is still spawning). */
 export const lockExists = (
   home: string,
-  daemonHome?: string,
+  daemonDir?: string,
 ): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) =>
-    Effect.gen(function* () {
-      const configuredLock = daemonLockPath(daemonHome ?? daemonDirectory(home));
-      if (daemonHome === undefined && (yield* fs.exists(legacyLockPath(home)))) return true;
-      return yield* fs.exists(configuredLock);
-    }),
-  ).pipe(Effect.orElseSucceed(() => false));
+  FileSystem.FileSystem.use((fs) => fs.exists(lockPath(home, daemonDir))).pipe(
+    Effect.orElseSucceed(() => false),
+  );
 
-/** Release configured and compatibility locks; missing files are not errors. */
+/** Release the lock; a missing lock (or a lost reclaim race) is not an error. */
 export const releaseLock = (
   home: string,
-  daemonHome?: string,
+  daemonDir?: string,
 ): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => {
-    const configuredLock = daemonLockPath(daemonHome ?? daemonDirectory(home));
-    const files =
-      daemonHome === undefined ? [configuredLock, legacyLockPath(home)] : [configuredLock];
-    return Effect.all(
-      files.map((file) => fs.remove(file, { force: true })),
-      { discard: true },
-    );
-  }).pipe(Effect.ignore);
+  FileSystem.FileSystem.use((fs) => fs.remove(lockPath(home, daemonDir), { force: true })).pipe(
+    Effect.ignore,
+  );

--- a/packages/server/src/daemon/paths.ts
+++ b/packages/server/src/daemon/paths.ts
@@ -1,13 +1,20 @@
 import path from "node:path";
 
-/** Default daemon state directory for a `$VIBEST_HOME`. */
-export const daemonDirectory = (home: string): string => path.join(home, "daemon");
+/**
+ * The four lifecycle files, named relative to a daemon directory the caller
+ * already resolved. Deliberately no default of its own — see
+ * `resolveDaemonLocation` in `config/paths.ts`.
+ */
 
+/** Discovery record — pid, address, and the daemon's auth token. */
 export const daemonRecordPath = (daemonDir: string): string => path.join(daemonDir, "daemon.pid");
 
+/** Exclusive-create launch lock, held only while a launcher is spawning. */
 export const daemonLockPath = (daemonDir: string): string => path.join(daemonDir, "daemon.lock");
 
+/** The detached daemon's stdout/stderr. */
 export const daemonLogPath = (daemonDir: string): string => path.join(daemonDir, "daemon.log");
 
+/** Written by an explicit stop so supervision does not resurrect the daemon. */
 export const daemonTombstonePath = (daemonDir: string): string =>
   path.join(daemonDir, "daemon.stopped");

--- a/packages/server/src/daemon/paths.ts
+++ b/packages/server/src/daemon/paths.ts
@@ -1,20 +1,20 @@
 import path from "node:path";
 
-/** `$VIBEST_HOME/daemon/` — lifecycle state for the one daemon owning this home. */
+/** Default daemon state directory for a `$VIBEST_HOME`. */
 export const daemonDirectory = (home: string): string => path.join(home, "daemon");
 
-export const recordPath = (home: string): string => path.join(daemonDirectory(home), "daemon.pid");
+export const daemonRecordPath = (daemonHome: string): string => path.join(daemonHome, "daemon.pid");
 
-export const lockPath = (home: string): string => path.join(daemonDirectory(home), "daemon.lock");
+export const daemonLockPath = (daemonHome: string): string => path.join(daemonHome, "daemon.lock");
 
-export const logPath = (home: string): string => path.join(daemonDirectory(home), "daemon.log");
+export const daemonLogPath = (daemonHome: string): string => path.join(daemonHome, "daemon.log");
 
-export const tombstonePath = (home: string): string =>
-  path.join(daemonDirectory(home), "daemon.stopped");
+export const daemonTombstonePath = (daemonHome: string): string =>
+  path.join(daemonHome, "daemon.stopped");
 
 // Compatibility with homes created before daemon lifecycle files moved under
-// `$VIBEST_HOME/daemon/`. Discovery, locking, and stop signals are mirrored at
-// these paths so mixed old/new launchers still converge on one daemon.
+// the default `$VIBEST_HOME/daemon/` directory. These mirrors are used only
+// when VIBEST_DAEMON_DIR is absent.
 export const legacyRecordPath = (home: string): string => path.join(home, "daemon.pid");
 export const legacyLockPath = (home: string): string => path.join(home, "daemon.lock");
 export const legacyTombstonePath = (home: string): string => path.join(home, "daemon.stopped");

--- a/packages/server/src/daemon/paths.ts
+++ b/packages/server/src/daemon/paths.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+
+/** `$VIBEST_HOME/daemon/` — lifecycle state for the one daemon owning this home. */
+export const daemonDirectory = (home: string): string => path.join(home, "daemon");
+
+export const recordPath = (home: string): string => path.join(daemonDirectory(home), "daemon.pid");
+
+export const lockPath = (home: string): string => path.join(daemonDirectory(home), "daemon.lock");
+
+export const logPath = (home: string): string => path.join(daemonDirectory(home), "daemon.log");
+
+export const tombstonePath = (home: string): string =>
+  path.join(daemonDirectory(home), "daemon.stopped");
+
+// Compatibility with homes created before daemon lifecycle files moved under
+// `$VIBEST_HOME/daemon/`. Discovery, locking, and stop signals are mirrored at
+// these paths so mixed old/new launchers still converge on one daemon.
+export const legacyRecordPath = (home: string): string => path.join(home, "daemon.pid");
+export const legacyLockPath = (home: string): string => path.join(home, "daemon.lock");
+export const legacyTombstonePath = (home: string): string => path.join(home, "daemon.stopped");

--- a/packages/server/src/daemon/paths.ts
+++ b/packages/server/src/daemon/paths.ts
@@ -3,18 +3,11 @@ import path from "node:path";
 /** Default daemon state directory for a `$VIBEST_HOME`. */
 export const daemonDirectory = (home: string): string => path.join(home, "daemon");
 
-export const daemonRecordPath = (daemonHome: string): string => path.join(daemonHome, "daemon.pid");
+export const daemonRecordPath = (daemonDir: string): string => path.join(daemonDir, "daemon.pid");
 
-export const daemonLockPath = (daemonHome: string): string => path.join(daemonHome, "daemon.lock");
+export const daemonLockPath = (daemonDir: string): string => path.join(daemonDir, "daemon.lock");
 
-export const daemonLogPath = (daemonHome: string): string => path.join(daemonHome, "daemon.log");
+export const daemonLogPath = (daemonDir: string): string => path.join(daemonDir, "daemon.log");
 
-export const daemonTombstonePath = (daemonHome: string): string =>
-  path.join(daemonHome, "daemon.stopped");
-
-// Compatibility with homes created before daemon lifecycle files moved under
-// the default `$VIBEST_HOME/daemon/` directory. These mirrors are used only
-// when VIBEST_DAEMON_DIR is absent.
-export const legacyRecordPath = (home: string): string => path.join(home, "daemon.pid");
-export const legacyLockPath = (home: string): string => path.join(home, "daemon.lock");
-export const legacyTombstonePath = (home: string): string => path.join(home, "daemon.stopped");
+export const daemonTombstonePath = (daemonDir: string): string =>
+  path.join(daemonDir, "daemon.stopped");

--- a/packages/server/src/daemon/record.ts
+++ b/packages/server/src/daemon/record.ts
@@ -1,7 +1,7 @@
 import { writeFileAtomic } from "@vibest/effect-json-store";
 import { Effect, FileSystem, type PlatformError } from "effect";
 
-import { daemonDirectory, daemonRecordPath } from "./paths";
+import { daemonRecordPath } from "./paths";
 
 /**
  * The discovery record the launcher writes to `$VIBEST_DAEMON_DIR/daemon.pid` —
@@ -20,19 +20,14 @@ export type DaemonRecord = {
   readonly startedAt: number;
 };
 
-/** Discovery record under the configured daemon directory. */
-export const recordPath = (home: string, daemonDir?: string): string =>
-  daemonRecordPath(daemonDir ?? daemonDirectory(home));
-
 /** Read and validate the record, or `undefined` if missing/garbage. */
 export const readRecord = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const raw = yield* fs
-      .readFileString(recordPath(home, daemonDir))
+      .readFileString(daemonRecordPath(daemonDir))
       .pipe(Effect.orElseSucceed(() => undefined));
     if (raw === undefined) return undefined;
 
@@ -61,19 +56,17 @@ export const readRecord = (
  * write fails or is interrupted.
  */
 export const writeRecord = (
-  home: string,
+  daemonDir: string,
   record: DaemonRecord,
-  daemonDir?: string,
 ): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
-    writeFileAtomic(fs, recordPath(home, daemonDir), JSON.stringify(record), { mode: 0o600 }),
+    writeFileAtomic(fs, daemonRecordPath(daemonDir), JSON.stringify(record), { mode: 0o600 }),
   );
 
 /** Remove the record; a missing file is not an error. */
 export const removeRecord = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.remove(recordPath(home, daemonDir), { force: true })).pipe(
+  FileSystem.FileSystem.use((fs) => fs.remove(daemonRecordPath(daemonDir), { force: true })).pipe(
     Effect.ignore,
   );

--- a/packages/server/src/daemon/record.ts
+++ b/packages/server/src/daemon/record.ts
@@ -1,9 +1,9 @@
-import path from "node:path";
-
 import { Effect, FileSystem, type PlatformError } from "effect";
 
+import { daemonDirectory, legacyRecordPath, recordPath } from "./paths";
+
 /**
- * The discovery record the launcher writes to `$VIBEST_HOME/daemon.pid` — the
+ * The discovery record the launcher writes to `$VIBEST_HOME/daemon/daemon.pid` — the
  * local mirror of the SSH remote's `ssh-launch/<stateKey>/{pid,port,token}`. It
  * is the single-instance marker: staleness is decided by "is the pid alive",
  * never a lock the server holds. The server itself never reads or writes it.
@@ -19,27 +19,16 @@ export type DaemonRecord = {
   readonly startedAt: number;
 };
 
-/** `$VIBEST_HOME/daemon.pid`. */
-export const recordPath = (home: string): string => path.join(home, "daemon.pid");
+/** `$VIBEST_HOME/daemon/daemon.pid`. */
+export { recordPath } from "./paths";
 
-/** Read and validate the record, or `undefined` if missing/garbage. */
-export const readRecord = (
-  home: string,
-): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const raw = yield* fs
-      .readFileString(recordPath(home))
-      .pipe(Effect.orElseSucceed(() => undefined));
-    if (raw === undefined) return undefined;
-
-    const parsed = yield* Effect.try(() => JSON.parse(raw) as Partial<DaemonRecord>).pipe(
-      Effect.orElseSucceed(() => undefined),
-    );
+const parseRecord = (raw: string): DaemonRecord | undefined => {
+  try {
+    const parsed = JSON.parse(raw) as Partial<DaemonRecord>;
     if (
-      typeof parsed?.pid === "number" &&
-      typeof parsed?.address === "string" &&
-      typeof parsed?.token === "string"
+      typeof parsed.pid === "number" &&
+      typeof parsed.address === "string" &&
+      typeof parsed.token === "string"
     ) {
       return {
         pid: parsed.pid,
@@ -48,8 +37,40 @@ export const readRecord = (
         startedAt: typeof parsed.startedAt === "number" ? parsed.startedAt : 0,
       };
     }
-    return undefined;
+  } catch {
+    // Missing/garbage discovery state is the same as no discoverable daemon.
+  }
+  return undefined;
+};
+
+/** Read every distinct current or legacy record that still parses. */
+export const readRecords = (
+  home: string,
+): Effect.Effect<ReadonlyArray<DaemonRecord>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const records: DaemonRecord[] = [];
+    for (const file of [recordPath(home), legacyRecordPath(home)]) {
+      const raw = yield* fs.readFileString(file).pipe(Effect.orElseSucceed(() => undefined));
+      if (raw === undefined) continue;
+      const record = parseRecord(raw);
+      if (
+        record !== undefined &&
+        !records.some(
+          (candidate) => candidate.pid === record.pid && candidate.address === record.address,
+        )
+      ) {
+        records.push(record);
+      }
+    }
+    return records;
   });
+
+/** Read the preferred current record, or the legacy record during migration. */
+export const readRecord = (
+  home: string,
+): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
+  readRecords(home).pipe(Effect.map((records) => records[0]));
 
 /**
  * Atomically write the record with `0600` perms (token is a secret): write a
@@ -62,18 +83,24 @@ export const writeRecord = (
 ): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    yield* fs.makeDirectory(home, { recursive: true });
-    const target = recordPath(home);
-    const tmp = `${target}.${process.pid}.tmp`;
-    yield* fs.writeFileString(tmp, JSON.stringify(record), { mode: 0o600 });
-    // `mode` only applies when the write creates the file, so a leftover temp
-    // from a crashed launcher would otherwise keep its old perms.
-    yield* fs.chmod(tmp, 0o600);
-    yield* fs.rename(tmp, target);
+    yield* fs.makeDirectory(daemonDirectory(home), { recursive: true });
+    // Publish the legacy/root mirror first: old launchers use it as canonical
+    // discovery, so they can never miss a daemon that new code has published.
+    for (const target of [legacyRecordPath(home), recordPath(home)]) {
+      const tmp = `${target}.${process.pid}.tmp`;
+      yield* fs.writeFileString(tmp, JSON.stringify(record), { mode: 0o600 });
+      // `mode` only applies when the write creates the file, so a leftover temp
+      // from a crashed launcher would otherwise keep its old perms.
+      yield* fs.chmod(tmp, 0o600);
+      yield* fs.rename(tmp, target);
+    }
   });
 
-/** Remove the record; a missing file is not an error. */
+/** Remove current and legacy records; missing files are not errors. */
 export const removeRecord = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.remove(recordPath(home), { force: true })).pipe(
-    Effect.ignore,
-  );
+  FileSystem.FileSystem.use((fs) =>
+    Effect.all(
+      [recordPath(home), legacyRecordPath(home)].map((file) => fs.remove(file, { force: true })),
+      { discard: true },
+    ),
+  ).pipe(Effect.ignore);

--- a/packages/server/src/daemon/record.ts
+++ b/packages/server/src/daemon/record.ts
@@ -1,6 +1,6 @@
 import { Effect, FileSystem, type PlatformError } from "effect";
 
-import { daemonDirectory, legacyRecordPath, recordPath } from "./paths";
+import { daemonDirectory, daemonRecordPath, legacyRecordPath } from "./paths";
 
 /**
  * The discovery record the launcher writes to `$VIBEST_HOME/daemon/daemon.pid` — the
@@ -19,8 +19,14 @@ export type DaemonRecord = {
   readonly startedAt: number;
 };
 
-/** `$VIBEST_HOME/daemon/daemon.pid`. */
-export { recordPath } from "./paths";
+/** Discovery record under the configured daemon directory. */
+export const recordPath = (home: string, daemonHome?: string): string =>
+  daemonRecordPath(daemonHome ?? daemonDirectory(home));
+
+const recordPaths = (home: string, daemonHome?: string): ReadonlyArray<string> => [
+  recordPath(home, daemonHome),
+  ...(daemonHome === undefined ? [legacyRecordPath(home)] : []),
+];
 
 const parseRecord = (raw: string): DaemonRecord | undefined => {
   try {
@@ -46,11 +52,12 @@ const parseRecord = (raw: string): DaemonRecord | undefined => {
 /** Read every distinct current or legacy record that still parses. */
 export const readRecords = (
   home: string,
+  daemonHome?: string,
 ): Effect.Effect<ReadonlyArray<DaemonRecord>, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const records: DaemonRecord[] = [];
-    for (const file of [recordPath(home), legacyRecordPath(home)]) {
+    for (const file of recordPaths(home, daemonHome)) {
       const raw = yield* fs.readFileString(file).pipe(Effect.orElseSucceed(() => undefined));
       if (raw === undefined) continue;
       const record = parseRecord(raw);
@@ -69,8 +76,9 @@ export const readRecords = (
 /** Read the preferred current record, or the legacy record during migration. */
 export const readRecord = (
   home: string,
+  daemonHome?: string,
 ): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
-  readRecords(home).pipe(Effect.map((records) => records[0]));
+  readRecords(home, daemonHome).pipe(Effect.map((records) => records[0]));
 
 /**
  * Atomically write the record with `0600` perms (token is a secret): write a
@@ -80,13 +88,18 @@ export const readRecord = (
 export const writeRecord = (
   home: string,
   record: DaemonRecord,
+  daemonHome?: string,
 ): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    yield* fs.makeDirectory(daemonDirectory(home), { recursive: true });
-    // Publish the legacy/root mirror first: old launchers use it as canonical
-    // discovery, so they can never miss a daemon that new code has published.
-    for (const target of [legacyRecordPath(home), recordPath(home)]) {
+    yield* fs.makeDirectory(daemonHome ?? daemonDirectory(home), { recursive: true });
+    // The default layout mirrors root-first for mixed-version clients. An
+    // explicit daemon home is isolated and never writes into `$VIBEST_HOME`.
+    const targets =
+      daemonHome === undefined
+        ? [legacyRecordPath(home), recordPath(home)]
+        : [recordPath(home, daemonHome)];
+    for (const target of targets) {
       const tmp = `${target}.${process.pid}.tmp`;
       yield* fs.writeFileString(tmp, JSON.stringify(record), { mode: 0o600 });
       // `mode` only applies when the write creates the file, so a leftover temp
@@ -96,11 +109,14 @@ export const writeRecord = (
     }
   });
 
-/** Remove current and legacy records; missing files are not errors. */
-export const removeRecord = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
+/** Remove configured and compatibility records; missing files are not errors. */
+export const removeRecord = (
+  home: string,
+  daemonHome?: string,
+): Effect.Effect<void, never, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
     Effect.all(
-      [recordPath(home), legacyRecordPath(home)].map((file) => fs.remove(file, { force: true })),
+      recordPaths(home, daemonHome).map((file) => fs.remove(file, { force: true })),
       { discard: true },
     ),
   ).pipe(Effect.ignore);

--- a/packages/server/src/daemon/record.ts
+++ b/packages/server/src/daemon/record.ts
@@ -1,11 +1,11 @@
 import { Effect, FileSystem, type PlatformError } from "effect";
 
-import { daemonDirectory, daemonRecordPath, legacyRecordPath } from "./paths";
+import { daemonDirectory, daemonRecordPath } from "./paths";
 
 /**
- * The discovery record the launcher writes to `$VIBEST_HOME/daemon/daemon.pid` — the
- * local mirror of the SSH remote's `ssh-launch/<stateKey>/{pid,port,token}`. It
- * is the single-instance marker: staleness is decided by "is the pid alive",
+ * The discovery record the launcher writes to `$VIBEST_DAEMON_DIR/daemon.pid` —
+ * the local mirror of the SSH remote's `ssh-launch/<stateKey>/{pid,port,token}`.
+ * It is the single-instance marker: staleness is decided by "is the pid alive",
  * never a lock the server holds. The server itself never reads or writes it.
  */
 export type DaemonRecord = {
@@ -20,21 +20,28 @@ export type DaemonRecord = {
 };
 
 /** Discovery record under the configured daemon directory. */
-export const recordPath = (home: string, daemonHome?: string): string =>
-  daemonRecordPath(daemonHome ?? daemonDirectory(home));
+export const recordPath = (home: string, daemonDir?: string): string =>
+  daemonRecordPath(daemonDir ?? daemonDirectory(home));
 
-const recordPaths = (home: string, daemonHome?: string): ReadonlyArray<string> => [
-  recordPath(home, daemonHome),
-  ...(daemonHome === undefined ? [legacyRecordPath(home)] : []),
-];
+/** Read and validate the record, or `undefined` if missing/garbage. */
+export const readRecord = (
+  home: string,
+  daemonDir?: string,
+): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const raw = yield* fs
+      .readFileString(recordPath(home, daemonDir))
+      .pipe(Effect.orElseSucceed(() => undefined));
+    if (raw === undefined) return undefined;
 
-const parseRecord = (raw: string): DaemonRecord | undefined => {
-  try {
-    const parsed = JSON.parse(raw) as Partial<DaemonRecord>;
+    const parsed = yield* Effect.try(() => JSON.parse(raw) as Partial<DaemonRecord>).pipe(
+      Effect.orElseSucceed(() => undefined),
+    );
     if (
-      typeof parsed.pid === "number" &&
-      typeof parsed.address === "string" &&
-      typeof parsed.token === "string"
+      typeof parsed?.pid === "number" &&
+      typeof parsed?.address === "string" &&
+      typeof parsed?.token === "string"
     ) {
       return {
         pid: parsed.pid,
@@ -43,42 +50,8 @@ const parseRecord = (raw: string): DaemonRecord | undefined => {
         startedAt: typeof parsed.startedAt === "number" ? parsed.startedAt : 0,
       };
     }
-  } catch {
-    // Missing/garbage discovery state is the same as no discoverable daemon.
-  }
-  return undefined;
-};
-
-/** Read every distinct current or legacy record that still parses. */
-export const readRecords = (
-  home: string,
-  daemonHome?: string,
-): Effect.Effect<ReadonlyArray<DaemonRecord>, never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const records: DaemonRecord[] = [];
-    for (const file of recordPaths(home, daemonHome)) {
-      const raw = yield* fs.readFileString(file).pipe(Effect.orElseSucceed(() => undefined));
-      if (raw === undefined) continue;
-      const record = parseRecord(raw);
-      if (
-        record !== undefined &&
-        !records.some(
-          (candidate) => candidate.pid === record.pid && candidate.address === record.address,
-        )
-      ) {
-        records.push(record);
-      }
-    }
-    return records;
+    return undefined;
   });
-
-/** Read the preferred current record, or the legacy record during migration. */
-export const readRecord = (
-  home: string,
-  daemonHome?: string,
-): Effect.Effect<DaemonRecord | undefined, never, FileSystem.FileSystem> =>
-  readRecords(home, daemonHome).pipe(Effect.map((records) => records[0]));
 
 /**
  * Atomically write the record with `0600` perms (token is a secret): write a
@@ -88,35 +61,25 @@ export const readRecord = (
 export const writeRecord = (
   home: string,
   record: DaemonRecord,
-  daemonHome?: string,
+  daemonDir?: string,
 ): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    yield* fs.makeDirectory(daemonHome ?? daemonDirectory(home), { recursive: true });
-    // The default layout mirrors root-first for mixed-version clients. An
-    // explicit daemon home is isolated and never writes into `$VIBEST_HOME`.
-    const targets =
-      daemonHome === undefined
-        ? [legacyRecordPath(home), recordPath(home)]
-        : [recordPath(home, daemonHome)];
-    for (const target of targets) {
-      const tmp = `${target}.${process.pid}.tmp`;
-      yield* fs.writeFileString(tmp, JSON.stringify(record), { mode: 0o600 });
-      // `mode` only applies when the write creates the file, so a leftover temp
-      // from a crashed launcher would otherwise keep its old perms.
-      yield* fs.chmod(tmp, 0o600);
-      yield* fs.rename(tmp, target);
-    }
+    yield* fs.makeDirectory(daemonDir ?? daemonDirectory(home), { recursive: true });
+    const target = recordPath(home, daemonDir);
+    const tmp = `${target}.${process.pid}.tmp`;
+    yield* fs.writeFileString(tmp, JSON.stringify(record), { mode: 0o600 });
+    // `mode` only applies when the write creates the file, so a leftover temp
+    // from a crashed launcher would otherwise keep its old perms.
+    yield* fs.chmod(tmp, 0o600);
+    yield* fs.rename(tmp, target);
   });
 
-/** Remove configured and compatibility records; missing files are not errors. */
+/** Remove the record; a missing file is not an error. */
 export const removeRecord = (
   home: string,
-  daemonHome?: string,
+  daemonDir?: string,
 ): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) =>
-    Effect.all(
-      recordPaths(home, daemonHome).map((file) => fs.remove(file, { force: true })),
-      { discard: true },
-    ),
-  ).pipe(Effect.ignore);
+  FileSystem.FileSystem.use((fs) => fs.remove(recordPath(home, daemonDir), { force: true })).pipe(
+    Effect.ignore,
+  );

--- a/packages/server/src/daemon/tombstone.ts
+++ b/packages/server/src/daemon/tombstone.ts
@@ -1,23 +1,24 @@
 import { Clock, Effect, FileSystem, type PlatformError } from "effect";
 
-import { daemonDirectory, daemonTombstonePath, legacyTombstonePath } from "./paths";
+import { daemonDirectory, daemonTombstonePath } from "./paths";
+
+const tombstonePath = (home: string, daemonDir?: string): string =>
+  daemonTombstonePath(daemonDir ?? daemonDirectory(home));
 
 /**
- * The stop tombstone — `$VIBEST_HOME/daemon/daemon.stopped`, written by an explicit
- * `stopDaemon` so automatic supervision (the desktop's respawn loop) does not
- * resurrect a daemon the user deliberately stopped. An explicit start clears
- * it. Its mere existence is the signal; the timestamp is only for debugging.
+ * The stop tombstone — `$VIBEST_DAEMON_DIR/daemon.stopped`, written by an
+ * explicit `stopDaemon` so automatic supervision (the desktop's respawn loop)
+ * does not resurrect a daemon the user deliberately stopped. An explicit start
+ * clears it. Its mere existence is the signal; the timestamp is only for
+ * debugging.
  */
 export const hasTombstone = (
   home: string,
   daemonDir?: string,
 ): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) =>
-    Effect.gen(function* () {
-      if (yield* fs.exists(daemonTombstonePath(daemonDir ?? daemonDirectory(home)))) return true;
-      return daemonDir === undefined ? yield* fs.exists(legacyTombstonePath(home)) : false;
-    }),
-  ).pipe(Effect.orElseSucceed(() => false));
+  FileSystem.FileSystem.use((fs) => fs.exists(tombstonePath(home, daemonDir))).pipe(
+    Effect.orElseSucceed(() => false),
+  );
 
 export const writeTombstone = (
   home: string,
@@ -26,29 +27,14 @@ export const writeTombstone = (
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const now = yield* Clock.currentTimeMillis;
-    const configuredDir = daemonDir ?? daemonDirectory(home);
-    yield* fs.makeDirectory(configuredDir, { recursive: true });
-    const files = [
-      daemonTombstonePath(configuredDir),
-      ...(daemonDir === undefined ? [legacyTombstonePath(home)] : []),
-    ];
-    yield* Effect.all(
-      files.map((file) => fs.writeFileString(file, String(now), { mode: 0o600 })),
-      { discard: true },
-    );
+    yield* fs.makeDirectory(daemonDir ?? daemonDirectory(home), { recursive: true });
+    yield* fs.writeFileString(tombstonePath(home, daemonDir), String(now), { mode: 0o600 });
   });
 
 export const clearTombstone = (
   home: string,
   daemonDir?: string,
 ): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => {
-    const files = [
-      daemonTombstonePath(daemonDir ?? daemonDirectory(home)),
-      ...(daemonDir === undefined ? [legacyTombstonePath(home)] : []),
-    ];
-    return Effect.all(
-      files.map((file) => fs.remove(file, { force: true })),
-      { discard: true },
-    );
-  }).pipe(Effect.ignore);
+  FileSystem.FileSystem.use((fs) =>
+    fs.remove(tombstonePath(home, daemonDir), { force: true }),
+  ).pipe(Effect.ignore);

--- a/packages/server/src/daemon/tombstone.ts
+++ b/packages/server/src/daemon/tombstone.ts
@@ -1,6 +1,6 @@
 import { Clock, Effect, FileSystem, type PlatformError } from "effect";
 
-import { daemonDirectory, legacyTombstonePath, tombstonePath } from "./paths";
+import { daemonDirectory, daemonTombstonePath, legacyTombstonePath } from "./paths";
 
 /**
  * The stop tombstone — `$VIBEST_HOME/daemon/daemon.stopped`, written by an explicit
@@ -8,35 +8,47 @@ import { daemonDirectory, legacyTombstonePath, tombstonePath } from "./paths";
  * resurrect a daemon the user deliberately stopped. An explicit start clears
  * it. Its mere existence is the signal; the timestamp is only for debugging.
  */
-export const hasTombstone = (home: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+export const hasTombstone = (
+  home: string,
+  daemonDir?: string,
+): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
     Effect.gen(function* () {
-      if (yield* fs.exists(tombstonePath(home))) return true;
-      return yield* fs.exists(legacyTombstonePath(home));
+      if (yield* fs.exists(daemonTombstonePath(daemonDir ?? daemonDirectory(home)))) return true;
+      return daemonDir === undefined ? yield* fs.exists(legacyTombstonePath(home)) : false;
     }),
   ).pipe(Effect.orElseSucceed(() => false));
 
 export const writeTombstone = (
   home: string,
+  daemonDir?: string,
 ): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const now = yield* Clock.currentTimeMillis;
-    yield* fs.makeDirectory(daemonDirectory(home), { recursive: true });
+    const configuredDir = daemonDir ?? daemonDirectory(home);
+    yield* fs.makeDirectory(configuredDir, { recursive: true });
+    const files = [
+      daemonTombstonePath(configuredDir),
+      ...(daemonDir === undefined ? [legacyTombstonePath(home)] : []),
+    ];
     yield* Effect.all(
-      [tombstonePath(home), legacyTombstonePath(home)].map((file) =>
-        fs.writeFileString(file, String(now), { mode: 0o600 }),
-      ),
+      files.map((file) => fs.writeFileString(file, String(now), { mode: 0o600 })),
       { discard: true },
     );
   });
 
-export const clearTombstone = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) =>
-    Effect.all(
-      [tombstonePath(home), legacyTombstonePath(home)].map((file) =>
-        fs.remove(file, { force: true }),
-      ),
+export const clearTombstone = (
+  home: string,
+  daemonDir?: string,
+): Effect.Effect<void, never, FileSystem.FileSystem> =>
+  FileSystem.FileSystem.use((fs) => {
+    const files = [
+      daemonTombstonePath(daemonDir ?? daemonDirectory(home)),
+      ...(daemonDir === undefined ? [legacyTombstonePath(home)] : []),
+    ];
+    return Effect.all(
+      files.map((file) => fs.remove(file, { force: true })),
       { discard: true },
-    ),
-  ).pipe(Effect.ignore);
+    );
+  }).pipe(Effect.ignore);

--- a/packages/server/src/daemon/tombstone.ts
+++ b/packages/server/src/daemon/tombstone.ts
@@ -1,19 +1,20 @@
-import path from "node:path";
-
 import { Clock, Effect, FileSystem, type PlatformError } from "effect";
 
+import { daemonDirectory, legacyTombstonePath, tombstonePath } from "./paths";
+
 /**
- * The stop tombstone — `$VIBEST_HOME/daemon.stopped`, written by an explicit
+ * The stop tombstone — `$VIBEST_HOME/daemon/daemon.stopped`, written by an explicit
  * `stopDaemon` so automatic supervision (the desktop's respawn loop) does not
  * resurrect a daemon the user deliberately stopped. An explicit start clears
  * it. Its mere existence is the signal; the timestamp is only for debugging.
  */
-const tombstoneFile = (home: string): string => path.join(home, "daemon.stopped");
-
 export const hasTombstone = (home: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.exists(tombstoneFile(home))).pipe(
-    Effect.orElseSucceed(() => false),
-  );
+  FileSystem.FileSystem.use((fs) =>
+    Effect.gen(function* () {
+      if (yield* fs.exists(tombstonePath(home))) return true;
+      return yield* fs.exists(legacyTombstonePath(home));
+    }),
+  ).pipe(Effect.orElseSucceed(() => false));
 
 export const writeTombstone = (
   home: string,
@@ -21,11 +22,21 @@ export const writeTombstone = (
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const now = yield* Clock.currentTimeMillis;
-    yield* fs.makeDirectory(home, { recursive: true });
-    yield* fs.writeFileString(tombstoneFile(home), String(now), { mode: 0o600 });
+    yield* fs.makeDirectory(daemonDirectory(home), { recursive: true });
+    yield* Effect.all(
+      [tombstonePath(home), legacyTombstonePath(home)].map((file) =>
+        fs.writeFileString(file, String(now), { mode: 0o600 }),
+      ),
+      { discard: true },
+    );
   });
 
 export const clearTombstone = (home: string): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.remove(tombstoneFile(home), { force: true })).pipe(
-    Effect.ignore,
-  );
+  FileSystem.FileSystem.use((fs) =>
+    Effect.all(
+      [tombstonePath(home), legacyTombstonePath(home)].map((file) =>
+        fs.remove(file, { force: true }),
+      ),
+      { discard: true },
+    ),
+  ).pipe(Effect.ignore);

--- a/packages/server/src/daemon/tombstone.ts
+++ b/packages/server/src/daemon/tombstone.ts
@@ -1,40 +1,34 @@
 import { Clock, Effect, FileSystem, type PlatformError } from "effect";
 
-import { daemonDirectory, daemonTombstonePath } from "./paths";
-
-const tombstonePath = (home: string, daemonDir?: string): string =>
-  daemonTombstonePath(daemonDir ?? daemonDirectory(home));
+import { daemonTombstonePath } from "./paths";
 
 /**
- * The stop tombstone — `$VIBEST_DAEMON_DIR/daemon.stopped`, written by an
- * explicit `stopDaemon` so automatic supervision (the desktop's respawn loop)
- * does not resurrect a daemon the user deliberately stopped. An explicit start
- * clears it. Its mere existence is the signal; the timestamp is only for
- * debugging.
+ * Whether the stop tombstone is present — `$VIBEST_DAEMON_DIR/daemon.stopped`,
+ * written by an explicit `stopDaemon` so automatic supervision (the desktop's
+ * respawn loop) does not resurrect a daemon the user deliberately stopped. An
+ * explicit start clears it. Its mere existence is the signal; the timestamp is
+ * only for debugging.
  */
 export const hasTombstone = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
-  FileSystem.FileSystem.use((fs) => fs.exists(tombstonePath(home, daemonDir))).pipe(
+  FileSystem.FileSystem.use((fs) => fs.exists(daemonTombstonePath(daemonDir))).pipe(
     Effect.orElseSucceed(() => false),
   );
 
 export const writeTombstone = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const now = yield* Clock.currentTimeMillis;
-    yield* fs.makeDirectory(daemonDir ?? daemonDirectory(home), { recursive: true });
-    yield* fs.writeFileString(tombstonePath(home, daemonDir), String(now), { mode: 0o600 });
+    yield* fs.makeDirectory(daemonDir, { recursive: true });
+    yield* fs.writeFileString(daemonTombstonePath(daemonDir), String(now), { mode: 0o600 });
   });
 
 export const clearTombstone = (
-  home: string,
-  daemonDir?: string,
+  daemonDir: string,
 ): Effect.Effect<void, never, FileSystem.FileSystem> =>
   FileSystem.FileSystem.use((fs) =>
-    fs.remove(tombstonePath(home, daemonDir), { force: true }),
+    fs.remove(daemonTombstonePath(daemonDir), { force: true }),
   ).pipe(Effect.ignore);

--- a/packages/server/test/daemon/launcher.test.ts
+++ b/packages/server/test/daemon/launcher.test.ts
@@ -15,7 +15,7 @@ import {
   stopDaemon,
 } from "../../src/daemon/launcher";
 import { pidAlive } from "../../src/daemon/liveness";
-import { readRecord, recordPath, writeRecord } from "../../src/daemon/record";
+import { readRecord, writeRecord } from "../../src/daemon/record";
 
 const FAKE_SERVER = url.fileURLToPath(new URL("./fixtures/fake-server.mjs", import.meta.url));
 
@@ -85,6 +85,12 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
         assert.equal(yield* readRecord(home), undefined);
         assert.ok(yield* fs.exists(path.join(daemonDir, "daemon.log")));
         assert.equal(yield* fs.exists(path.join(home, "daemon.pid")), false);
+        assert.equal(yield* fs.exists(path.join(home, "daemon.lock")), false);
+        assert.equal(yield* fs.exists(path.join(home, "daemon.stopped")), false);
+
+        assert.equal(yield* stopDaemon(home, daemonDir), "stopped");
+        assert.ok(yield* fs.exists(path.join(daemonDir, "daemon.stopped")));
+        assert.equal(yield* fs.exists(path.join(home, "daemon.stopped")), false);
       }),
     );
 
@@ -164,49 +170,6 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
       }),
     );
 
-    it.effect("stops every process recorded during a mixed-version conflict", () =>
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const home = yield* tempHome;
-        const a = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
-        const b = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
-        const pidA = a.pid!;
-        const pidB = b.pid!;
-        yield* Effect.addFinalizer(() =>
-          Effect.sync(() => {
-            for (const pid of [pidA, pidB]) {
-              if (pidAlive(pid)) process.kill(pid, "SIGKILL");
-            }
-          }),
-        );
-        yield* fs.makeDirectory(path.dirname(recordPath(home)), { recursive: true });
-        yield* fs.writeFileString(
-          recordPath(home),
-          JSON.stringify({
-            pid: pidA,
-            address: "http://127.0.0.1:1",
-            token: "nested",
-            startedAt: 1,
-          }),
-          { mode: 0o600 },
-        );
-        yield* fs.writeFileString(
-          path.join(home, "daemon.pid"),
-          JSON.stringify({
-            pid: pidB,
-            address: "http://127.0.0.1:2",
-            token: "legacy",
-            startedAt: 2,
-          }),
-          { mode: 0o600 },
-        );
-
-        assert.equal(yield* stopDaemon(home), "stopped");
-        assert.equal(pidAlive(pidA), false);
-        assert.equal(pidAlive(pidB), false);
-      }),
-    );
-
     it.effect("refuses to auto-respawn a daemon the user explicitly stopped", () =>
       Effect.gen(function* () {
         const home = yield* tempHome;
@@ -214,7 +177,7 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
         yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
         yield* stopDaemon(home);
         assert.ok(yield* fs.exists(path.join(home, "daemon", "daemon.stopped")));
-        assert.ok(yield* fs.exists(path.join(home, "daemon.stopped")));
+        assert.equal(yield* fs.exists(path.join(home, "daemon.stopped")), false);
 
         const error = yield* Effect.flip(resolve({ home, port: 0, autoRespawn: true }));
         assert.ok(error instanceof DaemonStoppedError);
@@ -224,21 +187,6 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
         assert.equal(restarted.reused, false);
         const attached = yield* resolve({ home, port: 0, autoRespawn: true });
         assert.equal(attached.pid, restarted.pid);
-      }),
-    );
-
-    it.effect("honors and clears a legacy root-level tombstone", () =>
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const home = yield* tempHome;
-        const legacyTombstone = path.join(home, "daemon.stopped");
-        yield* fs.writeFileString(legacyTombstone, "0", { mode: 0o600 });
-
-        const error = yield* Effect.flip(resolve({ home, port: 0, autoRespawn: true }));
-        assert.ok(error instanceof DaemonStoppedError);
-
-        yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-        assert.equal(yield* fs.exists(legacyTombstone), false);
       }),
     );
 

--- a/packages/server/test/daemon/launcher.test.ts
+++ b/packages/server/test/daemon/launcher.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import childProcess from "node:child_process";
+import path from "node:path";
 import url from "node:url";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -14,7 +15,7 @@ import {
   stopDaemon,
 } from "../../src/daemon/launcher";
 import { pidAlive } from "../../src/daemon/liveness";
-import { readRecord, writeRecord } from "../../src/daemon/record";
+import { readRecord, recordPath, writeRecord } from "../../src/daemon/record";
 
 const FAKE_SERVER = url.fileURLToPath(new URL("./fixtures/fake-server.mjs", import.meta.url));
 
@@ -47,11 +48,13 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
 
     it.effect("spawns a daemon, records it, then attaches on the next call", () =>
       Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
         const home = yield* tempHome;
         const spawned = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
         assert.equal(spawned.reused, false);
         assert.match(spawned.address, /^http:\/\/127\.0\.0\.1:\d+$/);
         assert.ok(pidAlive(spawned.pid));
+        assert.ok(yield* fs.exists(path.join(home, "daemon", "daemon.log")));
 
         const record = yield* readRecord(home);
         assert.equal(record?.pid, spawned.pid);
@@ -141,11 +144,57 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
       }),
     );
 
+    it.effect("stops every process recorded during a mixed-version conflict", () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* tempHome;
+        const a = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
+        const b = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
+        const pidA = a.pid!;
+        const pidB = b.pid!;
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            for (const pid of [pidA, pidB]) {
+              if (pidAlive(pid)) process.kill(pid, "SIGKILL");
+            }
+          }),
+        );
+        yield* fs.makeDirectory(path.dirname(recordPath(home)), { recursive: true });
+        yield* fs.writeFileString(
+          recordPath(home),
+          JSON.stringify({
+            pid: pidA,
+            address: "http://127.0.0.1:1",
+            token: "nested",
+            startedAt: 1,
+          }),
+          { mode: 0o600 },
+        );
+        yield* fs.writeFileString(
+          path.join(home, "daemon.pid"),
+          JSON.stringify({
+            pid: pidB,
+            address: "http://127.0.0.1:2",
+            token: "legacy",
+            startedAt: 2,
+          }),
+          { mode: 0o600 },
+        );
+
+        assert.equal(yield* stopDaemon(home), "stopped");
+        assert.equal(pidAlive(pidA), false);
+        assert.equal(pidAlive(pidB), false);
+      }),
+    );
+
     it.effect("refuses to auto-respawn a daemon the user explicitly stopped", () =>
       Effect.gen(function* () {
         const home = yield* tempHome;
+        const fs = yield* FileSystem.FileSystem;
         yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
         yield* stopDaemon(home);
+        assert.ok(yield* fs.exists(path.join(home, "daemon", "daemon.stopped")));
+        assert.ok(yield* fs.exists(path.join(home, "daemon.stopped")));
 
         const error = yield* Effect.flip(resolve({ home, port: 0, autoRespawn: true }));
         assert.ok(error instanceof DaemonStoppedError);
@@ -155,6 +204,21 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
         assert.equal(restarted.reused, false);
         const attached = yield* resolve({ home, port: 0, autoRespawn: true });
         assert.equal(attached.pid, restarted.pid);
+      }),
+    );
+
+    it.effect("honors and clears a legacy root-level tombstone", () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* tempHome;
+        const legacyTombstone = path.join(home, "daemon.stopped");
+        yield* fs.writeFileString(legacyTombstone, "0", { mode: 0o600 });
+
+        const error = yield* Effect.flip(resolve({ home, port: 0, autoRespawn: true }));
+        assert.ok(error instanceof DaemonStoppedError);
+
+        yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        assert.equal(yield* fs.exists(legacyTombstone), false);
       }),
     );
 

--- a/packages/server/test/daemon/launcher.test.ts
+++ b/packages/server/test/daemon/launcher.test.ts
@@ -68,6 +68,26 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
       }),
     );
 
+    it.effect("isolates lifecycle state in an explicit daemon directory", () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const home = yield* tempHome;
+        const daemonDir = path.join(home, "isolated-daemon");
+        yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(home, daemonDir)));
+
+        const spawned = yield* resolve({
+          home,
+          daemonDir,
+          port: 0,
+          readyTimeoutMs: 15_000,
+        });
+        assert.equal((yield* readRecord(home, daemonDir))?.pid, spawned.pid);
+        assert.equal(yield* readRecord(home), undefined);
+        assert.ok(yield* fs.exists(path.join(daemonDir, "daemon.log")));
+        assert.equal(yield* fs.exists(path.join(home, "daemon.pid")), false);
+      }),
+    );
+
     it.effect("reports status and stops the daemon", () =>
       Effect.gen(function* () {
         const home = yield* tempHome;

--- a/packages/server/test/daemon/launcher.test.ts
+++ b/packages/server/test/daemon/launcher.test.ts
@@ -7,6 +7,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
 import { Effect, FileSystem } from "effect";
 
+import { resolveDaemonLocation } from "../../src/config/paths";
 import { DaemonStoppedError } from "../../src/daemon/errors";
 import {
   type ResolveDaemonOptions,
@@ -34,34 +35,37 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
   "resolveOrSpawnDaemon",
   (it) => {
     /**
-     * A temp `$VIBEST_HOME` bound to the test's scope. Finalizers run LIFO, so
-     * the daemon is stopped before the directory holding its record goes away —
-     * and both happen however the test ends, which is what the old
-     * `afterEach` could only do on the happy path.
+     * A temp `$VIBEST_HOME` and the pair a front door would resolve for it —
+     * through the real resolver, so these tests never restate where the default
+     * daemon directory is (`test/paths.test.ts` owns that). Bound to the test's
+     * scope, and finalizers run LIFO, so the daemon is stopped before the
+     * directory holding its record goes away — however the test ends, which is
+     * what the old `afterEach` could only do on the happy path.
      */
     const tempHome = Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const home = yield* fs.makeTempDirectoryScoped({ prefix: "vibest-daemon-" });
-      yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(home)));
-      return home;
+      const location = resolveDaemonLocation({ VIBEST_HOME: home });
+      yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(location.daemonDir)));
+      return location;
     });
 
     it.effect("spawns a daemon, records it, then attaches on the next call", () =>
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        const home = yield* tempHome;
-        const spawned = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        const { home, daemonDir } = yield* tempHome;
+        const spawned = yield* resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 });
         assert.equal(spawned.reused, false);
         assert.match(spawned.address, /^http:\/\/127\.0\.0\.1:\d+$/);
         assert.ok(pidAlive(spawned.pid));
-        assert.ok(yield* fs.exists(path.join(home, "daemon", "daemon.log")));
+        assert.ok(yield* fs.exists(path.join(daemonDir, "daemon.log")));
 
-        const record = yield* readRecord(home);
+        const record = yield* readRecord(daemonDir);
         assert.equal(record?.pid, spawned.pid);
         assert.equal(record?.address, spawned.address);
         assert.equal(record?.token, spawned.token);
 
-        const attached = yield* resolve({ home, port: 0 });
+        const attached = yield* resolve({ home, daemonDir, port: 0 });
         assert.equal(attached.reused, true);
         assert.equal(attached.pid, spawned.pid);
         assert.equal(attached.address, spawned.address);
@@ -71,9 +75,9 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
     it.effect("isolates lifecycle state in an explicit daemon directory", () =>
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        const home = yield* tempHome;
+        const { home, daemonDir: defaultDir } = yield* tempHome;
         const daemonDir = path.join(home, "isolated-daemon");
-        yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(home, daemonDir)));
+        yield* Effect.addFinalizer(() => Effect.ignore(stopDaemon(daemonDir)));
 
         const spawned = yield* resolve({
           home,
@@ -81,14 +85,15 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
           port: 0,
           readyTimeoutMs: 15_000,
         });
-        assert.equal((yield* readRecord(home, daemonDir))?.pid, spawned.pid);
-        assert.equal(yield* readRecord(home), undefined);
+        assert.equal((yield* readRecord(daemonDir))?.pid, spawned.pid);
+        // Nothing leaks into the default directory, nor into `$VIBEST_HOME`.
+        assert.equal(yield* readRecord(defaultDir), undefined);
         assert.ok(yield* fs.exists(path.join(daemonDir, "daemon.log")));
-        assert.equal(yield* fs.exists(path.join(home, "daemon.pid")), false);
-        assert.equal(yield* fs.exists(path.join(home, "daemon.lock")), false);
-        assert.equal(yield* fs.exists(path.join(home, "daemon.stopped")), false);
+        for (const file of ["daemon.pid", "daemon.lock", "daemon.log", "daemon.stopped"]) {
+          assert.equal(yield* fs.exists(path.join(home, file)), false);
+        }
 
-        assert.equal(yield* stopDaemon(home, daemonDir), "stopped");
+        assert.equal(yield* stopDaemon(daemonDir), "stopped");
         assert.ok(yield* fs.exists(path.join(daemonDir, "daemon.stopped")));
         assert.equal(yield* fs.exists(path.join(home, "daemon.stopped")), false);
       }),
@@ -96,28 +101,28 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
 
     it.effect("reports status and stops the daemon", () =>
       Effect.gen(function* () {
-        const home = yield* tempHome;
-        const spawned = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        const { home, daemonDir } = yield* tempHome;
+        const spawned = yield* resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 });
 
-        const running = yield* statusDaemon(home);
+        const running = yield* statusDaemon(daemonDir);
         assert.equal(running.running, true);
         assert.equal(running.record?.pid, spawned.pid);
 
-        assert.equal(yield* stopDaemon(home), "stopped");
+        assert.equal(yield* stopDaemon(daemonDir), "stopped");
         assert.equal(pidAlive(spawned.pid), false);
-        assert.equal(yield* readRecord(home), undefined);
-        assert.equal((yield* statusDaemon(home)).running, false);
+        assert.equal(yield* readRecord(daemonDir), undefined);
+        assert.equal((yield* statusDaemon(daemonDir)).running, false);
       }),
     );
 
     it.effect("respawns when the recorded daemon is dead", () =>
       Effect.gen(function* () {
-        const home = yield* tempHome;
-        const first = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-        yield* stopDaemon(home);
+        const { home, daemonDir } = yield* tempHome;
+        const first = yield* resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 });
+        yield* stopDaemon(daemonDir);
         assert.equal(pidAlive(first.pid), false);
 
-        const second = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        const second = yield* resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 });
         assert.equal(second.reused, false);
         assert.notEqual(second.pid, first.pid);
         assert.ok(pidAlive(second.pid));
@@ -126,22 +131,22 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
 
     it.effect("reports not-running when stopping with no daemon", () =>
       Effect.gen(function* () {
-        const home = yield* tempHome;
-        assert.equal(yield* stopDaemon(home), "not-running");
+        const { daemonDir } = yield* tempHome;
+        assert.equal(yield* stopDaemon(daemonDir), "not-running");
       }),
     );
 
     it.effect("respawns after a crash that left the record behind", () =>
       Effect.gen(function* () {
-        const home = yield* tempHome;
-        const first = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        const { home, daemonDir } = yield* tempHome;
+        const first = yield* resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 });
 
         // Simulate a crash: kill the process without stopDaemon, so the stale
         // record (pid dead) stays and must be replaced, not attached to.
         process.kill(first.pid, "SIGKILL");
         yield* Effect.sleep("20 millis").pipe(Effect.repeat({ while: () => pidAlive(first.pid) }));
 
-        const second = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        const second = yield* resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 });
         assert.equal(second.reused, false);
         assert.notEqual(second.pid, first.pid);
         assert.ok(pidAlive(second.pid));
@@ -150,20 +155,20 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
 
     it.effect("kills a wedged daemon (pid alive, health failing) before respawning", () =>
       Effect.gen(function* () {
-        const home = yield* tempHome;
+        const { home, daemonDir } = yield* tempHome;
         // A live process that is not a server: pid answers signals, health fails.
         // Deliberately not `ChildProcessSpawner` — the launcher killing it is the
         // assertion, so it must not be tied to the test's scope.
         const wedged = childProcess.spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
         const wedgedPid = wedged.pid!;
-        yield* writeRecord(home, {
+        yield* writeRecord(daemonDir, {
           pid: wedgedPid,
           address: "http://127.0.0.1:1",
           token: "stale",
           startedAt: 0,
         });
 
-        const handle = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        const handle = yield* resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 });
         assert.equal(handle.reused, false);
         assert.equal(pidAlive(wedgedPid), false);
         assert.notEqual(handle.pid, wedgedPid);
@@ -172,31 +177,30 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
 
     it.effect("refuses to auto-respawn a daemon the user explicitly stopped", () =>
       Effect.gen(function* () {
-        const home = yield* tempHome;
+        const { home, daemonDir } = yield* tempHome;
         const fs = yield* FileSystem.FileSystem;
-        yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
-        yield* stopDaemon(home);
-        assert.ok(yield* fs.exists(path.join(home, "daemon", "daemon.stopped")));
-        assert.equal(yield* fs.exists(path.join(home, "daemon.stopped")), false);
+        yield* resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 });
+        yield* stopDaemon(daemonDir);
+        assert.ok(yield* fs.exists(path.join(daemonDir, "daemon.stopped")));
 
-        const error = yield* Effect.flip(resolve({ home, port: 0, autoRespawn: true }));
+        const error = yield* Effect.flip(resolve({ home, daemonDir, port: 0, autoRespawn: true }));
         assert.ok(error instanceof DaemonStoppedError);
 
         // An explicit start clears the tombstone; auto-respawn works again after.
-        const restarted = yield* resolve({ home, port: 0, readyTimeoutMs: 15_000 });
+        const restarted = yield* resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 });
         assert.equal(restarted.reused, false);
-        const attached = yield* resolve({ home, port: 0, autoRespawn: true });
+        const attached = yield* resolve({ home, daemonDir, port: 0, autoRespawn: true });
         assert.equal(attached.pid, restarted.pid);
       }),
     );
 
     it.effect("serializes concurrent launchers onto a single daemon", () =>
       Effect.gen(function* () {
-        const home = yield* tempHome;
+        const { home, daemonDir } = yield* tempHome;
         const [a, b] = yield* Effect.all(
           [
-            resolve({ home, port: 0, readyTimeoutMs: 15_000 }),
-            resolve({ home, port: 0, readyTimeoutMs: 15_000 }),
+            resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 }),
+            resolve({ home, daemonDir, port: 0, readyTimeoutMs: 15_000 }),
           ],
           { concurrency: 2 },
         );

--- a/packages/server/test/daemon/lock.test.ts
+++ b/packages/server/test/daemon/lock.test.ts
@@ -8,23 +8,34 @@ import { Effect, FileSystem } from "effect";
 import { releaseLock, tryAcquireLock } from "../../src/daemon/lock";
 
 layer(NodeServices.layer)("daemon lock", (it) => {
-  const tempHome = FileSystem.FileSystem.pipe(
+  const tempDaemonDir = FileSystem.FileSystem.pipe(
     Effect.flatMap((fs) => fs.makeTempDirectoryScoped({ prefix: "vibest-daemon-lock-" })),
   );
 
   it.effect("serializes launchers through the daemon directory lock", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
-      const home = yield* tempHome;
-      const lock = path.join(home, "daemon", "daemon.lock");
-      yield* fs.makeDirectory(path.dirname(lock), { recursive: true });
+      const daemonDir = yield* tempDaemonDir;
+      const lock = path.join(daemonDir, "daemon.lock");
 
-      assert.equal(yield* tryAcquireLock(home), true);
+      assert.equal(yield* tryAcquireLock(daemonDir), true);
       assert.equal(yield* fs.exists(lock), true);
-      assert.equal(yield* tryAcquireLock(home), false);
+      assert.equal(yield* tryAcquireLock(daemonDir), false);
 
-      yield* releaseLock(home);
+      yield* releaseLock(daemonDir);
       assert.equal(yield* fs.exists(lock), false);
+    }),
+  );
+
+  it.effect("locks in two daemon directories do not exclude each other", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const root = yield* tempDaemonDir;
+      const [first, second] = [path.join(root, "a"), path.join(root, "b")];
+      yield* Effect.forEach([first, second], (dir) => fs.makeDirectory(dir, { recursive: true }));
+
+      assert.equal(yield* tryAcquireLock(first), true);
+      assert.equal(yield* tryAcquireLock(second), true);
     }),
   );
 });

--- a/packages/server/test/daemon/lock.test.ts
+++ b/packages/server/test/daemon/lock.test.ts
@@ -12,26 +12,19 @@ layer(NodeServices.layer)("daemon lock", (it) => {
     Effect.flatMap((fs) => fs.makeTempDirectoryScoped({ prefix: "vibest-daemon-lock-" })),
   );
 
-  it.effect("uses the legacy root lock as the mixed-version exclusion point", () =>
+  it.effect("serializes launchers through the daemon directory lock", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const home = yield* tempHome;
-      const legacyLock = path.join(home, "daemon.lock");
-      const nestedLock = path.join(home, "daemon", "daemon.lock");
-      yield* fs.makeDirectory(path.dirname(nestedLock), { recursive: true });
-      yield* fs.writeFileString(legacyLock, String(process.pid), { mode: 0o600 });
+      const lock = path.join(home, "daemon", "daemon.lock");
+      yield* fs.makeDirectory(path.dirname(lock), { recursive: true });
 
-      assert.equal(yield* tryAcquireLock(home), false);
-      assert.equal(yield* fs.exists(nestedLock), false);
-
-      yield* fs.remove(legacyLock);
       assert.equal(yield* tryAcquireLock(home), true);
-      assert.equal(yield* fs.exists(legacyLock), true);
-      assert.equal(yield* fs.exists(nestedLock), true);
+      assert.equal(yield* fs.exists(lock), true);
+      assert.equal(yield* tryAcquireLock(home), false);
 
       yield* releaseLock(home);
-      assert.equal(yield* fs.exists(legacyLock), false);
-      assert.equal(yield* fs.exists(nestedLock), false);
+      assert.equal(yield* fs.exists(lock), false);
     }),
   );
 });

--- a/packages/server/test/daemon/lock.test.ts
+++ b/packages/server/test/daemon/lock.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { layer } from "@effect/vitest";
+import { Effect, FileSystem } from "effect";
+
+import { releaseLock, tryAcquireLock } from "../../src/daemon/lock";
+
+layer(NodeServices.layer)("daemon lock", (it) => {
+  const tempHome = FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.makeTempDirectoryScoped({ prefix: "vibest-daemon-lock-" })),
+  );
+
+  it.effect("uses the legacy root lock as the mixed-version exclusion point", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
+      const legacyLock = path.join(home, "daemon.lock");
+      const nestedLock = path.join(home, "daemon", "daemon.lock");
+      yield* fs.makeDirectory(path.dirname(nestedLock), { recursive: true });
+      yield* fs.writeFileString(legacyLock, String(process.pid), { mode: 0o600 });
+
+      assert.equal(yield* tryAcquireLock(home), false);
+      assert.equal(yield* fs.exists(nestedLock), false);
+
+      yield* fs.remove(legacyLock);
+      assert.equal(yield* tryAcquireLock(home), true);
+      assert.equal(yield* fs.exists(legacyLock), true);
+      assert.equal(yield* fs.exists(nestedLock), true);
+
+      yield* releaseLock(home);
+      assert.equal(yield* fs.exists(legacyLock), false);
+      assert.equal(yield* fs.exists(nestedLock), false);
+    }),
+  );
+});

--- a/packages/server/test/daemon/record.test.ts
+++ b/packages/server/test/daemon/record.test.ts
@@ -8,7 +8,6 @@ import { Effect, FileSystem } from "effect";
 import {
   type DaemonRecord,
   readRecord,
-  readRecords,
   recordPath,
   removeRecord,
   writeRecord,
@@ -43,7 +42,7 @@ layer(NodeServices.layer)("daemon record", (it) => {
       yield* writeRecord(home, record);
       assert.equal(recordPath(home), path.join(home, "daemon", "daemon.pid"));
       assert.ok(yield* fs.exists(recordPath(home)));
-      assert.ok(yield* fs.exists(path.join(home, "daemon.pid")));
+      assert.equal(yield* fs.exists(path.join(home, "daemon.pid")), false);
     }),
   );
 
@@ -71,46 +70,11 @@ layer(NodeServices.layer)("daemon record", (it) => {
       const home = yield* tempHome;
       yield* writeRecord(home, record);
 
-      for (const file of [recordPath(home), path.join(home, "daemon.pid")]) {
-        yield* fs.writeFileString(file, "not json");
-      }
+      yield* fs.writeFileString(recordPath(home), "not json");
       assert.equal(yield* readRecord(home), undefined);
 
-      for (const file of [recordPath(home), path.join(home, "daemon.pid")]) {
-        yield* fs.writeFileString(file, JSON.stringify({ pid: 1 }));
-      }
+      yield* fs.writeFileString(recordPath(home), JSON.stringify({ pid: 1 }));
       assert.equal(yield* readRecord(home), undefined);
-    }),
-  );
-
-  it.effect("returns divergent current and legacy records for conflict handling", () =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const home = yield* tempHome;
-      yield* writeRecord(home, record);
-      const legacyRecord: DaemonRecord = {
-        ...record,
-        pid: 9876,
-        address: "http://127.0.0.1:49876",
-      };
-      yield* fs.writeFileString(path.join(home, "daemon.pid"), JSON.stringify(legacyRecord), {
-        mode: 0o600,
-      });
-
-      assert.deepEqual(yield* readRecords(home), [record, legacyRecord]);
-    }),
-  );
-
-  it.effect("reads and removes a legacy root-level daemon.pid", () =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const home = yield* tempHome;
-      const legacyPath = path.join(home, "daemon.pid");
-      yield* fs.writeFileString(legacyPath, JSON.stringify(record), { mode: 0o600 });
-
-      assert.deepEqual(yield* readRecord(home), record);
-      yield* removeRecord(home);
-      assert.equal(yield* fs.exists(legacyPath), false);
     }),
   );
 

--- a/packages/server/test/daemon/record.test.ts
+++ b/packages/server/test/daemon/record.test.ts
@@ -5,13 +5,8 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
 import { Effect, FileSystem, PlatformError } from "effect";
 
-import {
-  type DaemonRecord,
-  readRecord,
-  recordPath,
-  removeRecord,
-  writeRecord,
-} from "../../src/daemon/record";
+import { daemonRecordPath } from "../../src/daemon/paths";
+import { type DaemonRecord, readRecord, removeRecord, writeRecord } from "../../src/daemon/record";
 
 const record: DaemonRecord = {
   pid: 4321,
@@ -21,28 +16,27 @@ const record: DaemonRecord = {
 };
 
 layer(NodeServices.layer)("daemon record", (it) => {
-  // `it.effect` bodies are scoped, so the temp home is removed when the test
-  // ends however it ends — no afterEach.
-  const tempHome = FileSystem.FileSystem.pipe(
+  // `it.effect` bodies are scoped, so the temp directory is removed when the
+  // test ends however it ends — no afterEach.
+  const tempDaemonDir = FileSystem.FileSystem.pipe(
     Effect.flatMap((fs) => fs.makeTempDirectoryScoped({ prefix: "vibest-daemon-" })),
   );
 
   it.effect("round-trips through daemon.pid", () =>
     Effect.gen(function* () {
-      const home = yield* tempHome;
-      yield* writeRecord(home, record);
-      assert.deepEqual(yield* readRecord(home), record);
+      const daemonDir = yield* tempDaemonDir;
+      yield* writeRecord(daemonDir, record);
+      assert.deepEqual(yield* readRecord(daemonDir), record);
     }),
   );
 
-  it.effect("writes daemon.pid at the expected path", () =>
+  it.effect("writes daemon.pid inside the daemon directory", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
-      const home = yield* tempHome;
-      yield* writeRecord(home, record);
-      assert.equal(recordPath(home), path.join(home, "daemon", "daemon.pid"));
-      assert.ok(yield* fs.exists(recordPath(home)));
-      assert.equal(yield* fs.exists(path.join(home, "daemon.pid")), false);
+      const daemonDir = yield* tempDaemonDir;
+      yield* writeRecord(daemonDir, record);
+      assert.equal(daemonRecordPath(daemonDir), path.join(daemonDir, "daemon.pid"));
+      assert.ok(yield* fs.exists(daemonRecordPath(daemonDir)));
     }),
   );
 
@@ -50,40 +44,39 @@ layer(NodeServices.layer)("daemon record", (it) => {
   it.effect.skipIf(process.platform === "win32")("writes daemon.pid with 0600 perms", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
-      const home = yield* tempHome;
-      yield* writeRecord(home, record);
-      const info = yield* fs.stat(recordPath(home));
+      const daemonDir = yield* tempDaemonDir;
+      yield* writeRecord(daemonDir, record);
+      const info = yield* fs.stat(daemonRecordPath(daemonDir));
       assert.equal((info.mode ?? 0) & 0o777, 0o600);
     }),
   );
 
   it.effect("returns undefined when the record is missing", () =>
     Effect.gen(function* () {
-      const home = yield* tempHome;
-      assert.equal(yield* readRecord(home), undefined);
+      const daemonDir = yield* tempDaemonDir;
+      assert.equal(yield* readRecord(daemonDir), undefined);
     }),
   );
 
   it.effect("returns undefined for a garbage or incomplete record", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
-      const home = yield* tempHome;
-      yield* writeRecord(home, record);
+      const daemonDir = yield* tempDaemonDir;
 
-      yield* fs.writeFileString(recordPath(home), "not json");
-      assert.equal(yield* readRecord(home), undefined);
+      yield* fs.writeFileString(daemonRecordPath(daemonDir), "not json");
+      assert.equal(yield* readRecord(daemonDir), undefined);
 
-      yield* fs.writeFileString(recordPath(home), JSON.stringify({ pid: 1 }));
-      assert.equal(yield* readRecord(home), undefined);
+      yield* fs.writeFileString(daemonRecordPath(daemonDir), JSON.stringify({ pid: 1 }));
+      assert.equal(yield* readRecord(daemonDir), undefined);
     }),
   );
 
   it.effect("a failed rename keeps the old record and leaves no temp file", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
-      const home = yield* tempHome;
-      yield* writeRecord(home, record);
-      const original = yield* fs.readFileString(recordPath(home));
+      const daemonDir = yield* tempDaemonDir;
+      yield* writeRecord(daemonDir, record);
+      const original = yield* fs.readFileString(daemonRecordPath(daemonDir));
       const failingRename: FileSystem.FileSystem = {
         ...fs,
         rename: () =>
@@ -96,23 +89,23 @@ layer(NodeServices.layer)("daemon record", (it) => {
           ),
       };
       const error = yield* Effect.flip(
-        writeRecord(home, { ...record, pid: 9999 }).pipe(
+        writeRecord(daemonDir, { ...record, pid: 9999 }).pipe(
           Effect.provideService(FileSystem.FileSystem, failingRename),
         ),
       );
       assert.equal(error.reason._tag, "PermissionDenied");
-      assert.equal(yield* fs.readFileString(recordPath(home)), original);
-      assert.deepEqual(yield* fs.readDirectory(path.join(home, "daemon")), ["daemon.pid"]);
+      assert.equal(yield* fs.readFileString(daemonRecordPath(daemonDir)), original);
+      assert.deepEqual(yield* fs.readDirectory(daemonDir), ["daemon.pid"]);
     }),
   );
 
   it.effect("removeRecord is a no-op when the file is already gone", () =>
     Effect.gen(function* () {
-      const home = yield* tempHome;
-      yield* removeRecord(home);
-      yield* writeRecord(home, record);
-      yield* removeRecord(home);
-      assert.equal(yield* readRecord(home), undefined);
+      const daemonDir = yield* tempDaemonDir;
+      yield* removeRecord(daemonDir);
+      yield* writeRecord(daemonDir, record);
+      yield* removeRecord(daemonDir);
+      assert.equal(yield* readRecord(daemonDir), undefined);
     }),
   );
 });

--- a/packages/server/test/daemon/record.test.ts
+++ b/packages/server/test/daemon/record.test.ts
@@ -8,6 +8,7 @@ import { Effect, FileSystem } from "effect";
 import {
   type DaemonRecord,
   readRecord,
+  readRecords,
   recordPath,
   removeRecord,
   writeRecord,
@@ -40,8 +41,9 @@ layer(NodeServices.layer)("daemon record", (it) => {
       const fs = yield* FileSystem.FileSystem;
       const home = yield* tempHome;
       yield* writeRecord(home, record);
-      assert.equal(recordPath(home), path.join(home, "daemon.pid"));
+      assert.equal(recordPath(home), path.join(home, "daemon", "daemon.pid"));
       assert.ok(yield* fs.exists(recordPath(home)));
+      assert.ok(yield* fs.exists(path.join(home, "daemon.pid")));
     }),
   );
 
@@ -67,12 +69,48 @@ layer(NodeServices.layer)("daemon record", (it) => {
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const home = yield* tempHome;
+      yield* writeRecord(home, record);
 
-      yield* fs.writeFileString(recordPath(home), "not json");
+      for (const file of [recordPath(home), path.join(home, "daemon.pid")]) {
+        yield* fs.writeFileString(file, "not json");
+      }
       assert.equal(yield* readRecord(home), undefined);
 
-      yield* fs.writeFileString(recordPath(home), JSON.stringify({ pid: 1 }));
+      for (const file of [recordPath(home), path.join(home, "daemon.pid")]) {
+        yield* fs.writeFileString(file, JSON.stringify({ pid: 1 }));
+      }
       assert.equal(yield* readRecord(home), undefined);
+    }),
+  );
+
+  it.effect("returns divergent current and legacy records for conflict handling", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
+      yield* writeRecord(home, record);
+      const legacyRecord: DaemonRecord = {
+        ...record,
+        pid: 9876,
+        address: "http://127.0.0.1:49876",
+      };
+      yield* fs.writeFileString(path.join(home, "daemon.pid"), JSON.stringify(legacyRecord), {
+        mode: 0o600,
+      });
+
+      assert.deepEqual(yield* readRecords(home), [record, legacyRecord]);
+    }),
+  );
+
+  it.effect("reads and removes a legacy root-level daemon.pid", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const home = yield* tempHome;
+      const legacyPath = path.join(home, "daemon.pid");
+      yield* fs.writeFileString(legacyPath, JSON.stringify(record), { mode: 0o600 });
+
+      assert.deepEqual(yield* readRecord(home), record);
+      yield* removeRecord(home);
+      assert.equal(yield* fs.exists(legacyPath), false);
     }),
   );
 

--- a/packages/server/test/paths.test.ts
+++ b/packages/server/test/paths.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { resolveVibestHome } from "../src/config/paths";
+import { resolveDaemonDirectory, resolveVibestHome } from "../src/config/paths";
 
 describe("resolveVibestHome", () => {
   it("prefers an explicit VIBEST_HOME over any default", () => {
@@ -20,6 +20,29 @@ describe("resolveVibestHome", () => {
   it("defaults to ~/.vibest-dev under NODE_ENV=development", () => {
     expect(resolveVibestHome({ NODE_ENV: "development" })).toBe(
       path.join(os.homedir(), ".vibest-dev"),
+    );
+  });
+});
+
+describe("resolveDaemonDirectory", () => {
+  it("prefers an explicit VIBEST_DAEMON_DIR", () => {
+    expect(
+      resolveDaemonDirectory({
+        VIBEST_HOME: "/tmp/data",
+        VIBEST_DAEMON_DIR: "/tmp/daemon-state",
+      }),
+    ).toBe("/tmp/daemon-state");
+  });
+
+  it("defaults to the daemon directory under VIBEST_HOME", () => {
+    expect(resolveDaemonDirectory({ VIBEST_HOME: "/tmp/data" })).toBe(
+      path.join("/tmp/data", "daemon"),
+    );
+  });
+
+  it("follows the development VIBEST_HOME default", () => {
+    expect(resolveDaemonDirectory({ NODE_ENV: "development" })).toBe(
+      path.join(os.homedir(), ".vibest-dev", "daemon"),
     );
   });
 });

--- a/packages/server/test/paths.test.ts
+++ b/packages/server/test/paths.test.ts
@@ -22,6 +22,11 @@ describe("resolveVibestHome", () => {
       path.join(os.homedir(), ".vibest-dev"),
     );
   });
+
+  it("treats an empty VIBEST_HOME as unset", () => {
+    expect(resolveVibestHome({ VIBEST_HOME: "" })).toBe(path.join(os.homedir(), ".vibest"));
+    expect(resolveVibestHome({ VIBEST_HOME: "   " })).toBe(path.join(os.homedir(), ".vibest"));
+  });
 });
 
 describe("resolveDaemonDirectory", () => {
@@ -43,6 +48,15 @@ describe("resolveDaemonDirectory", () => {
   it("follows the development VIBEST_HOME default", () => {
     expect(resolveDaemonDirectory({ NODE_ENV: "development" })).toBe(
       path.join(os.homedir(), ".vibest-dev", "daemon"),
+    );
+  });
+
+  it("treats an empty VIBEST_DAEMON_DIR as unset", () => {
+    expect(resolveDaemonDirectory({ VIBEST_HOME: "/tmp/data", VIBEST_DAEMON_DIR: "" })).toBe(
+      path.join("/tmp/data", "daemon"),
+    );
+    expect(resolveDaemonDirectory({ VIBEST_HOME: "/tmp/data", VIBEST_DAEMON_DIR: "  " })).toBe(
+      path.join("/tmp/data", "daemon"),
     );
   });
 });

--- a/packages/vibest/src/node/cli.ts
+++ b/packages/vibest/src/node/cli.ts
@@ -63,7 +63,15 @@ const stopHandler = () =>
 const statusHandler = () =>
   Effect.gen(function* () {
     const status = yield* statusDaemon(resolveVibestHome());
-    if (!status.running || status.record === undefined) {
+    if ("conflict" in status) {
+      console.log(
+        `multiple vibest daemons are running for this home: ${status.conflict
+          .map((record) => `${record.address} (pid ${record.pid})`)
+          .join(", ")}`,
+      );
+      return;
+    }
+    if (!status.running) {
       console.log("vibest daemon is not running");
       return;
     }

--- a/packages/vibest/src/node/cli.ts
+++ b/packages/vibest/src/node/cli.ts
@@ -3,6 +3,7 @@
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
+  resolveDaemonDirectory,
   resolveOrSpawnDaemon,
   resolveVibestHome,
   statusDaemon,
@@ -28,6 +29,11 @@ type DaemonStartInput = {
   readonly corsOrigin: ReadonlyArray<string>;
 };
 
+const daemonLocation = () => ({
+  home: resolveVibestHome(),
+  ...(process.env.VIBEST_DAEMON_DIR === undefined ? {} : { daemonDir: resolveDaemonDirectory() }),
+});
+
 // Default startup is the daemon: a short-lived `vibest` command must operate a
 // backend that outlives it, so it attaches to the running daemon or spawns one.
 const startDaemon = (input: DaemonStartInput) =>
@@ -37,7 +43,7 @@ const startDaemon = (input: DaemonStartInput) =>
     // inherited from the ambient VIBEST_CORS_ORIGINS by the spawned daemon.
     const { port } = resolveServeConfig(input);
     const handle = yield* resolveOrSpawnDaemon({
-      home: resolveVibestHome(),
+      ...daemonLocation(),
       serverArgv: serverArgv(),
       port,
     });
@@ -56,16 +62,18 @@ const startDaemon = (input: DaemonStartInput) =>
 
 const stopHandler = () =>
   Effect.gen(function* () {
-    const result = yield* stopDaemon(resolveVibestHome());
+    const { home, daemonDir } = daemonLocation();
+    const result = yield* stopDaemon(home, daemonDir);
     console.log(result === "stopped" ? "vibest daemon stopped" : "vibest daemon is not running");
   });
 
 const statusHandler = () =>
   Effect.gen(function* () {
-    const status = yield* statusDaemon(resolveVibestHome());
+    const { home, daemonDir } = daemonLocation();
+    const status = yield* statusDaemon(home, daemonDir);
     if ("conflict" in status) {
       console.log(
-        `multiple vibest daemons are running for this home: ${status.conflict
+        `multiple vibest daemons are running for this daemon directory: ${status.conflict
           .map((record) => `${record.address} (pid ${record.pid})`)
           .join(", ")}`,
       );

--- a/packages/vibest/src/node/cli.ts
+++ b/packages/vibest/src/node/cli.ts
@@ -71,14 +71,6 @@ const statusHandler = () =>
   Effect.gen(function* () {
     const { home, daemonDir } = daemonLocation();
     const status = yield* statusDaemon(home, daemonDir);
-    if ("conflict" in status) {
-      console.log(
-        `multiple vibest daemons are running for this daemon directory: ${status.conflict
-          .map((record) => `${record.address} (pid ${record.pid})`)
-          .join(", ")}`,
-      );
-      return;
-    }
     if (!status.running) {
       console.log("vibest daemon is not running");
       return;

--- a/packages/vibest/src/node/cli.ts
+++ b/packages/vibest/src/node/cli.ts
@@ -4,8 +4,8 @@ import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   resolveDaemonDirectory,
+  resolveDaemonLocation,
   resolveOrSpawnDaemon,
-  resolveVibestHome,
   statusDaemon,
   stopDaemon,
 } from "@vibest/server/daemon";
@@ -29,13 +29,11 @@ type DaemonStartInput = {
   readonly corsOrigin: ReadonlyArray<string>;
 };
 
-const daemonLocation = () => ({
-  home: resolveVibestHome(),
-  ...(process.env.VIBEST_DAEMON_DIR === undefined ? {} : { daemonDir: resolveDaemonDirectory() }),
-});
-
 // Default startup is the daemon: a short-lived `vibest` command must operate a
 // backend that outlives it, so it attaches to the running daemon or spawns one.
+// Both directories come from the ambient environment through the shared
+// resolver, which is also what `stop`/`status` and a desktop app inheriting the
+// same `VIBEST_DAEMON_DIR` use — that is what makes them address one daemon.
 const startDaemon = (input: DaemonStartInput) =>
   Effect.gen(function* () {
     // Same flag > env > default port precedence as `vibest serve`. CORS is not
@@ -43,7 +41,7 @@ const startDaemon = (input: DaemonStartInput) =>
     // inherited from the ambient VIBEST_CORS_ORIGINS by the spawned daemon.
     const { port } = resolveServeConfig(input);
     const handle = yield* resolveOrSpawnDaemon({
-      ...daemonLocation(),
+      ...resolveDaemonLocation(),
       serverArgv: serverArgv(),
       port,
     });
@@ -62,15 +60,13 @@ const startDaemon = (input: DaemonStartInput) =>
 
 const stopHandler = () =>
   Effect.gen(function* () {
-    const { home, daemonDir } = daemonLocation();
-    const result = yield* stopDaemon(home, daemonDir);
+    const result = yield* stopDaemon(resolveDaemonDirectory());
     console.log(result === "stopped" ? "vibest daemon stopped" : "vibest daemon is not running");
   });
 
 const statusHandler = () =>
   Effect.gen(function* () {
-    const { home, daemonDir } = daemonLocation();
-    const status = yield* statusDaemon(home, daemonDir);
+    const status = yield* statusDaemon(resolveDaemonDirectory());
     if (!status.running) {
       console.log("vibest daemon is not running");
       return;

--- a/packages/vibest/turbo.json
+++ b/packages/vibest/turbo.json
@@ -19,7 +19,9 @@
         "NODE_EXTRA_CA_CERTS",
         "SSL_CERT_FILE",
         "SSL_CERT_DIR",
-        "VIBEST_CLAUDE_EXECUTABLE"
+        "VIBEST_CLAUDE_EXECUTABLE",
+        "VIBEST_HOME",
+        "VIBEST_DAEMON_DIR"
       ]
     },
     "start": {
@@ -43,7 +45,9 @@
         "NODE_EXTRA_CA_CERTS",
         "SSL_CERT_FILE",
         "SSL_CERT_DIR",
-        "VIBEST_CLAUDE_EXECUTABLE"
+        "VIBEST_CLAUDE_EXECUTABLE",
+        "VIBEST_HOME",
+        "VIBEST_DAEMON_DIR"
       ]
     }
   }


### PR DESCRIPTION
## Summary

- redesign the zero-project draft state with the shared empty-state components, clearer onboarding copy, and a semantic heading
- move daemon lifecycle files under a dedicated daemon directory
- add `VIBEST_DAEMON_DIR` so daemon discovery/lifecycle state can be isolated from persistent Project and Session data in `VIBEST_HOME`
- keep pid, lock, log, and stop-tombstone state in one daemon namespace shared by CLI and Desktop
- add coverage for default/custom daemon directories, locking, spawning, stopping, tombstones, and Desktop propagation

## Configuration

```bash
VIBEST_HOME="$HOME/.vibest" \
VIBEST_DAEMON_DIR="$HOME/.vibest-daemons/my-worktree" \
vibest daemon start
```

- `VIBEST_HOME` owns Projects and Sessions.
- `VIBEST_DAEMON_DIR` owns `daemon.pid`, `daemon.log`, `daemon.lock`, and `daemon.stopped`.
- When unset, `VIBEST_DAEMON_DIR` defaults to `$VIBEST_HOME/daemon` (`~/.vibest/daemon` in production and `~/.vibest-dev/daemon` in development).
- No daemon lifecycle files are written directly under `VIBEST_HOME`.
- Legacy root-level daemon lifecycle files are intentionally not supported or migrated.

## Default layout

```text
$VIBEST_HOME/
├── daemon/
│   ├── daemon.pid
│   ├── daemon.log
│   ├── daemon.lock
│   └── daemon.stopped
└── storage/
```

## Validation

- `pnpm turbo run test --filter=@vibest/server --filter=desktop --force` — server 317 passed / 2 skipped; Desktop 43 passed
- `pnpm turbo run typecheck --filter=@vibest/server --filter=@vibest/cli --filter=desktop --force`
- Oxlint and Oxfmt checks on changed files
- React Doctor changed-file scan — 100/100
- browser verification of the empty state on desktop and mobile viewports
- isolated daemon start/status/stop smoke test confirming no lifecycle files are written directly under `VIBEST_HOME`
