### PR TITLE
fix(app): move transcript width cap inside the scroll container

### DIFF
--- a/apps/app/src/components/chat.tsx
+++ b/apps/app/src/components/chat.tsx
@@ -17,7 +17,7 @@ export function Chat({ className, sessionRef }: { className?: string; sessionRef
     <ChatSessionProvider sessionRef={sessionRef}>
       <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
         <ChatTranscript />
-        <div className="flex-shrink-0 p-2">
+        <div className="mx-auto w-full max-w-4xl min-w-80 flex-shrink-0 p-2">
           <ChatInputComposer
             toolbar={
               <>

--- a/apps/app/src/components/chat/chat-transcript.tsx
+++ b/apps/app/src/components/chat/chat-transcript.tsx
@@ -33,7 +33,9 @@ function ChatTranscriptView({
   const showEmptyNotice = snapshot.messages.length === 0 && snapshot.status === "ready";
   return (
     <Conversation>
-      <ConversationContent>
+      {/* Width cap lives here, inside the scroller, so the scrollbar stays at
+          the panel edge instead of hugging the centered column. */}
+      <ConversationContent className="mx-auto w-full max-w-4xl min-w-80">
         {showEmptyNotice && (
           <div className="text-muted-foreground mx-auto max-w-md py-12 text-center text-sm">
             Past messages can&apos;t be replayed yet. The agent still has its own context, so you

--- a/apps/app/src/routes/session/$sessionId.tsx
+++ b/apps/app/src/routes/session/$sessionId.tsx
@@ -42,5 +42,8 @@ function Component() {
   const sessionRef = Route.useLoaderData();
 
   // The shell lives in the root route; this is just the chat filling the card.
-  return <Chat className="mx-auto w-full max-w-4xl min-w-80" sessionRef={sessionRef} />;
+  // Full width on purpose: the transcript's scroll container must span the
+  // panel so its scrollbar sits at the panel edge — the reading column is
+  // centered inside the scroller, not around it.
+  return <Chat sessionRef={sessionRef} />;
 }


### PR DESCRIPTION
## Problem

On wide windows the chat transcript scrollbar rendered in the middle of the screen, hugging the centered `max-w-4xl` column instead of the panel edge (~380px of dead space to its right at 1920px). The margins outside the column were also scroll dead zones — the wheel did nothing there.

Cause: `$sessionId.tsx` put `mx-auto w-full max-w-4xl` on `<Chat>`, so the `Conversation` scroll container lived *inside* the centered 896px column.

## Fix

Let the scroll container span the panel and move the width cap inside it:

- `$sessionId.tsx` — `<Chat>` no longer carries the width cap
- `chat-transcript.tsx` — `ConversationContent` (the scroll content) gets `mx-auto w-full max-w-4xl min-w-80`
- `chat.tsx` — the composer wrapper gets the same cap so it stays aligned with the messages

## Verified

Driven in the browser at 1920×914 with an overflowing transcript: scroll container now spans the panel (right edge 1px from the panel edge, was 381px), the reading column stays centered at 896px, and the wheel scrolls from anywhere in the panel. `turbo run typecheck --filter=@vibest/app` and oxlint pass.