### PR TITLE
feat(app): add collapsible Projects sidebar group

### DIFF
--- a/apps/app/src/components/layout/app-sidebar.tsx
+++ b/apps/app/src/components/layout/app-sidebar.tsx
@@ -8,7 +8,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@vibest/ui/components/sidebar";
-import { Blocks, FolderPlus, Search, SquarePen } from "lucide-react";
+import { Blocks, Search, SquarePen } from "lucide-react";
 import { useState } from "react";
 
 import { ImportProjectDialog } from "@/components/projects/import-project-dialog";
@@ -23,7 +23,7 @@ export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
       <SidebarHeader className="h-10 [-webkit-app-region:drag]" />
 
       <SidebarContent className="[-webkit-app-region:no-drag]">
-        {/* New chat and Import project are wired; the rest are placeholders. */}
+        {/* New chat is wired; the rest are placeholders. */}
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
@@ -31,12 +31,6 @@ export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
                 <SidebarMenuButton onClick={onNewChat}>
                   <SquarePen />
                   <span>New chat</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton onClick={() => setImportOpen(true)}>
-                  <FolderPlus />
-                  <span>Import project</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>
@@ -55,7 +49,7 @@ export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        <ProjectList />
+        <ProjectList onImport={() => setImportOpen(true)} />
       </SidebarContent>
 
       {importOpen && <ImportProjectDialog onClose={() => setImportOpen(false)} />}

--- a/apps/app/src/components/projects/project-list.tsx
+++ b/apps/app/src/components/projects/project-list.tsx
@@ -1,5 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
+import {
+  Collapsible,
+  CollapsiblePanel,
+  CollapsibleTrigger,
+} from "@vibest/ui/components/collapsible";
+import {
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+} from "@vibest/ui/components/sidebar";
+import { ChevronRight, FolderPlus } from "lucide-react";
 
 import { ProjectSessionsGroup } from "@/components/projects/project-sessions-group";
 
@@ -8,7 +20,7 @@ import { ProjectSessionsGroup } from "@/components/projects/project-sessions-gro
  * ordered oldest-first so importing one appends to the bottom instead of
  * pushing the whole tree down.
  */
-export function ProjectList() {
+export function ProjectList({ onImport }: { onImport: () => void }) {
   const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
 
   // The only writer is the import dialog's create mutation, which invalidates on success.
@@ -19,10 +31,29 @@ export function ProjectList() {
   });
 
   return (
-    <>
-      {(projects.data ?? []).map((project) => (
-        <ProjectSessionsGroup key={project.id} project={project} />
-      ))}
-    </>
+    <Collapsible defaultOpen>
+      <SidebarGroup>
+        <SidebarGroupLabel
+          className="text-sidebar-foreground/70 tracking-wider"
+          render={
+            <CollapsibleTrigger className="group/projects-trigger hover:bg-sidebar-accent/70 cursor-pointer gap-1.5 pe-8" />
+          }
+        >
+          <span>Projects</span>
+          <ChevronRight className="transition-transform group-data-[panel-open]/projects-trigger:rotate-90" />
+        </SidebarGroupLabel>
+        <SidebarGroupAction onClick={onImport} title="Import project">
+          <FolderPlus />
+          <span className="sr-only">Import project</span>
+        </SidebarGroupAction>
+        <CollapsiblePanel>
+          <SidebarGroupContent className="flex flex-col gap-2">
+            {(projects.data ?? []).map((project) => (
+              <ProjectSessionsGroup key={project.id} project={project} />
+            ))}
+          </SidebarGroupContent>
+        </CollapsiblePanel>
+      </SidebarGroup>
+    </Collapsible>
   );
 }

--- a/apps/app/src/components/projects/project-sessions-group.tsx
+++ b/apps/app/src/components/projects/project-sessions-group.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams, useRouteContext } from "@tanstack/react-router";
 import type { Project } from "@vibest/contract";
 import {
-  SidebarGroup,
   SidebarGroupAction,
   SidebarGroupContent,
   SidebarGroupLabel,
@@ -31,12 +30,17 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
   });
 
   return (
-    <SidebarGroup>
+    <section className="relative min-w-0" aria-labelledby={`project-${project.id}`}>
       {/* pe-8 keeps a long name from running under the absolutely positioned action. */}
-      <SidebarGroupLabel className="min-w-0 pe-8" title={project.path}>
+      <SidebarGroupLabel
+        className="text-sidebar-accent-foreground h-7 min-w-0 pe-8 text-sm"
+        id={`project-${project.id}`}
+        title={project.path}
+      >
         <span className="truncate">{project.name}</span>
       </SidebarGroupLabel>
       <SidebarGroupAction
+        className="top-1 right-1"
         onClick={() => navigate({ to: "/draft", search: { projectId: project.id } })}
         title={`New chat in ${project.name}`}
       >
@@ -65,6 +69,6 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
           ))}
         </SidebarMenu>
       </SidebarGroupContent>
-    </SidebarGroup>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

- group imported projects under a sentence-case `Projects` header
- add an inline collapse/expand control and keep the import-project action at the far right
- refine project/session spacing and accessible project labels
- use a moderate hover treatment for the group trigger

## Verification

- `pnpm turbo run typecheck --filter=@vibest/app --force`
- `pnpm turbo run test --filter=@vibest/app --force` (27 tests)
- `npx react-doctor@latest --verbose --scope changed` (100/100)
- runtime-verified hover, collapse, and expand interactions