### PR TITLE
fix: disable dev overlays for agent runs

### DIFF
--- a/apps/app/src/app-interface.tsx
+++ b/apps/app/src/app-interface.tsx
@@ -14,25 +14,32 @@ import { usePlatform } from "./platform-context";
 import { createRouter } from "./router";
 import type { ServerConnection } from "./server-connection";
 
+declare global {
+  interface ImportMetaEnv {
+    readonly VIBEST_RUN_IN_AGENT: boolean;
+  }
+}
+
 // Dev only: hover any element and press Cmd/Ctrl+C to copy it with its React
 // component stack and source locations, for pasting into a coding agent. The
-// guard is statically false in production, so react-grab is dead-code-eliminated
-// from both the Vite and electron-vite builds. See https://react-grab.com.
+// guard is statically false in production and in dev servers launched by coding
+// agents, so react-grab is not loaded there. See https://react-grab.com.
 //
 // `/core` is the entry that doesn't auto-init, so it takes `telemetry: false` —
 // the default init fires a version check at react-grab.com, which the Electron
 // renderer's CSP blocks with a console error.
-if (import.meta.env.DEV) {
+if (import.meta.env.DEV && !import.meta.env.VIBEST_RUN_IN_AGENT) {
   void import("react-grab/core").then(({ init }) => init({ telemetry: false }));
 }
 
 // Dev only: highlights components as they re-render so you can spot wasted
 // renders. Loaded just after React (a tick later than react-scan's ideal
 // "before React" position), so it may miss the very first render but catches
-// everything after. Dead-code-eliminated from production. See https://react-scan.com.
+// everything after. Not loaded in production or agent-run dev servers. See
+// https://react-scan.com.
 // Its own version check has no opt-out and is patched out instead — see
 // `patches/react-scan@0.5.7.patch`.
-if (import.meta.env.DEV) {
+if (import.meta.env.DEV && !import.meta.env.VIBEST_RUN_IN_AGENT) {
   void import("react-scan").then(({ scan }) => scan());
 }
 

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -3,6 +3,7 @@ import url from "node:url";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
+import { isRunningFromAgent } from "agent-cli-detector";
 import { codeInspectorPlugin } from "code-inspector-plugin";
 import { defineConfig } from "vite";
 
@@ -21,8 +22,12 @@ import { defineConfig } from "vite";
  */
 const SERVER_PORT = Number(process.env.VIBEST_PORT ?? 4180);
 const serverTarget = `http://127.0.0.1:${SERVER_PORT}`;
+const RUNNING_IN_AGENT = isRunningFromAgent({ experimentalProcessTree: true });
 
 export default defineConfig({
+  define: {
+    "import.meta.env.VIBEST_RUN_IN_AGENT": JSON.stringify(RUNNING_IN_AGENT),
+  },
   server: {
     // Strict, so a taken port fails the boot instead of silently drifting to
     // the next one — that drift is how you end up reading someone else's dev

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -3,15 +3,18 @@ import url from "node:url";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
+import { isRunningFromAgent } from "agent-cli-detector";
 import { codeInspectorPlugin } from "code-inspector-plugin";
 import { defineConfig } from "electron-vite";
 import type { Plugin } from "vite";
 
-// The dev overlays (react-grab, react-scan) reach outside the origin on boot,
-// which the shipped CSP rejects with console errors on every `electron-vite dev`.
-// Production builds eliminate both overlays, so index.html stays strict and the
-// origins they need are spliced in for the dev server only. Each entry is
-// [exact substring of the shipped policy, its dev replacement].
+const RUNNING_IN_AGENT = isRunningFromAgent({ experimentalProcessTree: true });
+
+// When enabled, the dev overlays (react-grab, react-scan) reach outside the
+// origin on boot, which the shipped CSP rejects. Production eliminates both;
+// agent-run dev leaves index.html strict because neither overlay loads. Their
+// required origins are spliced in only for an interactive dev server. Each entry
+// is [exact substring of the shipped policy, its dev replacement].
 const DEV_CSP_PATCHES: ReadonlyArray<readonly [string, string]> = [
   // react-grab's overlay @imports Geist from Google Fonts inside its shadow root.
   // The stylesheet's own @font-face points at gstatic, and the strict policy has
@@ -78,11 +81,14 @@ export default defineConfig({
   },
   renderer: {
     root: url.fileURLToPath(new URL("./src/renderer/", import.meta.url)),
+    define: {
+      "import.meta.env.VIBEST_RUN_IN_AGENT": JSON.stringify(RUNNING_IN_AGENT),
+    },
     resolve: {
       alias: { "@": url.fileURLToPath(new URL("../app/src/", import.meta.url)) },
     },
     plugins: [
-      devOverlayCsp(),
+      ...(RUNNING_IN_AGENT ? [] : [devOverlayCsp()]),
       codeInspectorPlugin({ bundler: "vite" }),
       tanstackRouter({
         target: "react",

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -10,11 +10,10 @@ import type { Plugin } from "vite";
 
 const RUNNING_IN_AGENT = isRunningFromAgent({ experimentalProcessTree: true });
 
-// When enabled, the dev overlays (react-grab, react-scan) reach outside the
-// origin on boot, which the shipped CSP rejects. Production eliminates both;
-// agent-run dev leaves index.html strict because neither overlay loads. Their
-// required origins are spliced in only for an interactive dev server. Each entry
-// is [exact substring of the shipped policy, its dev replacement].
+// The dev overlays (react-grab, react-scan) reach outside the origin on boot,
+// which the shipped CSP rejects. Production eliminates both overlays, so the
+// origins they need are spliced in for the dev server only. Each entry is [exact
+// substring of the shipped policy, its dev replacement].
 const DEV_CSP_PATCHES: ReadonlyArray<readonly [string, string]> = [
   // react-grab's overlay @imports Geist from Google Fonts inside its shadow root.
   // The stylesheet's own @font-face points at gstatic, and the strict policy has
@@ -88,7 +87,7 @@ export default defineConfig({
       alias: { "@": url.fileURLToPath(new URL("../app/src/", import.meta.url)) },
     },
     plugins: [
-      ...(RUNNING_IN_AGENT ? [] : [devOverlayCsp()]),
+      devOverlayCsp(),
       codeInspectorPlugin({ bundler: "vite" }),
       tanstackRouter({
         target: "react",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
     "@types/node": "catalog:",
+    "agent-cli-detector": "^0.1.4",
     "lint-staged": "^17.1.0",
     "oxfmt": "^0.58.0",
     "oxlint": "^1.74.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      agent-cli-detector:
+        specifier: ^0.1.4
+        version: 0.1.4
       lint-staged:
         specifier: ^17.1.0
         version: 17.1.0
@@ -4431,6 +4434,11 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agent-cli-detector@0.1.4:
+    resolution: {integrity: sha512-qPgevFvpaQoBaRJVKzr8R7h1WPvV3DtbgRIQlne4le66KBzXx5hNBwo/+NTw67LgkKBlhCzksrdautpUdlls0Q==}
+    engines: {node: '>=18.18'}
+    hasBin: true
 
   agent-install@0.0.5:
     resolution: {integrity: sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==}
@@ -12404,6 +12412,8 @@ snapshots:
   acorn@8.17.0: {}
 
   agent-base@7.1.4: {}
+
+  agent-cli-detector@0.1.4: {}
 
   agent-install@0.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

- detect coding-agent execution directly in the Vite configs with `agent-cli-detector`
- expose `VIBEST_RUN_IN_AGENT` to the renderer and skip `react-scan` / `react-grab` in agent-run dev servers
- keep the Desktop renderer CSP strict when those overlays are disabled

## Verification

- `pnpm format:check`
- `pnpm lint:check`
- `pnpm exec turbo run typecheck test build --filter=@vibest/app --filter=desktop --force`
- runtime check through Turbo: `VIBEST_RUN_IN_AGENT=true`
- browser resource/network check: no `react-scan` or `react-grab` requests