### PR TITLE
fix(daemon): bound the stop wait and narrow when a daemon is replaced

### DIFF
--- a/apps/desktop/e2e/tests/desktop-rpc.spec.ts
+++ b/apps/desktop/e2e/tests/desktop-rpc.spec.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 import { type ElectronApplication, _electron as electron, type Page } from "@playwright/test";
 
-import { expect, stopE2eDaemon, test, waitForE2eDaemon } from "./fixtures.js";
+import { expect, stopE2eDaemonAndDetectLeak, test, waitForE2eDaemon } from "./fixtures.js";
 
 function appPid(electronApp: ElectronApplication): number {
   const pid = electronApp.process().pid;
@@ -208,12 +208,21 @@ test("boots the development HTTP renderer through MessagePort", async ({}, testI
   } finally {
     try {
       if (app !== undefined) {
-        await waitForE2eDaemon(vibestHome);
+        // Discarding this made a 30s discovery timeout look like an instant
+        // hit, and the stop below then ran against a daemon never found.
+        if (!(await waitForE2eDaemon(vibestHome))) {
+          console.warn(`e2e daemon never published a record (home=${vibestHome})`);
+        }
         await app.close();
       }
     } finally {
       try {
-        await stopE2eDaemon(vibestHome);
+        const leakedPid = await stopE2eDaemonAndDetectLeak(vibestHome);
+        // Warn rather than throw: this `finally` may already be unwinding the
+        // test's own failure, which must not be masked.
+        if (leakedPid !== undefined) {
+          console.warn(`e2e daemon ${leakedPid} survived teardown (home=${vibestHome})`);
+        }
       } finally {
         await new Promise<void>((resolve, reject) =>
           server.close((error) => (error ? reject(error) : resolve())),

--- a/apps/desktop/e2e/tests/fixtures.ts
+++ b/apps/desktop/e2e/tests/fixtures.ts
@@ -9,7 +9,7 @@ import {
   expect,
   test as base,
 } from "@playwright/test";
-import { readRecord, resolveDaemonLocation, stopDaemon } from "@vibest/server/daemon";
+import { pidAlive, readRecord, resolveDaemonLocation, stopDaemon } from "@vibest/server/daemon";
 import { Effect, FileSystem } from "effect";
 
 const provideFileSystem = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem>) =>
@@ -22,6 +22,21 @@ function e2eDaemonLocation(home: string) {
 export function stopE2eDaemon(home: string): Promise<"stopped" | "not-running"> {
   const { daemonDir, legacyDaemonDir } = e2eDaemonLocation(home);
   return provideFileSystem(stopDaemon(daemonDir, legacyDaemonDir));
+}
+
+/**
+ * Stop the daemon and report the pid it left running, if any.
+ *
+ * `stopDaemon`'s own answer cannot carry this: `"not-running"` is the correct
+ * result for every test that drives the server to a terminal failure, so it
+ * says nothing about whether a process survived. Reading the record first and
+ * re-checking that pid afterwards does.
+ */
+export async function stopE2eDaemonAndDetectLeak(home: string): Promise<number | undefined> {
+  const { daemonDir } = e2eDaemonLocation(home);
+  const record = await provideFileSystem(readRecord(daemonDir));
+  await stopE2eDaemon(home);
+  return record !== undefined && pidAlive(record.pid) ? record.pid : undefined;
 }
 
 export async function waitForE2eDaemon(home: string, timeoutMs = 30_000): Promise<boolean> {
@@ -107,18 +122,27 @@ export const test = base.extend<{
       },
     });
 
+    let leakedPid: number | undefined;
     try {
       await use(app);
     } finally {
-      try {
-        await waitForE2eDaemon(e2ePaths.vibestHome);
-      } finally {
-        try {
-          await app.close();
-        } finally {
-          await stopE2eDaemon(e2ePaths.vibestHome);
-        }
+      // The discovery result used to be discarded outright, so a 30s timeout
+      // was indistinguishable from an instant hit and the teardown below went
+      // on to stop a daemon it had never found.
+      const discovered = await waitForE2eDaemon(e2ePaths.vibestHome);
+      if (!discovered) {
+        console.warn(`e2e daemon never published a record (home=${e2ePaths.vibestHome})`);
       }
+      try {
+        await app.close();
+      } finally {
+        leakedPid = await stopE2eDaemonAndDetectLeak(e2ePaths.vibestHome);
+      }
+    }
+    // Only reached when the test body itself passed, so a leak can never mask
+    // the real failure.
+    if (leakedPid !== undefined) {
+      throw new Error(`e2e daemon ${leakedPid} survived teardown (home=${e2ePaths.vibestHome})`);
     }
   },
 

--- a/apps/desktop/src/main/server/daemon-server-process.ts
+++ b/apps/desktop/src/main/server/daemon-server-process.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import {
   type DaemonHandle,
   type DaemonPlatform,
@@ -55,7 +57,14 @@ export function makeDaemonServerProcess(
         const handle = yield* resolveOrSpawnDaemon({
           ...resolveDaemonLocation(config.environment),
           serverArgv: [process.execPath, config.entry],
-          launchOwnerPath: process.execPath,
+          // The server bundle, not `process.execPath`: the failure this guards
+          // against is the daemon's lazy imports resolving out of a deleted
+          // installation, and those resolve relative to the entry. Electron's
+          // own binary can outlive that entry (a hoisted or store-linked
+          // electron, ELECTRON_OVERRIDE_DIST_PATH, a packaged shell pointed at
+          // an external entry), which would leave the check green while the
+          // exact breakage it exists for still happens.
+          launchOwnerPath: path.resolve(config.entry),
           // 0 means "no preference" on the first attempt; afterwards the
           // supervisor pins the port it saw, which we pass as preferred.
           port: port === 0 ? undefined : port,

--- a/packages/server/src/daemon/errors.ts
+++ b/packages/server/src/daemon/errors.ts
@@ -13,3 +13,14 @@ export class DaemonLaunchError extends Data.TaggedError("DaemonLaunchError")<{
 export class DaemonStoppedError extends Data.TaggedError("DaemonStoppedError")<{
   readonly message: string;
 }> {}
+
+/**
+ * `stopDaemon` could not take the lifecycle locks before its deadline. Stopping
+ * has to be bounded: a launcher wedged mid-publish (or a lock leaked by a
+ * killed one) would otherwise hang `vibest daemon stop` forever with nothing to
+ * report. The tombstone is already written when this fails, so a retry after
+ * the holder releases is the whole recovery.
+ */
+export class DaemonStopError extends Data.TaggedError("DaemonStopError")<{
+  readonly message: string;
+}> {}

--- a/packages/server/src/daemon/index.ts
+++ b/packages/server/src/daemon/index.ts
@@ -4,7 +4,7 @@ export {
   resolveDaemonLocation,
   resolveVibestHome,
 } from "../config/paths";
-export { DaemonLaunchError, DaemonStoppedError } from "./errors";
+export { DaemonLaunchError, DaemonStopError, DaemonStoppedError } from "./errors";
 export {
   type DaemonHandle,
   type DaemonLauncherError,

--- a/packages/server/src/daemon/launcher.ts
+++ b/packages/server/src/daemon/launcher.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 
 import { Clock, Crypto, Effect, Encoding, FileSystem, type PlatformError } from "effect";
 
-import { DaemonLaunchError, DaemonStoppedError } from "./errors";
+import { DaemonLaunchError, DaemonStopError, DaemonStoppedError } from "./errors";
 import { daemonAlive, healthy, pidAlive } from "./liveness";
 import { lockExists, readLockPid, releaseLock, tryAcquireLock } from "./lock";
-import { daemonLogPath } from "./paths";
+import { daemonLockPath, daemonLogPath } from "./paths";
 import { reservePort } from "./port";
 import { type DaemonRecord, readRecord, removeRecord, writeRecord } from "./record";
 import { clearTombstone, hasTombstone, writeTombstone } from "./tombstone";
@@ -17,6 +17,8 @@ const READY_TIMEOUT_MS = 30_000;
 const HEALTH_POLL_INTERVAL_MS = 150;
 const STOP_GRACE_MS = 5_000;
 const LOCK_ATTEMPTS = 10;
+/** How long `stopDaemon` waits for another launcher to release its locks. */
+const STOP_LOCK_TIMEOUT_MS = 30_000;
 
 export type DaemonHandle = {
   readonly address: string;
@@ -297,9 +299,14 @@ export const statusDaemon = (
 export const stopDaemon = (
   daemonDir: string,
   legacyDaemonDir?: string,
-): Effect.Effect<"stopped" | "not-running", PlatformError.PlatformError, FileSystem.FileSystem> =>
+  /** How long to wait for another launcher's locks. Tests shorten it. */
+  lockTimeoutMs: number = STOP_LOCK_TIMEOUT_MS,
+): Effect.Effect<
+  "stopped" | "not-running",
+  PlatformError.PlatformError | DaemonStopError,
+  FileSystem.FileSystem
+> =>
   Effect.gen(function* () {
-    const directories = daemonDirectories(daemonDir, legacyDaemonDir);
     const lockDirectories = lifecycleLockDirectories(daemonDir, legacyDaemonDir);
     const fileSystem = yield* FileSystem.FileSystem;
     for (const directory of lockDirectories) {
@@ -309,47 +316,44 @@ export const stopDaemon = (
     // Signal intent before waiting: an automatic respawn holding either lock
     // observes the tombstone, while an explicit start is stopped after it
     // publishes and releases its locks.
-    yield* Effect.forEach(directories, (directory) => writeTombstone(directory), {
-      discard: true,
+    yield* writeTombstones(daemonDir, legacyDaemonDir);
+
+    const stop = Effect.gen(function* () {
+      // A compatible explicit launcher may have cleared the early signal while
+      // holding a lock. Reassert it inside the critical section so no
+      // supervision loop can resurrect the daemon after this stop completes.
+      yield* writeTombstones(daemonDir, legacyDaemonDir);
+      const records = yield* readRecords(daemonDir, legacyDaemonDir);
+      const running = records.filter(({ record }) => pidAlive(record.pid));
+      yield* killRecords(running);
+      yield* removeRecords(daemonDir, legacyDaemonDir);
+      if (running.length > 0) return "stopped" as const;
+
+      // Nothing was stopped, so leave nothing behind. Suppressing a
+      // supervisor's auto-heal is the consequence of stopping a *running*
+      // daemon; a no-op stop that tombstoned the home would refuse every later
+      // respawn until someone ran an explicit start. The early write above only
+      // had to hold a respawn off while we waited for the locks.
+      yield* clearTombstones(daemonDir, legacyDaemonDir);
+      return "not-running" as const;
     });
 
+    // Bounded, unlike the spawn path's attempt counter: a launcher wedged
+    // mid-publish holds its lock indefinitely, and an unbounded wait here turns
+    // `vibest daemon stop` into a hang with no diagnostic.
+    const deadline = (yield* Clock.currentTimeMillis) + lockTimeoutMs;
     while (true) {
-      const acquiredDirectories: string[] = [];
-      let blocked = false;
-      for (const directory of lockDirectories) {
-        const acquired = yield* tryAcquireLock(directory).pipe(
-          Effect.tapError(() => releaseLocks(acquiredDirectories)),
+      const outcome = yield* withLocks(lockDirectories, stop);
+      if (outcome !== undefined) return outcome;
+      if ((yield* Clock.currentTimeMillis) >= deadline) {
+        const locks = lockDirectories.map((directory) => daemonLockPath(directory)).join(" and ");
+        return yield* Effect.fail(
+          new DaemonStopError({
+            message: `Another launcher has held the vibest daemon lock for ${lockTimeoutMs}ms. The stop tombstone is already in place, so retry once it releases (or remove ${locks} if no launcher is running).`,
+          }),
         );
-        if (acquired) {
-          acquiredDirectories.push(directory);
-          continue;
-        }
-
-        const holder = yield* readLockPid(directory);
-        if (holder !== undefined && !pidAlive(holder)) yield* releaseLock(directory);
-        blocked = true;
-        break;
       }
-
-      if (blocked) {
-        yield* releaseLocks(acquiredDirectories);
-        yield* Effect.sleep(HEALTH_POLL_INTERVAL_MS);
-        continue;
-      }
-
-      return yield* Effect.gen(function* () {
-        // A compatible explicit launcher may have cleared the early signal
-        // while holding a lock. Reassert it inside the critical section so no
-        // supervision loop can resurrect the daemon after this stop completes.
-        yield* Effect.forEach(directories, (directory) => writeTombstone(directory), {
-          discard: true,
-        });
-        const records = yield* readRecords(daemonDir, legacyDaemonDir);
-        const running = records.filter(({ record }) => pidAlive(record.pid));
-        yield* killRecords(running);
-        yield* removeRecords(daemonDir, legacyDaemonDir);
-        return running.length === 0 ? "not-running" : "stopped";
-      }).pipe(Effect.ensuring(releaseLocks(acquiredDirectories)));
+      yield* Effect.sleep(HEALTH_POLL_INTERVAL_MS);
     }
   });
 
@@ -359,7 +363,12 @@ const launchOwnerExists = (
   const ownerPath = record.launchOwnerPath;
   if (ownerPath === undefined || !path.isAbsolute(ownerPath)) return Effect.succeed(false);
   return FileSystem.FileSystem.use((fileSystem) => fileSystem.exists(ownerPath)).pipe(
-    Effect.orElseSucceed(() => false),
+    // `exists` already answers `false` for NotFound, so the only failures left
+    // here are EACCES/EIO/ELOOP — "we could not tell", not "it is gone". A
+    // `false` from this helper kills a healthy daemon, so an unreadable path
+    // must resolve the other way: only a definitive absence is a removed
+    // installation.
+    Effect.orElseSucceed(() => true),
   );
 };
 
@@ -391,13 +400,76 @@ const lifecycleLockDirectories = (
 const launchLockDirectories = (options: ResolveDaemonOptions): ReadonlyArray<string> =>
   lifecycleLockDirectories(options.daemonDir, options.legacyDaemonDir);
 
+/**
+ * Release order is free, unlike acquisition: each lock is its own file and
+ * `releaseLock` treats a missing one as success, so nothing here can deadlock
+ * or half-release.
+ */
 const releaseLocks = (
   directories: ReadonlyArray<string>,
 ): Effect.Effect<void, never, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    for (let index = directories.length - 1; index >= 0; index -= 1) {
-      yield* releaseLock(directories[index]!);
+  Effect.forEach(directories, (directory) => releaseLock(directory), { discard: true });
+
+/**
+ * Take every lifecycle lock in `directories` (already in a stable order), run
+ * `use`, and release on every exit path — success, failure, *and interruption*.
+ *
+ * `Effect.ensuring` rather than a `tapError` on each acquisition: `tapError`
+ * only fires on the error channel, so an interrupt landing between the first
+ * and second acquisition leaked a lock whose holder pid is still alive — and a
+ * live holder is exactly the case `pidAlive` reclamation refuses to clear, so
+ * that lock never came back.
+ *
+ * Returns `undefined` without running `use` when another launcher holds one of
+ * the locks; a dead holder's lock is reclaimed first so the next attempt wins.
+ * Both callers' `use` values are non-`undefined`, which is what makes that
+ * sentinel unambiguous.
+ */
+const withLocks = <A, E, R>(
+  directories: ReadonlyArray<string>,
+  use: Effect.Effect<A, E, R>,
+): Effect.Effect<A | undefined, E | PlatformError.PlatformError, R | FileSystem.FileSystem> => {
+  const held: string[] = [];
+  return Effect.gen(function* () {
+    for (const directory of directories) {
+      if (yield* tryAcquireLock(directory)) {
+        held.push(directory);
+        continue;
+      }
+      const holder = yield* readLockPid(directory);
+      if (holder !== undefined && !pidAlive(holder)) yield* releaseLock(directory);
+      return undefined;
     }
+    return yield* use;
+  }).pipe(
+    // `splice` empties the list as it hands it over, so a finalizer that somehow
+    // runs twice cannot delete a lock another launcher has since acquired.
+    Effect.ensuring(Effect.suspend(() => releaseLocks(held.splice(0)))),
+  );
+};
+
+/**
+ * Write the stop tombstone to every layout, attempting all of them before
+ * re-raising the first failure. A fail-fast `Effect.forEach` wrote the nested
+ * directory first, so one unwritable directory aborted `stopDaemon` before it
+ * killed anything *and* before the root tombstone existed — the two halves of
+ * "leaves tombstones in both layouts" failed together.
+ */
+const writeTombstones = (
+  daemonDir: string,
+  legacyDaemonDir?: string,
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    let failure: PlatformError.PlatformError | undefined;
+    for (const directory of daemonDirectories(daemonDir, legacyDaemonDir)) {
+      yield* writeTombstone(directory).pipe(
+        Effect.catch((error) => {
+          failure ??= error;
+          return Effect.void;
+        }),
+      );
+    }
+    if (failure !== undefined) return yield* Effect.fail(failure);
   });
 
 /**
@@ -425,38 +497,18 @@ const spawnLocked = (
     const timeoutMs = options.readyTimeoutMs ?? READY_TIMEOUT_MS;
 
     for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt += 1) {
-      const acquiredDirectories: string[] = [];
-      let blocked = false;
-
-      for (const directory of directories) {
-        const acquired = yield* tryAcquireLock(directory).pipe(
-          Effect.tapError(() => releaseLocks(acquiredDirectories)),
-          Effect.mapError(
-            (cause) =>
-              new DaemonLaunchError({
+      const handle = yield* withLocks(directories, replaceOrSpawnDaemon(options)).pipe(
+        Effect.mapError((cause) =>
+          cause._tag === "DaemonLaunchError" || cause._tag === "DaemonStoppedError"
+            ? cause
+            : new DaemonLaunchError({
                 message: `Unable to acquire the vibest daemon launch lock: ${cause.message}`,
                 cause,
               }),
-          ),
-        );
-        if (acquired) {
-          acquiredDirectories.push(directory);
-          continue;
-        }
+        ),
+      );
+      if (handle !== undefined) return handle;
 
-        const holder = yield* readLockPid(directory);
-        if (holder !== undefined && !pidAlive(holder)) yield* releaseLock(directory);
-        blocked = true;
-        break;
-      }
-
-      if (!blocked) {
-        return yield* replaceOrSpawnDaemon(options).pipe(
-          Effect.ensuring(releaseLocks(acquiredDirectories)),
-        );
-      }
-
-      yield* releaseLocks(acquiredDirectories);
       // Another old or current launcher is publishing state. Wait until it
       // records a healthy daemon or releases every relevant lock, then resolve
       // again so compatibility records are reconciled under our locks.

--- a/packages/server/test/daemon/launcher.test.ts
+++ b/packages/server/test/daemon/launcher.test.ts
@@ -8,7 +8,7 @@ import { layer } from "@effect/vitest";
 import { Effect, Fiber, FileSystem } from "effect";
 
 import { resolveDaemonLocation } from "../../src/config/paths";
-import { DaemonStoppedError } from "../../src/daemon/errors";
+import { DaemonLaunchError, DaemonStopError, DaemonStoppedError } from "../../src/daemon/errors";
 import {
   type ResolveDaemonOptions,
   resolveOrSpawnDaemon,
@@ -16,7 +16,7 @@ import {
   stopDaemon,
 } from "../../src/daemon/launcher";
 import { pidAlive } from "../../src/daemon/liveness";
-import { releaseLock, tryAcquireLock } from "../../src/daemon/lock";
+import { lockExists, releaseLock, tryAcquireLock } from "../../src/daemon/lock";
 import { readRecord, writeRecord } from "../../src/daemon/record";
 import { clearTombstone, hasTombstone, writeTombstone } from "../../src/daemon/tombstone";
 
@@ -509,6 +509,100 @@ layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })(
       Effect.gen(function* () {
         const { daemonDir } = yield* tempHome;
         assert.equal(yield* stopDaemon(daemonDir), "not-running");
+      }),
+    );
+
+    it.effect("leaves no tombstone behind when there was nothing to stop", () =>
+      Effect.gen(function* () {
+        const { home, daemonDir, legacyDaemonDir } = yield* tempHome;
+        assert.equal(yield* stopDaemon(daemonDir, legacyDaemonDir), "not-running");
+        assert.equal(yield* hasTombstone(daemonDir), false);
+        if (legacyDaemonDir !== undefined) {
+          assert.equal(yield* hasTombstone(legacyDaemonDir), false);
+        }
+
+        // Vetoing auto-heal is the consequence of stopping a *running* daemon.
+        // A no-op stop that tombstoned the home would refuse every later
+        // respawn until someone ran an explicit start.
+        const respawned = yield* resolve({
+          home,
+          daemonDir,
+          legacyDaemonDir,
+          port: 0,
+          autoRespawn: true,
+          readyTimeoutMs: 15_000,
+        });
+        assert.equal(respawned.reused, false);
+      }),
+    );
+
+    it.effect("fails instead of hanging when another launcher holds the locks", () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const { daemonDir, legacyDaemonDir } = yield* tempHome;
+        yield* fs.makeDirectory(daemonDir, { recursive: true });
+        // Held by this very much alive process, so it is not reclaimable and
+        // the wait can only end on its deadline.
+        assert.equal(yield* tryAcquireLock(daemonDir), true);
+        yield* Effect.addFinalizer(() => releaseLock(daemonDir));
+
+        const error = yield* Effect.flip(stopDaemon(daemonDir, legacyDaemonDir, 300));
+        assert.ok(error instanceof DaemonStopError);
+        // The stop intent outlives the failure, so retrying is the whole recovery.
+        assert.equal(yield* hasTombstone(daemonDir), true);
+      }),
+    );
+
+    it.effect("keeps a healthy daemon whose launch owner path cannot be read", () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const { home, daemonDir } = yield* tempHome;
+        const vault = path.join(home, "vault");
+        yield* fs.makeDirectory(vault, { recursive: true });
+        const launchOwnerPath = path.join(vault, "entry.mjs");
+        yield* fs.writeFileString(launchOwnerPath, "");
+        const running = yield* resolve({
+          home,
+          daemonDir,
+          port: 0,
+          launchOwnerPath,
+          readyTimeoutMs: 15_000,
+        });
+
+        // EACCES on the owner path is "we could not tell", not "the
+        // installation is gone" — answering `false` here would SIGKILL a
+        // perfectly healthy daemon over a transient permission error.
+        yield* fs.chmod(vault, 0o000);
+        yield* Effect.addFinalizer(() => Effect.ignore(fs.chmod(vault, 0o700)));
+
+        const attached = yield* resolve({ home, daemonDir, port: 0, launchOwnerPath });
+        assert.equal(attached.reused, true);
+        assert.equal(attached.pid, running.pid);
+      }),
+    );
+
+    it.effect("releases every lifecycle lock when a launch fails", () =>
+      Effect.gen(function* () {
+        const { home, daemonDir, legacyDaemonDir } = yield* tempHome;
+        const error = yield* Effect.flip(
+          resolveOrSpawnDaemon({
+            home,
+            daemonDir,
+            legacyDaemonDir,
+            // A "server" that exits immediately: the readiness wait
+            // short-circuits on the dead pid, so this fails fast and leaves no
+            // process behind.
+            serverArgv: [process.execPath, "-e", "process.exit(1)"],
+            launchOwnerPath: FAKE_SERVER,
+            port: 0,
+            readyTimeoutMs: 2_000,
+          }),
+        );
+        assert.ok(error instanceof DaemonLaunchError);
+        assert.equal(yield* lockExists(daemonDir), false);
+        if (legacyDaemonDir !== undefined) {
+          assert.equal(yield* lockExists(legacyDaemonDir), false);
+        }
       }),
     );
 


### PR DESCRIPTION
Stacked on #175 — review follow-ups, so this targets `fix/replace-stale-dev-daemon` rather than `main`.

## Summary

- bound `stopDaemon`'s wait for the lifecycle locks and fail with a typed `DaemonStopError` instead of hanging
- write the stop tombstone to every layout even when one directory is unwritable, and leave none behind when nothing was running
- release lifecycle locks through `ensuring` so an interrupted launch cannot leak a lock held by a live pid
- treat an unreadable launch-owner path as "could not tell" rather than "removed", and record the desktop's server entry as its launch owner instead of the Electron binary
- detect a surviving daemon in E2E teardown by re-checking the recorded pid, which `stopDaemon`'s own result cannot express

## Findings addressed

| Finding | Fix |
| --- | --- |
| `stopDaemon` waited on an unbounded `while (true)`, so a launcher wedged mid-publish hung `vibest daemon stop` forever with nothing to report | 30s deadline, then `DaemonStopError`. The tombstone is already written by then, so a retry is the whole recovery. A `lockTimeoutMs` parameter lets tests shorten it. |
| The pre-kill tombstone write was a fail-fast `Effect.forEach` over the nested directory first: one unwritable directory aborted the stop before it killed anything *and* before the root tombstone existed | `writeTombstones` attempts every layout, then re-raises the first failure — so "leaves tombstones in both layouts" no longer fails in both halves at once |
| A stop that found nothing running still left tombstones, vetoing every later auto-respawn until someone ran an explicit start | Only a stop that actually killed something leaves one. The early write still holds a respawn off while we wait for the locks. |
| Lock acquisition released through `Effect.tapError`, which never fires on interruption — an interrupt between two acquisitions leaked a lock held by a live pid, which the reclaim path deliberately will not break | New `withLocks` releases through `Effect.ensuring`; `splice(0)` makes the finalizer idempotent so it cannot delete a lock another launcher has since acquired |
| `launchOwnerExists` mapped every platform error to "gone", so a transient EACCES/EIO on the owner path SIGKILLed a healthy daemon | `exists` already answers `false` for NotFound; anything left is "could not tell", which must not kill anything |
| The desktop recorded `process.execPath` (the Electron binary) as its launch owner | The breakage this guards against is the daemon's lazy imports resolving out of a deleted installation, and those resolve relative to `config.entry`. Electron's own dist can outlive that entry (hoisted or store-linked electron, `ELECTRON_OVERRIDE_DIST_PATH`, a packaged shell pointed at an external entry), leaving the check green while the exact failure still happens. |
| E2E teardown discarded both `waitForE2eDaemon` and `stopE2eDaemon` results, so a 30s discovery timeout was indistinguishable from a clean stop | Discovery timeouts warn; leaks are detected by `stopE2eDaemonAndDetectLeak`, which reads the record before the stop and re-checks that pid after |

The last one is worth calling out: `stopDaemon` returning `"not-running"` is **not** a leak signal. It is the correct answer for every test that drives the server to a terminal failure, and an earlier version of this patch that asserted on it failed `quits through Desktop RPC from the terminal failure state`. Comparing the recorded pid across the stop is the signal that actually distinguishes the two.

## New API

`DaemonStopError` (`packages/server/src/daemon/errors.ts`, re-exported from `@vibest/server/daemon`). The alternative — silently degrading to a lock-free stop on timeout — hides exactly the condition the user needs to know about.

## Tests

Four regression tests in `packages/server/test/daemon/launcher.test.ts` (341 → 345). Two were mutation-checked: reverting `orElseSucceed(() => true)` to `false` and dropping the `clearTombstones` call each fail their test.

- leaves no tombstone behind when there was nothing to stop
- fails instead of hanging when another launcher holds the locks
- keeps a healthy daemon whose launch owner path cannot be read
- releases every lifecycle lock when a launch fails

## Validation

- `pnpm check`
- `pnpm turbo run test --filter=@vibest/server --filter=desktop --force` — server 345 passed / 2 skipped, no type errors; desktop 43 passed
- `pnpm turbo run build --filter=desktop --force`
- `pnpm --dir apps/desktop e2e` — 8/8 passed
- verified no E2E server processes remained after teardown

## Not addressed

Left for #175 or a follow-up, since they need a decision rather than a fix: root-only and nested-only launchers share no lock and so cannot serialize with each other; the "temporarily mirror" compatibility path has no removal trigger; `statusDaemon` ignores `launchOwnerExists` and reports "running" for a daemon the launcher will replace.