### PR TITLE
fix(app): allow importing projects from hidden directories

### DIFF
--- a/apps/app/src/features/projects/import-project-dialog.tsx
+++ b/apps/app/src/features/projects/import-project-dialog.tsx
@@ -14,14 +14,14 @@ import {
   CommandPanel,
 } from "@vibest/ui/components/command";
 import { CornerLeftUpIcon, FolderIcon } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
-interface Entry {
-  value: string;
-  label: string;
-  kind: "up" | "dir";
-}
+import {
+  isProjectDirectoryEntryVisible,
+  type ProjectDirectoryEntry,
+  projectDirectoryEntryMatches,
+} from "./project-directory-filter";
 
 /**
  * Command-palette folder browser: drill into a folder, then import it.
@@ -37,12 +37,13 @@ export function ImportProjectDialog({
 }) {
   // null = the server's default starting point (the home directory).
   const [path, setPath] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
   const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
   const queryClient = useQueryClient();
 
   const listing = useQuery({
     ...orpcQueryUtils.fs.browse.queryOptions({
-      input: path === null ? {} : { path },
+      input: path === null ? { includeHidden: true } : { path, includeHidden: true },
     }),
     placeholderData: keepPreviousData,
     staleTime: 30_000,
@@ -55,10 +56,14 @@ export function ImportProjectDialog({
           label: d.name,
           kind: "dir" as const,
         })),
-      ] satisfies Entry[],
+      ] satisfies ProjectDirectoryEntry[],
     }),
   });
   const current = listing.data;
+  const entries = useMemo(
+    () => current?.entries.filter((entry) => isProjectDirectoryEntryVisible(entry, search)) ?? [],
+    [current?.entries, search],
+  );
 
   const importProject = useMutation({
     mutationFn: (target: string) => orpcQueryUtils.project.create.call({ path: target }),
@@ -76,16 +81,25 @@ export function ImportProjectDialog({
     <CommandDialog open onOpenChange={(open) => !open && onClose()}>
       <CommandDialogPopup>
         {/* Remount on navigation so the search text and highlight reset. */}
-        <Command items={current?.entries ?? []} key={current?.path ?? "loading"}>
-          <CommandInput placeholder="Search folders..." />
+        <Command
+          filter={projectDirectoryEntryMatches}
+          items={entries}
+          key={current?.path ?? "loading"}
+          onValueChange={setSearch}
+          value={search}
+        >
+          <CommandInput placeholder="Search folders or enter a full path..." />
           <CommandPanel>
             <CommandEmpty>{listing.isPending ? "Loading..." : "No folders found."}</CommandEmpty>
             <CommandList>
-              {(item: Entry) => (
+              {(item: ProjectDirectoryEntry) => (
                 <CommandItem
                   className="gap-2"
                   key={item.value}
-                  onClick={() => setPath(item.value)}
+                  onClick={() => {
+                    setPath(item.value);
+                    setSearch("");
+                  }}
                   value={item.value}
                 >
                   {item.kind === "up" ? (

--- a/apps/app/src/features/projects/project-directory-filter.test.ts
+++ b/apps/app/src/features/projects/project-directory-filter.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isProjectDirectoryEntryVisible,
+  type ProjectDirectoryEntry,
+  projectDirectoryEntryMatches,
+} from "./project-directory-filter";
+
+const hidden: ProjectDirectoryEntry = {
+  value: "/Users/dinq/.herdr",
+  label: ".herdr",
+  kind: "dir",
+};
+
+const regular: ProjectDirectoryEntry = {
+  value: "/Users/dinq/Code",
+  label: "Code",
+  kind: "dir",
+};
+
+describe("project directory filter", () => {
+  it("hides dotfolders until the search starts with a dot", () => {
+    expect(isProjectDirectoryEntryVisible(hidden, "")).toBe(false);
+    expect(isProjectDirectoryEntryVisible(hidden, "herdr")).toBe(false);
+    expect(isProjectDirectoryEntryVisible(hidden, ".")).toBe(true);
+    expect(isProjectDirectoryEntryVisible(hidden, ".her")).toBe(true);
+    expect(isProjectDirectoryEntryVisible(regular, "")).toBe(true);
+  });
+
+  it("reveals and matches a dotfolder searched by its full path", () => {
+    expect(isProjectDirectoryEntryVisible(hidden, hidden.value)).toBe(true);
+    expect(isProjectDirectoryEntryVisible(hidden, `${hidden.value}/`)).toBe(true);
+    expect(projectDirectoryEntryMatches(hidden, hidden.value)).toBe(true);
+    expect(projectDirectoryEntryMatches(hidden, `${hidden.value}/`)).toBe(true);
+  });
+});

--- a/apps/app/src/features/projects/project-directory-filter.ts
+++ b/apps/app/src/features/projects/project-directory-filter.ts
@@ -1,0 +1,40 @@
+export interface ProjectDirectoryEntry {
+  value: string;
+  label: string;
+  kind: "up" | "dir";
+}
+
+const withoutTrailingSeparators = (value: string) => value.replace(/[\\/]+$/, "");
+
+const isExactPathSearch = (entry: ProjectDirectoryEntry, search: string): boolean =>
+  withoutTrailingSeparators(entry.value) === withoutTrailingSeparators(search);
+
+export const isProjectDirectoryEntryVisible = (
+  entry: ProjectDirectoryEntry,
+  search: string,
+): boolean =>
+  entry.kind !== "dir" ||
+  !entry.label.startsWith(".") ||
+  search.startsWith(".") ||
+  isExactPathSearch(entry, search);
+
+export const projectDirectoryEntryMatches = (entry: unknown, search: string): boolean => {
+  if (
+    typeof entry !== "object" ||
+    entry === null ||
+    !("label" in entry) ||
+    typeof entry.label !== "string" ||
+    !("value" in entry) ||
+    typeof entry.value !== "string"
+  ) {
+    return false;
+  }
+
+  const query = withoutTrailingSeparators(search).toLocaleLowerCase();
+  if (query.length === 0) return true;
+
+  return (
+    entry.label.toLocaleLowerCase().includes(query) ||
+    withoutTrailingSeparators(entry.value).toLocaleLowerCase().includes(query)
+  );
+};

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -575,6 +575,7 @@ export type DirectoryEntry = typeof DirectoryEntrySchema.Type;
 
 export const BrowseInputSchema = Schema.Struct({
   path: Schema.optionalKey(Schema.String),
+  includeHidden: Schema.optionalKey(Schema.Boolean),
 });
 export const BrowseResultSchema = Schema.Struct({
   path: Schema.String,

--- a/packages/contract/src/fs.ts
+++ b/packages/contract/src/fs.ts
@@ -36,7 +36,7 @@ export const fsContract = {
     .input(toStandardSchema(CwdPathInput))
     .errors(readErrors)
     .output(type<string>()),
-  /** Browse immediate subdirectories of `path` (default: the home directory). */
+  /** Browse immediate subdirectories of `path` (default: the home directory). Hidden directories are opt-in. */
   browse: oc
     .input(toStandardSchema(BrowseInputSchema))
     .errors({ READ_FAILED: { data: pathData } })

--- a/packages/server/src/rpc/fs.ts
+++ b/packages/server/src/rpc/fs.ts
@@ -39,11 +39,14 @@ export const fsRouter = orpc.router({
     // Resolving and joining are pure string math, so they stay on `node:path`.
     const dir = path.resolve(input.path ?? os.homedir());
     // Folder-picker policy (owned here, not a shared fs service): directories
-    // only, hide dotfolders and node_modules, sorted by name.
+    // only, hide dotfolders unless requested, always hide node_modules, and
+    // sort by name.
     const names = yield* fs
       .readDirectory(dir)
       .pipe(Effect.mapError(() => errors.READ_FAILED({ data: { path: dir } })));
-    const candidates = names.filter((name) => !name.startsWith(".") && !IGNORED_DIRS.has(name));
+    const candidates = names.filter(
+      (name) => (input.includeHidden || !name.startsWith(".")) && !IGNORED_DIRS.has(name),
+    );
     // readDirectory yields names only, so stat each to keep just directories. A
     // failing stat (e.g. broken symlink) drops that entry rather than the list.
     const flagged = yield* Effect.forEach(

--- a/packages/server/test/rpc-fs.test.ts
+++ b/packages/server/test/rpc-fs.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import { makeRpcTestHarness } from "./rpc-harness";
 
 describe("fs router", () => {
-  it("browses sorted subdirectories with parent, hiding dotfolders and node_modules", async () => {
+  it("browses sorted subdirectories with parent, including dotfolders only when requested", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-home-"));
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vibest-browse-"));
     fs.mkdirSync(path.join(dir, "beta"));
@@ -20,6 +20,13 @@ describe("fs router", () => {
       expect(listing.path).toBe(dir);
       expect(listing.parent).toBe(path.dirname(dir));
       expect(listing.directories).toEqual([
+        { name: "alpha", path: path.join(dir, "alpha") },
+        { name: "beta", path: path.join(dir, "beta") },
+      ]);
+
+      const listingWithHidden = await h.client.fs.browse({ path: dir, includeHidden: true });
+      expect(listingWithHidden.directories).toEqual([
+        { name: ".hidden", path: path.join(dir, ".hidden") },
         { name: "alpha", path: path.join(dir, "alpha") },
         { name: "beta", path: path.join(dir, "beta") },
       ]);


### PR DESCRIPTION
## Summary

- add an opt-in `includeHidden` flag to `fs.browse` while continuing to exclude `node_modules`
- keep dotfolders hidden in the Project import dialog by default, reveal them when the search starts with `.`, and allow an exact full path to match a hidden directory
- add regression coverage for the RPC policy and Project directory filtering

## Verification

- `pnpm check`
- `pnpm test`
- runtime verification against the Vite app and local API server
  - default Project import listing hides dotfolders
  - searching `.` reveals dotfolders
  - entering `/Users/dinq/.herdr` selects the hidden directory
  - navigation reaches worktrees under `.herdr/worktrees/vibest`

## Recording

[Play the Project import demo (MP4)](https://fileout.iamdin.workers.dev/f/4fGQKkFk)

> The temporary recording link expires on 2026-08-11.
