### PR TITLE
ci: run trusted pull requests on rn runner

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,10 +6,18 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    # Pull request events still appear in Actions for other authors, but the job
+    # is skipped before GitHub assigns it to the self-hosted runner.
+    if: >-
+      github.event_name == 'push' ||
+      contains(fromJSON(vars.TRUSTED_PR_AUTHORS || '[]'), github.event.pull_request.user.login)
+    runs-on: [self-hosted, Linux, X64, rn, vibest]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -27,7 +27,12 @@ concurrency:
 
 jobs:
   react-doctor:
-    runs-on: ubuntu-latest
+    # Pull request events still appear in Actions for other authors, but the job
+    # is skipped before GitHub assigns it to the self-hosted runner.
+    if: >-
+      github.event_name == 'push' ||
+      contains(fromJSON(vars.TRUSTED_PR_AUTHORS || '[]'), github.event.pull_request.user.login)
+    runs-on: [self-hosted, Linux, X64, rn, vibest]
     steps:
       # fetch-depth: 0 gives React Doctor the full git history it needs to find the merge base with the target branch. Without it a shallow checkout has no merge base, so PR runs can't compare against the base and fall back to reporting every issue in the changed files (pre-existing ones included) instead of only the ones the PR introduced.
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

- route Code check and React Doctor to the dedicated `rn-vibest-01` self-hosted runner
- skip PR jobs unless the author is listed in `TRUSTED_PR_AUTHORS`
- keep push-to-main checks enabled
- give Code check an explicit read-only token

## Repository configuration

- `TRUSTED_PR_AUTHORS=["iamdin","oxwen11"]`
- external fork PR runs require approval every time

## Validation

- YAML parsed successfully
- oxfmt check passed
- actionlint passed with the registered custom labels acknowledged
- this PR exercises both workflows on the new runner