### PR TITLE
ci: align runner with project toolchain

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - rn
+    - vibest
+    - ubuntu-24.04

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CI: "true"
+
 jobs:
   check:
     name: Check
@@ -17,19 +20,49 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       contains(fromJSON(vars.TRUSTED_PR_AUTHORS || '[]'), github.event.pull_request.user.login)
-    runs-on: [self-hosted, Linux, X64, rn, vibest]
+    runs-on: [self-hosted, Linux, X64, ubuntu-24.04, rn, vibest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - name: Enable corepack
-        run: corepack enable
-        shell: bash
-
-      - name: Setup Node & Pnpm
-        uses: actions/setup-node@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".node-version"
-          cache: pnpm
+          architecture: x64
+          package-manager-cache: false
+
+      # Activate the exact pnpm release (including its integrity hash) declared
+      # by package.json, after setup-node has selected the project's Node 24.
+      - name: Activate project package manager
+        run: |
+          corepack enable
+          corepack install
+        shell: bash
+
+      - name: Verify CI environment
+        run: |
+          source /etc/os-release
+          test "$ID" = "ubuntu"
+          test "$VERSION_ID" = "24.04"
+          test "$(uname -m)" = "x86_64"
+
+          expected_node="$(tr -d '[:space:]' < .node-version)"
+          actual_node="$(node --version)"
+          actual_node="${actual_node#v}"
+          case "$actual_node" in
+            "$expected_node" | "$expected_node".*) ;;
+            *) echo "Expected Node $expected_node.x, got $actual_node" >&2; exit 1 ;;
+          esac
+
+          expected_pnpm="$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")"
+          actual_pnpm="$(pnpm --version)"
+          test "$actual_pnpm" = "$expected_pnpm"
+
+          printf 'Ubuntu %s, Node %s, pnpm %s, %s\n' \
+            "$VERSION_ID" "$actual_node" "$actual_pnpm" "$(uname -m)"
+        shell: bash
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -20,6 +20,9 @@ permissions:
   issues: write
   statuses: write
 
+env:
+  CI: "true"
+
 # Cancels any in-flight scan for the same PR (or branch, on push) the moment a new commit arrives, so reviewers only ever see the latest run.
 concurrency:
   group: react-doctor-${{ github.event.pull_request.number || github.ref }}
@@ -32,20 +35,27 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       contains(fromJSON(vars.TRUSTED_PR_AUTHORS || '[]'), github.event.pull_request.user.login)
-    runs-on: [self-hosted, Linux, X64, rn, vibest]
+    runs-on: [self-hosted, Linux, X64, ubuntu-24.04, rn, vibest]
     steps:
       # fetch-depth: 0 gives React Doctor the full git history it needs to find the merge base with the target branch. Without it a shallow checkout has no merge base, so PR runs can't compare against the base and fall back to reporting every issue in the changed files (pre-existing ones included) instead of only the ones the PR introduced.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: millionco/react-doctor@v2
+      - name: Read project Node version
+        id: project-node
+        run: echo "version=$(tr -d '[:space:]' < .node-version)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - uses: millionco/react-doctor@01820bb4fd4d0a4aebcd8df2b2a143a098649cb2 # v2.2.8
         # The repo is error-clean as of the react-doctor integration, so the gate
         # is armed: any new error-severity finding fails the check. Warnings stay
         # advisory — there are ~115 of them left to work through, and blocking on
         # them today would red-X every PR.
         # Full reference: https://www.react.doctor/ci
         with:
+          node-version: ${{ steps.project-node.outputs.version }}
           blocking: error
           scope: full
           # Everything except @vibest/ui. Its base components are vendored


### PR DESCRIPTION
## Summary

- upgrade checkout to v7.0.1 and setup-node to v7.0.0, pinned by commit SHA
- pin React Doctor to the latest v2.2.8 commit
- select Node from `.node-version` before activating Corepack
- activate the integrity-pinned pnpm version from `package.json#packageManager`
- verify Ubuntu 24.04, x86_64, Node 24, and pnpm 11.15.1 during CI
- pass the project Node version into React Doctor
- disable package-manager auto-cache and checkout credential persistence
- add actionlint metadata for the self-hosted runner labels

## Runner configuration

The `rn-vibest-01` runner now also has the `ubuntu-24.04` label.

## Local validation

- actionlint
- oxfmt check
- Ruby YAML parser
- git diff --check