### PR TITLE
feat(app): collapsible project groups with Folder/FolderOpen icon

### DIFF
--- a/apps/app/src/features/projects/project-sessions-group.tsx
+++ b/apps/app/src/features/projects/project-sessions-group.tsx
@@ -1,6 +1,11 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
 import type { Project } from "@vibest/contract";
 import {
+  Collapsible,
+  CollapsiblePanel,
+  CollapsibleTrigger,
+} from "@vibest/ui/components/collapsible";
+import {
   SidebarGroupAction,
   SidebarGroupContent,
   SidebarGroupLabel,
@@ -8,12 +13,14 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@vibest/ui/components/sidebar";
-import { SquarePen } from "lucide-react";
+import { Folder, FolderOpen, SquarePen } from "lucide-react";
 
 import { useProjectSessions } from "@/features/projects/use-project-sessions";
 
 /**
- * One project and the sessions under it, as a sidebar group. Fetching lives in
+ * One project and the sessions under it, as a collapsible sidebar group. The
+ * label is its own collapse trigger; a Folder icon swaps to FolderOpen when the
+ * panel is open (two icon entities, not a rotation). Fetching lives in
  * `useProjectSessions`; how a row looks and what a click does are this
  * component's own business.
  */
@@ -24,57 +31,63 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
   const sessions = useProjectSessions(project.id);
 
   return (
-    <section className="relative min-w-0" aria-labelledby={`project-${project.id}`}>
-      {/* pe-8 keeps a long name from running under the absolutely positioned action. */}
-      <SidebarGroupLabel
-        className="text-sidebar-accent-foreground h-7 min-w-0 pe-8 text-sm"
-        id={`project-${project.id}`}
-        title={project.path}
-      >
-        <span className="truncate">{project.name}</span>
-      </SidebarGroupLabel>
-      <SidebarGroupAction
-        className="top-1 right-1"
-        onClick={() => navigate({ to: "/draft", search: { projectId: project.id } })}
-        title={`New chat in ${project.name}`}
-      >
-        <SquarePen />
-        {/* Names the button per project: element content wins over `title` in the
-            accessible-name computation, so a bare "New chat" would make every
-            project's action announce identically. */}
-        <span className="sr-only">New chat in {project.name}</span>
-      </SidebarGroupAction>
-      <SidebarGroupContent>
-        <SidebarMenu>
-          {sessions.map((session) => (
-            <SidebarMenuItem key={session.sessionId}>
-              <SidebarMenuButton
-                isActive={session.sessionId === activeSessionId}
-                // The whole ref rides along so the route can resume directly.
-                onClick={() =>
-                  navigate({
-                    to: "/session/$sessionId",
-                    params: { sessionId: session.sessionId },
-                    search: { projectId: session.projectId, harness: session.harnessAgentId },
-                  })
-                }
-              >
-                <span className="truncate">{session.title ?? "New chat"}</span>
-                {/* Busy elsewhere too: status is server-derived, so a turn any
-                    client is running shows here. requires_action keeps the
-                    turn open, so it counts as busy. */}
-                {(session.status?.phase === "running" ||
-                  session.status?.phase === "requires_action") && (
-                  <span
-                    className="ms-auto size-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
-                    title="A turn is running in this session"
-                  />
-                )}
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
-        </SidebarMenu>
-      </SidebarGroupContent>
-    </section>
+    <Collapsible defaultOpen>
+      <section className="relative min-w-0" aria-labelledby={`project-${project.id}`}>
+        {/* pe-8 keeps a long name from running under the absolutely positioned action. */}
+        <SidebarGroupLabel
+          className="text-sidebar-accent-foreground h-7 min-w-0 pe-8 text-sm"
+          id={`project-${project.id}`}
+          title={project.path}
+          render={
+            <CollapsibleTrigger className="group/project hover:bg-sidebar-accent/70 cursor-pointer gap-1.5" />
+          }
+        >
+          {/* Folder closed → FolderOpen when the panel expands. */}
+          <Folder className="size-4 shrink-0 group-data-[panel-open]/project:hidden" />
+          <FolderOpen className="hidden size-4 shrink-0 group-data-[panel-open]/project:block" />
+          <span className="truncate">{project.name}</span>
+        </SidebarGroupLabel>
+        <SidebarGroupAction
+          className="top-1 right-1"
+          onClick={() => navigate({ to: "/draft", search: { projectId: project.id } })}
+          title={`New chat in ${project.name}`}
+        >
+          <SquarePen />
+          {/* Names the button per project: element content wins over `title` in the accessible-name computation, so a bare "New chat" would make every project's action announce identically. */}
+          <span className="sr-only">New chat in {project.name}</span>
+        </SidebarGroupAction>
+        <CollapsiblePanel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {sessions.map((session) => (
+                <SidebarMenuItem key={session.sessionId}>
+                  <SidebarMenuButton
+                    isActive={session.sessionId === activeSessionId}
+                    // The whole ref rides along so the route can resume directly.
+                    onClick={() =>
+                      navigate({
+                        to: "/session/$sessionId",
+                        params: { sessionId: session.sessionId },
+                        search: { projectId: session.projectId, harness: session.harnessAgentId },
+                      })
+                    }
+                  >
+                    <span className="truncate">{session.title ?? "New chat"}</span>
+                    {/* Busy elsewhere too: status is server-derived, so a turn any client is running shows here. requires_action keeps the turn open, so it counts as busy. */}
+                    {(session.status?.phase === "running" ||
+                      session.status?.phase === "requires_action") && (
+                      <span
+                        className="ms-auto size-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
+                        title="A turn is running in this session"
+                      />
+                    )}
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </CollapsiblePanel>
+      </section>
+    </Collapsible>
   );
 }


### PR DESCRIPTION
## What
Session List 里每个 Project 行变成可折叠分组:点击 Project 名展开/收起其下的 sessions,并加了一个 Folder 图标——展开时切换为 FolderOpen(两个 lucide 图标实体,非旋转)。

## Why
project / session 多时,需要收起不常用的 project 来整理侧栏。

## How
- `project-sessions-group.tsx` 外层包 `<Collapsible defaultOpen>`;`SidebarGroupLabel` 用 `render={<CollapsibleTrigger/>}` 变成整行可点的 trigger。
- 图标切换靠 Base UI 的 `data-panel-open` + `group-data-[panel-open]/project:{hidden,block}`(同 `tool.tsx` 已有范式)。
- 默认全展开、不持久化(非受控,符合 `frontend-state.md` 的 "derive, don't sync")。

## Verification
typecheck + lint + build 全绿;运行时 DOM 验证:点击后 `aria-expanded` true→false、svg display `[none,block]`→`[block,none]`、panel 高 824px→0。