### PR TITLE
docs(claude): add squash-merge policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,13 @@ outside their hash inputs. `pnpm clean` runs `git clean -xdf`.
 `apps/desktop/src` has its own layering contract in `apps/desktop/AGENTS.md` —
 read it before touching that app.
 
+## Pull requests
+
+Use **squash merge** — one commit per PR keeps `main` readable. Don't mix
+merge-commit / rebase merges in the repo. Squash rewrites the branch tip out
+of `main`'s history, so deleting the local feature branch needs `git branch -D`
+— the changes are already on `main`, so it's safe.
+
 ## Going deeper
 
 - `CONTEXT.md` — glossary. Read it before naming anything in the session domain;


### PR DESCRIPTION
## What
把仓库的合并约定写进 `CLAUDE.md`(新增 `## Pull requests` section)。

## Content
- 统一用 **squash merge**(一 PR 一 commit,`main` 干净)。
- 不在仓库内混用 merge-commit / rebase。
- squash 后本地 feature 分支 tip 不在 `main` 历史,删本地分支用 `git branch -D`(改动已在 main,安全)。

## Why
codify 现状(history 清一色 squash),并提前说明 `-D` 这个小副作用,免得每次删分支都困惑。