### PR TITLE
fix(app): surface provider stream errors

### DIFF
--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -37,6 +37,7 @@ class FakeTransport implements ChatSessionTransport {
   historyGate: Promise<void> | null = null;
   getMessagesCalls = 0;
   promptCalls: Array<{ messageId: string; parts: ReadonlyArray<PromptPart> }> = [];
+  promptError: unknown = null;
   responded: Array<{ requestId: string; response: AgentResponse }> = [];
 
   subscribe(onEvent: (event: ChatTransportEvent) => void): () => void {
@@ -47,6 +48,7 @@ class FakeTransport implements ChatSessionTransport {
   }
   prompt = async (input: { messageId: string; parts: ReadonlyArray<PromptPart> }) => {
     this.promptCalls.push(input);
+    if (this.promptError) throw this.promptError;
     return { turnId: "turn-receipt" };
   };
   getMessages = async () => {
@@ -352,6 +354,118 @@ describe("Chat prompting", () => {
     expect(messages).toHaveLength(2);
     expect(assistantText(messages[1]!)).toBe("reply");
     expect(chat.store.getState().status).toBe("ready");
+  });
+});
+
+describe("Chat stream errors", () => {
+  it("surfaces the exact live provider error after the turn settles", async () => {
+    const { chat, transport, attach, live } = makeChat();
+    const providerError = "429: 已达到 5 小时的使用上限。";
+    await attach({});
+
+    live(1, { type: "session.turn.started", turnId: "turn-1", phase: "running" });
+    live(2, {
+      type: "session.message.chunk",
+      turnId: "turn-1",
+      chunk: { type: "error", errorText: providerError },
+    });
+    // Pi currently follows the error chunk with finish, which the adapter
+    // reports as a completed turn. Visibility must not depend on the outcome.
+    live(3, { type: "session.turn.ended", turnId: "turn-1", outcome: "completed", phase: "idle" });
+    await settle();
+
+    expect(chat.store.getState().error?.message).toBe(providerError);
+    expect(chat.store.getState().status).toBe("ready");
+
+    await chat.prompt("retry");
+    expect(chat.store.getState().error).toBeUndefined();
+    expect(chat.store.getState().status).toBe("submitted");
+    expect(transport.promptCalls.at(-1)?.parts).toEqual([{ type: "text", text: "retry" }]);
+  });
+
+  it("restores an unseen provider error after its retained prompt boundary", async () => {
+    const { chat, attach } = makeChat();
+    const providerError = "Connection error.";
+    await attach({ cursor: 1 });
+
+    await attach({
+      status: { phase: "idle" },
+      activePrompt: { messageId: "prompt-1", parts: [{ type: "text", text: "go" }], seq: 2 },
+      activeTurn: activeTurn({
+        turnId: "turn-1",
+        chunks: [
+          chunkEvent(3, "turn-1", {
+            type: "error",
+            errorText: providerError,
+          }),
+        ],
+        complete: true,
+      }),
+      cursor: 4,
+    });
+
+    expect(chat.store.getState().error?.message).toBe(providerError);
+  });
+
+  it("lets a newer retained prompt clear an older completed-turn error", async () => {
+    const { chat, attach } = makeChat();
+    await attach({});
+    chat.store.setState({ error: new Error("older local failure") });
+
+    await attach({
+      status: { phase: "idle" },
+      activePrompt: {
+        messageId: "prompt-new",
+        parts: [{ type: "text", text: "try again" }],
+        seq: 4,
+      },
+      activeTurn: activeTurn({
+        turnId: "turn-old",
+        chunks: [chunkEvent(2, "turn-old", { type: "error", errorText: "old provider error" })],
+        complete: true,
+      }),
+      cursor: 4,
+    });
+
+    expect(chat.store.getState().error).toBeUndefined();
+    expect(chat.store.getState().messages.at(-1)?.id).toBe("prompt-new");
+  });
+
+  it("clears a stale error for unseen broadcast and retained prompts", async () => {
+    const { chat, attach, live } = makeChat();
+    await attach({});
+    chat.store.setState({ error: new Error("old failure") });
+
+    live(1, {
+      type: "session.prompt.submitted",
+      messageId: "remote-1",
+      parts: [{ type: "text", text: "remote" }],
+      phase: "idle",
+    });
+    expect(chat.store.getState().error).toBeUndefined();
+
+    chat.store.setState({ error: new Error("another old failure") });
+    await attach({
+      status: { phase: "running" },
+      activePrompt: { messageId: "remote-2", parts: [{ type: "text", text: "retained" }], seq: 2 },
+      activeTurn: activeTurn({ turnId: "turn-2", chunks: [] }),
+      cursor: 3,
+    });
+    expect(chat.store.getState().error).toBeUndefined();
+  });
+
+  it("does not let a delayed self-echo clear a prompt RPC failure", async () => {
+    const { chat, transport, attach, live } = makeChat();
+    const promptError = new Error("Prompt RPC failed");
+    await attach({});
+    transport.promptError = promptError;
+
+    await expect(chat.prompt("go")).rejects.toThrow(promptError);
+    const { messageId, parts } = transport.promptCalls[0]!;
+    expect(chat.store.getState().error?.message).toBe(promptError.message);
+
+    live(1, { type: "session.prompt.submitted", messageId, parts, phase: "idle" });
+    expect(chat.store.getState().error?.message).toBe(promptError.message);
   });
 });
 

--- a/apps/app/src/features/chat/runtime/chat.ts
+++ b/apps/app/src/features/chat/runtime/chat.ts
@@ -3,6 +3,7 @@ import type {
   PermissionMode,
   PromptPart,
   ReasoningEffort,
+  SessionMessageChunkEvent,
   SessionPhase,
   SessionRef,
   SessionRuntimeSnapshot,
@@ -128,6 +129,7 @@ export class Chat {
     this.#cursor = event.seq;
     switch (event.type) {
       case "session.message.chunk":
+        this.#captureChunkError(event.chunk);
         if (!this.#recoverTurnIds.has(event.turnId)) {
           if (event.chunk.type === "error") this.#erroredTurnIds.add(event.turnId);
           this.#turnFold(event.turnId).enqueue(event.chunk);
@@ -137,7 +139,10 @@ export class Chat {
       // optimistic message already carries the same id, making the append a
       // no-op.
       case "session.prompt.submitted":
-        this.#pushUserMessage(event.messageId, event.parts);
+        // The sender already cleared its stale error synchronously in prompt().
+        // Only a genuinely unseen prompt may clear here: a delayed self-echo
+        // must not erase a newer prompt RPC failure.
+        if (this.#pushUserMessage(event.messageId, event.parts)) this.#state.error = undefined;
         break;
       // The harness rejected a prompt whose submitted event already broadcast:
       // drop the phantom user message (the sender's optimistic copy included).
@@ -292,11 +297,36 @@ export class Chat {
     const stale = this.#cursor === 0 && activeTurn?.complete === true;
 
     // The retained prompt is the only recovery for a `prompt.submitted`
-    // missed while detached (events are never re-sent). Delivered before the
-    // chunk replay so the user bubble lands above the streaming reply.
+    // missed while detached (events are never re-sent). A complete turn is
+    // normally stale on first attach, except when the retained prompt itself
+    // is the snapshot's latest event: then it belongs to the next, not-yet-
+    // started turn and must render above the settled history floor.
     const activePrompt = snapshot.activePrompt;
-    if (activePrompt && activePrompt.seq > this.#cursor && !stale) {
-      this.#pushUserMessage(activePrompt.messageId, activePrompt.parts);
+    let appliedPromptSeq: number | undefined;
+    if (
+      activePrompt &&
+      activePrompt.seq > this.#cursor &&
+      (!stale || activePrompt.seq === snapshot.cursor)
+    ) {
+      appliedPromptSeq = activePrompt.seq;
+      if (this.#pushUserMessage(activePrompt.messageId, activePrompt.parts)) {
+        this.#state.error = undefined;
+      }
+    }
+
+    // Error text is not part of the settled transcript floor. Only the latest
+    // unseen error matters, but compare its seq with the retained prompt: the
+    // runtime can hold a completed old turn beside a newer submitted prompt.
+    // In that shape the prompt clears the old error rather than resurrecting
+    // it; an error after the prompt belongs to the new turn and wins.
+    let latestError: SessionMessageChunkEvent | undefined;
+    for (const chunkEvent of activeTurn?.chunks ?? []) {
+      if (chunkEvent.seq > this.#cursor && chunkEvent.chunk.type === "error") {
+        latestError = chunkEvent;
+      }
+    }
+    if (latestError && (appliedPromptSeq === undefined || latestError.seq > appliedPromptSeq)) {
+      this.#captureChunkError(latestError.chunk);
     }
 
     // A turn flagged for recovery that is no longer active ended while we
@@ -373,9 +403,14 @@ export class Chat {
   // Shared handlers
   // ---------------------------------------------------------------------
 
-  #pushUserMessage(messageId: string, parts: ReadonlyArray<PromptPart>): void {
-    if (this.#state.messages.some((message) => message.id === messageId)) return;
+  #captureChunkError(chunk: UIMessageChunk): void {
+    if (chunk.type === "error") this.#state.error = new Error(chunk.errorText);
+  }
+
+  #pushUserMessage(messageId: string, parts: ReadonlyArray<PromptPart>): boolean {
+    if (this.#state.messages.some((message) => message.id === messageId)) return false;
     this.#state.pushMessage(toUserMessage(messageId, parts));
+    return true;
   }
 
   // Policy, not transport: an empty plan carries nothing to review, so it is
@@ -468,6 +503,7 @@ export class Chat {
   prompt = async (text: string): Promise<void> => {
     const messageId = generateId();
     const parts: PromptPart[] = [{ type: "text", text }];
+    this.#state.error = undefined;
     this.#state.pushMessage(toUserMessage(messageId, parts));
     this.#setStatus("submitted");
     try {


### PR DESCRIPTION
## Summary

- surface exact model/provider error chunks in the Chat transcript instead of only logging fold failures
- recover unseen errors from retained snapshots while respecting prompt/error sequence ordering
- clear stale errors when a new local, broadcast, or retained prompt begins without allowing delayed self-echoes to erase newer RPC failures
- preserve existing Pi retry/history reconciliation behavior and server-owned status transitions

## Tests

- `pnpm exec turbo run test --filter=@vibest/app --force` — 74 passed
- `pnpm exec turbo run typecheck --filter=@vibest/app --force`
- `pnpm exec turbo run build --filter=@vibest/app --force`
- `pnpm exec oxlint --deny-warnings apps/app/src/features/chat/runtime/chat.ts apps/app/src/features/chat/runtime/chat.test.ts`
- `pnpm exec oxfmt --check apps/app/src/features/chat/runtime/chat.ts apps/app/src/features/chat/runtime/chat.test.ts`
- production-style server + Vite health check and successful real Pi turn; the previous provider quota had reset, so deterministic Chat runtime tests cover the error path
