### PR TITLE
feat(session): add session archiving

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,7 @@ A client connecting to a session's live event stream — `session.subscribe` plu
 _Avoid_: attach for the cold pre-flight (its former name) or for taking a Chat instance; resume (`session.prepare` starts nothing — only a prompt does)
 
 **Session metadata**:
-The server-owned recovery record for a session: which Project, which harness agent, which harness session id. Distinct from conversation history, which stays in the agent's native storage.
+The server-owned recovery record for a session: which Project, which harness agent, which harness session id, and whether the session is archived. Distinct from conversation history, which stays in the agent's native storage.
 
 **Workspace path**:
 The validated absolute directory handed to a harness agent when opening or resuming a session; always derived from `Project.path`, never accepted directly from session API callers.

--- a/apps/app/src/features/projects/project-session-row.tsx
+++ b/apps/app/src/features/projects/project-session-row.tsx
@@ -1,0 +1,38 @@
+import { useNavigate, useParams } from "@tanstack/react-router";
+import type { SessionSummary } from "@vibest/contract";
+import { SidebarMenuButton, SidebarMenuItem } from "@vibest/ui/components/sidebar";
+
+import { SessionActionsMenu } from "@/features/projects/session-actions-menu";
+
+/** One session row: open-session navigation plus composed session actions. */
+export function ProjectSessionRow({ session }: { readonly session: SessionSummary }) {
+  const navigate = useNavigate();
+  // strict: false — the sidebar renders on every route, and most have no sessionId.
+  const { sessionId: activeSessionId } = useParams({ strict: false });
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        isActive={session.sessionId === activeSessionId}
+        onClick={() =>
+          navigate({
+            to: "/session/$sessionId",
+            params: { sessionId: session.sessionId },
+            search: { projectId: session.projectId, harness: session.harnessAgentId },
+          })
+        }
+      >
+        <span className="truncate">{session.title ?? "New chat"}</span>
+        {/* Busy elsewhere too: status is server-derived, so a turn any client
+            is running shows here. requires_action keeps the turn open. */}
+        {(session.status?.phase === "running" || session.status?.phase === "requires_action") && (
+          <span
+            className="ms-auto size-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
+            title="A turn is running in this session"
+          />
+        )}
+      </SidebarMenuButton>
+      <SessionActionsMenu session={session} />
+    </SidebarMenuItem>
+  );
+}

--- a/apps/app/src/features/projects/project-sessions-group.tsx
+++ b/apps/app/src/features/projects/project-sessions-group.tsx
@@ -1,146 +1,39 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useParams, useRouteContext } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import type { Project, SessionSummary } from "@vibest/contract";
 import {
   Collapsible,
   CollapsiblePanel,
   CollapsibleTrigger,
 } from "@vibest/ui/components/collapsible";
-import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@vibest/ui/components/menu";
 import {
   SidebarGroupAction,
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarMenu,
-  SidebarMenuAction,
-  SidebarMenuButton,
-  SidebarMenuItem,
 } from "@vibest/ui/components/sidebar";
-import {
-  Archive,
-  ArchiveRestore,
-  ChevronRight,
-  Ellipsis,
-  Folder,
-  FolderOpen,
-  SquarePen,
-} from "lucide-react";
+import { ChevronRight, Folder, FolderOpen, SquarePen } from "lucide-react";
 import { useState } from "react";
-import { toast } from "sonner";
 
+import { ProjectSessionRow } from "@/features/projects/project-session-row";
 import { useProjectSessions } from "@/features/projects/use-project-sessions";
 
 const EMPTY_SESSIONS: ReadonlyArray<SessionSummary> = [];
 
-function SessionMenuItem({
-  activeSessionId,
-  archivePending,
-  onArchiveChange,
-  onOpen,
-  session,
-}: {
-  readonly activeSessionId: string | undefined;
-  readonly archivePending: boolean;
-  readonly onArchiveChange: (session: SessionSummary, archived: boolean) => void;
-  readonly onOpen: (session: SessionSummary) => void;
-  readonly session: SessionSummary;
-}) {
-  const title = session.title ?? "New chat";
-
-  return (
-    <SidebarMenuItem>
-      <SidebarMenuButton
-        isActive={session.sessionId === activeSessionId}
-        onClick={() => onOpen(session)}
-      >
-        <span className="truncate">{title}</span>
-        {/* Busy elsewhere too: status is server-derived, so a turn any client
-            is running shows here. requires_action keeps the turn open. */}
-        {(session.status?.phase === "running" || session.status?.phase === "requires_action") && (
-          <span
-            className="ms-auto size-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
-            title="A turn is running in this session"
-          />
-        )}
-      </SidebarMenuButton>
-      <Menu>
-        <MenuTrigger
-          render={
-            <SidebarMenuAction
-              aria-label={`Actions for ${title}`}
-              disabled={archivePending}
-              showOnHover
-            />
-          }
-        >
-          <Ellipsis />
-        </MenuTrigger>
-        <MenuPopup align="start" side="right">
-          <MenuItem
-            disabled={archivePending}
-            onClick={() => onArchiveChange(session, !session.archived)}
-          >
-            {session.archived ? <ArchiveRestore /> : <Archive />}
-            {session.archived ? "Restore" : "Archive"}
-          </MenuItem>
-        </MenuPopup>
-      </Menu>
-    </SidebarMenuItem>
-  );
-}
-
 /**
  * One project and the sessions under it, as a collapsible sidebar group. The
  * label is its own collapse trigger; a Folder icon swaps to FolderOpen when the
- * panel is open (two icon entities, not a rotation). Fetching lives in
- * `useProjectSessions`; how a row looks and what a click does are this
- * component's own business.
+ * panel is open (two icon entities, not a rotation). This component owns only
+ * grouping and fetching; each row composes its own navigation and actions.
  */
 export function ProjectSessionsGroup({ project }: { project: Project }) {
-  const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const [archivedOpen, setArchivedOpen] = useState(false);
-  // strict: false — the sidebar renders on every route, and most have no sessionId.
-  const { sessionId: activeSessionId } = useParams({ strict: false });
   const activeSessions = useProjectSessions(project.id);
   const archivedSessions = useProjectSessions(project.id, {
     archived: true,
     enabled: archivedOpen,
   });
 
-  const setArchived = useMutation({
-    mutationFn: ({ archived, session }: { archived: boolean; session: SessionSummary }) =>
-      orpcQueryUtils.session.archive.call({
-        ref: {
-          projectId: session.projectId,
-          harnessAgentId: session.harnessAgentId,
-          sessionId: session.sessionId,
-        },
-        archived,
-      }),
-    onSuccess: (_, { session }) => {
-      const listKey = (archived: boolean) =>
-        orpcQueryUtils.session.list.queryOptions({
-          input: { projectId: session.projectId, archived },
-        }).queryKey;
-      return Promise.all([
-        queryClient.invalidateQueries({ queryKey: listKey(false) }),
-        queryClient.invalidateQueries({ queryKey: listKey(true) }),
-      ]);
-    },
-    onError: (error) => toast.error(`Failed to update session: ${error.message}`),
-  });
-
-  const openSession = (session: SessionSummary) =>
-    navigate({
-      to: "/session/$sessionId",
-      params: { sessionId: session.sessionId },
-      search: { projectId: session.projectId, harness: session.harnessAgentId },
-    });
-  const pendingSessionId = setArchived.isPending
-    ? setArchived.variables?.session.sessionId
-    : undefined;
   const activeRows = activeSessions.data ?? EMPTY_SESSIONS;
   const archivedRows = archivedSessions.data ?? EMPTY_SESSIONS;
 
@@ -175,16 +68,7 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
           <SidebarGroupContent>
             <SidebarMenu>
               {activeRows.map((session) => (
-                <SessionMenuItem
-                  activeSessionId={activeSessionId}
-                  archivePending={pendingSessionId === session.sessionId}
-                  key={session.sessionId}
-                  onArchiveChange={(target, archived) =>
-                    setArchived.mutate({ session: target, archived })
-                  }
-                  onOpen={openSession}
-                  session={session}
-                />
+                <ProjectSessionRow key={session.sessionId} session={session} />
               ))}
             </SidebarMenu>
             <Collapsible className="mt-1" onOpenChange={setArchivedOpen} open={archivedOpen}>
@@ -205,16 +89,7 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
                 ) : (
                   <SidebarMenu className="pt-1">
                     {archivedRows.map((session) => (
-                      <SessionMenuItem
-                        activeSessionId={activeSessionId}
-                        archivePending={pendingSessionId === session.sessionId}
-                        key={session.sessionId}
-                        onArchiveChange={(target, archived) =>
-                          setArchived.mutate({ session: target, archived })
-                        }
-                        onOpen={openSession}
-                        session={session}
-                      />
+                      <ProjectSessionRow key={session.sessionId} session={session} />
                     ))}
                   </SidebarMenu>
                 )}

--- a/apps/app/src/features/projects/project-sessions-group.tsx
+++ b/apps/app/src/features/projects/project-sessions-group.tsx
@@ -11,8 +11,7 @@ import {
   SidebarGroupLabel,
   SidebarMenu,
 } from "@vibest/ui/components/sidebar";
-import { ChevronRight, Folder, FolderOpen, SquarePen } from "lucide-react";
-import { useState } from "react";
+import { Folder, FolderOpen, SquarePen } from "lucide-react";
 
 import { ProjectSessionRow } from "@/features/projects/project-session-row";
 import { useProjectSessions } from "@/features/projects/use-project-sessions";
@@ -27,15 +26,8 @@ const EMPTY_SESSIONS: ReadonlyArray<SessionSummary> = [];
  */
 export function ProjectSessionsGroup({ project }: { project: Project }) {
   const navigate = useNavigate();
-  const [archivedOpen, setArchivedOpen] = useState(false);
-  const activeSessions = useProjectSessions(project.id);
-  const archivedSessions = useProjectSessions(project.id, {
-    archived: true,
-    enabled: archivedOpen,
-  });
-
-  const activeRows = activeSessions.data ?? EMPTY_SESSIONS;
-  const archivedRows = archivedSessions.data ?? EMPTY_SESSIONS;
+  const sessions = useProjectSessions(project.id);
+  const rows = sessions.data ?? EMPTY_SESSIONS;
 
   return (
     <Collapsible defaultOpen>
@@ -67,34 +59,10 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
         <CollapsiblePanel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {activeRows.map((session) => (
+              {rows.map((session) => (
                 <ProjectSessionRow key={session.sessionId} session={session} />
               ))}
             </SidebarMenu>
-            <Collapsible className="mt-1" onOpenChange={setArchivedOpen} open={archivedOpen}>
-              <CollapsibleTrigger className="text-sidebar-foreground/70 hover:bg-sidebar-accent/70 group/archived-trigger flex h-7 w-full items-center gap-1.5 rounded-lg px-2 text-xs font-medium outline-hidden focus-visible:ring-2">
-                <ChevronRight className="size-3.5 transition-transform group-data-[panel-open]/archived-trigger:rotate-90" />
-                <span>Archived</span>
-                {archivedSessions.data !== undefined ? (
-                  <span className="ms-auto tabular-nums">{archivedRows.length}</span>
-                ) : null}
-              </CollapsibleTrigger>
-              <CollapsiblePanel>
-                {archivedSessions.isPending ? (
-                  <p className="text-sidebar-foreground/60 px-2 py-1 text-xs">Loading...</p>
-                ) : archivedRows.length === 0 ? (
-                  <p className="text-sidebar-foreground/60 px-2 py-1 text-xs">
-                    No archived sessions
-                  </p>
-                ) : (
-                  <SidebarMenu className="pt-1">
-                    {archivedRows.map((session) => (
-                      <ProjectSessionRow key={session.sessionId} session={session} />
-                    ))}
-                  </SidebarMenu>
-                )}
-              </CollapsiblePanel>
-            </Collapsible>
           </SidebarGroupContent>
         </CollapsiblePanel>
       </section>

--- a/apps/app/src/features/projects/project-sessions-group.tsx
+++ b/apps/app/src/features/projects/project-sessions-group.tsx
@@ -1,21 +1,93 @@
-import { useNavigate, useParams } from "@tanstack/react-router";
-import type { Project } from "@vibest/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate, useParams, useRouteContext } from "@tanstack/react-router";
+import type { Project, SessionSummary } from "@vibest/contract";
 import {
   Collapsible,
   CollapsiblePanel,
   CollapsibleTrigger,
 } from "@vibest/ui/components/collapsible";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@vibest/ui/components/menu";
 import {
   SidebarGroupAction,
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@vibest/ui/components/sidebar";
-import { Folder, FolderOpen, SquarePen } from "lucide-react";
+import {
+  Archive,
+  ArchiveRestore,
+  ChevronRight,
+  Ellipsis,
+  Folder,
+  FolderOpen,
+  SquarePen,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 
 import { useProjectSessions } from "@/features/projects/use-project-sessions";
+
+const EMPTY_SESSIONS: ReadonlyArray<SessionSummary> = [];
+
+function SessionMenuItem({
+  activeSessionId,
+  archivePending,
+  onArchiveChange,
+  onOpen,
+  session,
+}: {
+  readonly activeSessionId: string | undefined;
+  readonly archivePending: boolean;
+  readonly onArchiveChange: (session: SessionSummary, archived: boolean) => void;
+  readonly onOpen: (session: SessionSummary) => void;
+  readonly session: SessionSummary;
+}) {
+  const title = session.title ?? "New chat";
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        isActive={session.sessionId === activeSessionId}
+        onClick={() => onOpen(session)}
+      >
+        <span className="truncate">{title}</span>
+        {/* Busy elsewhere too: status is server-derived, so a turn any client
+            is running shows here. requires_action keeps the turn open. */}
+        {(session.status?.phase === "running" || session.status?.phase === "requires_action") && (
+          <span
+            className="ms-auto size-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
+            title="A turn is running in this session"
+          />
+        )}
+      </SidebarMenuButton>
+      <Menu>
+        <MenuTrigger
+          render={
+            <SidebarMenuAction
+              aria-label={`Actions for ${title}`}
+              disabled={archivePending}
+              showOnHover
+            />
+          }
+        >
+          <Ellipsis />
+        </MenuTrigger>
+        <MenuPopup align="start" side="right">
+          <MenuItem
+            disabled={archivePending}
+            onClick={() => onArchiveChange(session, !session.archived)}
+          >
+            {session.archived ? <ArchiveRestore /> : <Archive />}
+            {session.archived ? "Restore" : "Archive"}
+          </MenuItem>
+        </MenuPopup>
+      </Menu>
+    </SidebarMenuItem>
+  );
+}
 
 /**
  * One project and the sessions under it, as a collapsible sidebar group. The
@@ -25,10 +97,52 @@ import { useProjectSessions } from "@/features/projects/use-project-sessions";
  * component's own business.
  */
 export function ProjectSessionsGroup({ project }: { project: Project }) {
+  const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [archivedOpen, setArchivedOpen] = useState(false);
   // strict: false — the sidebar renders on every route, and most have no sessionId.
   const { sessionId: activeSessionId } = useParams({ strict: false });
-  const sessions = useProjectSessions(project.id);
+  const activeSessions = useProjectSessions(project.id);
+  const archivedSessions = useProjectSessions(project.id, {
+    archived: true,
+    enabled: archivedOpen,
+  });
+
+  const setArchived = useMutation({
+    mutationFn: ({ archived, session }: { archived: boolean; session: SessionSummary }) =>
+      orpcQueryUtils.session.archive.call({
+        ref: {
+          projectId: session.projectId,
+          harnessAgentId: session.harnessAgentId,
+          sessionId: session.sessionId,
+        },
+        archived,
+      }),
+    onSuccess: (_, { session }) => {
+      const listKey = (archived: boolean) =>
+        orpcQueryUtils.session.list.queryOptions({
+          input: { projectId: session.projectId, archived },
+        }).queryKey;
+      return Promise.all([
+        queryClient.invalidateQueries({ queryKey: listKey(false) }),
+        queryClient.invalidateQueries({ queryKey: listKey(true) }),
+      ]);
+    },
+    onError: (error) => toast.error(`Failed to update session: ${error.message}`),
+  });
+
+  const openSession = (session: SessionSummary) =>
+    navigate({
+      to: "/session/$sessionId",
+      params: { sessionId: session.sessionId },
+      search: { projectId: session.projectId, harness: session.harnessAgentId },
+    });
+  const pendingSessionId = setArchived.isPending
+    ? setArchived.variables?.session.sessionId
+    : undefined;
+  const activeRows = activeSessions.data ?? EMPTY_SESSIONS;
+  const archivedRows = archivedSessions.data ?? EMPTY_SESSIONS;
 
   return (
     <Collapsible defaultOpen>
@@ -60,32 +174,52 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
         <CollapsiblePanel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {sessions.map((session) => (
-                <SidebarMenuItem key={session.sessionId}>
-                  <SidebarMenuButton
-                    isActive={session.sessionId === activeSessionId}
-                    // The whole ref rides along so the route can resume directly.
-                    onClick={() =>
-                      navigate({
-                        to: "/session/$sessionId",
-                        params: { sessionId: session.sessionId },
-                        search: { projectId: session.projectId, harness: session.harnessAgentId },
-                      })
-                    }
-                  >
-                    <span className="truncate">{session.title ?? "New chat"}</span>
-                    {/* Busy elsewhere too: status is server-derived, so a turn any client is running shows here. requires_action keeps the turn open, so it counts as busy. */}
-                    {(session.status?.phase === "running" ||
-                      session.status?.phase === "requires_action") && (
-                      <span
-                        className="ms-auto size-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
-                        title="A turn is running in this session"
-                      />
-                    )}
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
+              {activeRows.map((session) => (
+                <SessionMenuItem
+                  activeSessionId={activeSessionId}
+                  archivePending={pendingSessionId === session.sessionId}
+                  key={session.sessionId}
+                  onArchiveChange={(target, archived) =>
+                    setArchived.mutate({ session: target, archived })
+                  }
+                  onOpen={openSession}
+                  session={session}
+                />
               ))}
             </SidebarMenu>
+            <Collapsible className="mt-1" onOpenChange={setArchivedOpen} open={archivedOpen}>
+              <CollapsibleTrigger className="text-sidebar-foreground/70 hover:bg-sidebar-accent/70 group/archived-trigger flex h-7 w-full items-center gap-1.5 rounded-lg px-2 text-xs font-medium outline-hidden focus-visible:ring-2">
+                <ChevronRight className="size-3.5 transition-transform group-data-[panel-open]/archived-trigger:rotate-90" />
+                <span>Archived</span>
+                {archivedSessions.data !== undefined ? (
+                  <span className="ms-auto tabular-nums">{archivedRows.length}</span>
+                ) : null}
+              </CollapsibleTrigger>
+              <CollapsiblePanel>
+                {archivedSessions.isPending ? (
+                  <p className="text-sidebar-foreground/60 px-2 py-1 text-xs">Loading...</p>
+                ) : archivedRows.length === 0 ? (
+                  <p className="text-sidebar-foreground/60 px-2 py-1 text-xs">
+                    No archived sessions
+                  </p>
+                ) : (
+                  <SidebarMenu className="pt-1">
+                    {archivedRows.map((session) => (
+                      <SessionMenuItem
+                        activeSessionId={activeSessionId}
+                        archivePending={pendingSessionId === session.sessionId}
+                        key={session.sessionId}
+                        onArchiveChange={(target, archived) =>
+                          setArchived.mutate({ session: target, archived })
+                        }
+                        onOpen={openSession}
+                        session={session}
+                      />
+                    ))}
+                  </SidebarMenu>
+                )}
+              </CollapsiblePanel>
+            </Collapsible>
           </SidebarGroupContent>
         </CollapsiblePanel>
       </section>

--- a/apps/app/src/features/projects/session-actions-menu.tsx
+++ b/apps/app/src/features/projects/session-actions-menu.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
+import { useNavigate, useParams, useRouteContext } from "@tanstack/react-router";
 import type { SessionSummary } from "@vibest/contract";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@vibest/ui/components/menu";
 import { SidebarMenuAction } from "@vibest/ui/components/sidebar";
@@ -9,7 +9,10 @@ import { toast } from "sonner";
 /** Session mutations live behind one actions-menu capability boundary. */
 export function SessionActionsMenu({ session }: { readonly session: SessionSummary }) {
   const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
+  // strict: false — the menu also renders on routes without a sessionId.
+  const { sessionId: activeSessionId } = useParams({ strict: false });
   const title = session.title ?? "New chat";
 
   const setArchived = useMutation({
@@ -22,15 +25,24 @@ export function SessionActionsMenu({ session }: { readonly session: SessionSumma
         },
         archived,
       }),
-    onSuccess: () => {
-      const listKey = (archived: boolean) =>
+    onSuccess: (_, archived) => {
+      const listKey = (isArchived: boolean) =>
         orpcQueryUtils.session.list.queryOptions({
-          input: { projectId: session.projectId, archived },
+          input: { projectId: session.projectId, archived: isArchived },
         }).queryKey;
-      return Promise.all([
+      const refreshLists = Promise.all([
         queryClient.invalidateQueries({ queryKey: listKey(false) }),
         queryClient.invalidateQueries({ queryKey: listKey(true) }),
       ]);
+
+      if (archived && activeSessionId === session.sessionId) {
+        return Promise.all([
+          refreshLists,
+          navigate({ to: "/draft", search: { projectId: session.projectId } }),
+        ]);
+      }
+
+      return refreshLists;
     },
     onError: (error) => toast.error(`Failed to update session: ${error.message}`),
   });

--- a/apps/app/src/features/projects/session-actions-menu.tsx
+++ b/apps/app/src/features/projects/session-actions-menu.tsx
@@ -1,0 +1,62 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
+import type { SessionSummary } from "@vibest/contract";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@vibest/ui/components/menu";
+import { SidebarMenuAction } from "@vibest/ui/components/sidebar";
+import { Archive, ArchiveRestore, Ellipsis } from "lucide-react";
+import { toast } from "sonner";
+
+/** Session mutations live behind one actions-menu capability boundary. */
+export function SessionActionsMenu({ session }: { readonly session: SessionSummary }) {
+  const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
+  const queryClient = useQueryClient();
+  const title = session.title ?? "New chat";
+
+  const setArchived = useMutation({
+    mutationFn: (archived: boolean) =>
+      orpcQueryUtils.session.archive.call({
+        ref: {
+          projectId: session.projectId,
+          harnessAgentId: session.harnessAgentId,
+          sessionId: session.sessionId,
+        },
+        archived,
+      }),
+    onSuccess: () => {
+      const listKey = (archived: boolean) =>
+        orpcQueryUtils.session.list.queryOptions({
+          input: { projectId: session.projectId, archived },
+        }).queryKey;
+      return Promise.all([
+        queryClient.invalidateQueries({ queryKey: listKey(false) }),
+        queryClient.invalidateQueries({ queryKey: listKey(true) }),
+      ]);
+    },
+    onError: (error) => toast.error(`Failed to update session: ${error.message}`),
+  });
+
+  return (
+    <Menu>
+      <MenuTrigger
+        render={
+          <SidebarMenuAction
+            aria-label={`Actions for ${title}`}
+            disabled={setArchived.isPending}
+            showOnHover
+          />
+        }
+      >
+        <Ellipsis />
+      </MenuTrigger>
+      <MenuPopup align="start" side="right">
+        <MenuItem
+          disabled={setArchived.isPending}
+          onClick={() => setArchived.mutate(!session.archived)}
+        >
+          {session.archived ? <ArchiveRestore /> : <Archive />}
+          {session.archived ? "Restore" : "Archive"}
+        </MenuItem>
+      </MenuPopup>
+    </Menu>
+  );
+}

--- a/apps/app/src/features/projects/session-list-cache.test.ts
+++ b/apps/app/src/features/projects/session-list-cache.test.ts
@@ -10,16 +10,17 @@ const ref: SessionRef = {
   sessionId: "session-1",
 };
 
-const listKeyFor: ListKeyFor = (projectId) => ["sessions", projectId];
+const listKeyFor: ListKeyFor = (projectId, archived) => ["sessions", projectId, archived];
 
 const seed = (rows: ListSessionsOutput) => {
   const queryClient = new QueryClient();
-  queryClient.setQueryData<ListSessionsOutput>(listKeyFor(ref.projectId), rows);
+  queryClient.setQueryData<ListSessionsOutput>(listKeyFor(ref.projectId, false), rows);
   return queryClient;
 };
 
 const row = (overrides: Partial<ListSessionsOutput[number]> = {}): ListSessionsOutput[number] => ({
   ...ref,
+  archived: false,
   createdAt: "2026-08-03T00:00:00.000Z",
   historyAvailable: true,
   title: "hello",
@@ -27,7 +28,7 @@ const row = (overrides: Partial<ListSessionsOutput[number]> = {}): ListSessionsO
 });
 
 const rows = (queryClient: QueryClient) =>
-  queryClient.getQueryData<ListSessionsOutput>(listKeyFor(ref.projectId));
+  queryClient.getQueryData<ListSessionsOutput>(listKeyFor(ref.projectId, false));
 
 describe("applySessionListEvent", () => {
   it("copies the server-stamped phase onto the row", () => {
@@ -90,7 +91,19 @@ describe("applySessionListEvent", () => {
       title: "created elsewhere",
     };
     applySessionListEvent(queryClient, listKeyFor, event);
-    expect(queryClient.getQueryState(listKeyFor(ref.projectId))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(listKeyFor(ref.projectId, false))?.isInvalidated).toBe(true);
+  });
+
+  it("removes an archived row from the active cache and invalidates the archived cache", () => {
+    const queryClient = seed([row()]);
+    queryClient.setQueryData<ListSessionsOutput>(listKeyFor(ref.projectId, true), []);
+    applySessionListEvent(queryClient, listKeyFor, {
+      ref,
+      type: "session.archived",
+      archived: true,
+    });
+    expect(rows(queryClient)).toEqual([]);
+    expect(queryClient.getQueryState(listKeyFor(ref.projectId, true))?.isInvalidated).toBe(true);
   });
 
   it("renames and deletes rows in place", () => {

--- a/apps/app/src/features/projects/session-list-cache.ts
+++ b/apps/app/src/features/projects/session-list-cache.ts
@@ -4,7 +4,7 @@ import { isSessionScopedEvent } from "@vibest/contract";
 
 type SessionRow = ListSessionsOutput[number];
 
-export type ListKeyFor = (projectId: string) => QueryKey;
+export type ListKeyFor = (projectId: string, archived: boolean) => QueryKey;
 
 // One in-place row edit. Returns whether the row existed; an `update` that
 // returns the same row leaves the previous array untouched, so query
@@ -31,6 +31,31 @@ const patchRow = (
   return found;
 };
 
+const patchLists = (
+  queryClient: QueryClient,
+  listKeys: ReadonlyArray<QueryKey>,
+  sessionId: string,
+  update: (row: SessionRow) => SessionRow,
+): boolean => {
+  let found = false;
+  for (const listKey of listKeys) {
+    found = patchRow(queryClient, listKey, sessionId, update) || found;
+  }
+  return found;
+};
+
+const removeFromLists = (
+  queryClient: QueryClient,
+  listKeys: ReadonlyArray<QueryKey>,
+  sessionId: string,
+) => {
+  for (const listKey of listKeys) {
+    queryClient.setQueryData<ListSessionsOutput>(listKey, (prev) =>
+      prev?.filter((row) => row.sessionId !== sessionId),
+    );
+  }
+};
+
 /**
  * Fold one firehose event into the `session.list` caches. Pure with respect to
  * React — the hook owns the subscription, this owns what an event means.
@@ -46,11 +71,11 @@ export const applySessionListEvent = (
   listKeyFor: ListKeyFor,
   event: ServerEvent,
 ): void => {
-  const listKey = listKeyFor(event.ref.projectId);
+  const listKeys = [listKeyFor(event.ref.projectId, false), listKeyFor(event.ref.projectId, true)];
   if (isSessionScopedEvent(event)) {
     const phase = event.phase;
     if (phase === undefined || event.type === "session.message.chunk") return;
-    patchRow(queryClient, listKey, event.ref.sessionId, (row) =>
+    patchLists(queryClient, listKeys, event.ref.sessionId, (row) =>
       row.status?.phase === phase ? row : { ...row, status: { phase } },
     );
     return;
@@ -61,22 +86,33 @@ export const applySessionListEvent = (
       // one's live status/createdAt. A row we don't hold yet (another client
       // created this session) → pull the authoritative list once; the read is
       // a cheap pure-storage query.
-      const found = patchRow(queryClient, listKey, event.ref.sessionId, (row) =>
+      const found = patchLists(queryClient, listKeys, event.ref.sessionId, (row) =>
         event.title !== undefined ? { ...row, title: event.title } : row,
       );
-      if (!found) void queryClient.invalidateQueries({ queryKey: listKey });
+      if (!found) {
+        for (const listKey of listKeys) {
+          void queryClient.invalidateQueries({ queryKey: listKey });
+        }
+      }
       break;
     }
     case "session.renamed":
-      patchRow(queryClient, listKey, event.ref.sessionId, (row) => ({
+      patchLists(queryClient, listKeys, event.ref.sessionId, (row) => ({
         ...row,
         title: event.name,
       }));
       break;
+    case "session.archived": {
+      const sourceKey = listKeyFor(event.ref.projectId, !event.archived);
+      const destinationKey = listKeyFor(event.ref.projectId, event.archived);
+      removeFromLists(queryClient, [sourceKey], event.ref.sessionId);
+      // The event carries no full summary. An open destination query refetches
+      // now; a disabled archived query remains lazy until its panel opens.
+      void queryClient.invalidateQueries({ queryKey: destinationKey });
+      break;
+    }
     case "session.deleted":
-      queryClient.setQueryData<ListSessionsOutput>(listKey, (prev) =>
-        prev?.filter((s) => s.sessionId !== event.ref.sessionId),
-      );
+      removeFromLists(queryClient, listKeys, event.ref.sessionId);
       break;
     case "session.created":
       // The creating tab already seeded this row optimistically; a title-less

--- a/apps/app/src/features/projects/use-project-sessions.ts
+++ b/apps/app/src/features/projects/use-project-sessions.ts
@@ -2,8 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
 import type { SessionSummary } from "@vibest/contract";
 
-const NO_SESSIONS: ReadonlyArray<SessionSummary> = [];
-
 // Newest-first: a session is opened right after it is created. Module scope
 // keeps `select` referentially stable across renders.
 const selectNewestFirst = (
@@ -18,12 +16,15 @@ const selectNewestFirst = (
  * the draft route seeds an optimistic row, `useSessionListSync` patches titles
  * in from `session.updated`.
  */
-export function useProjectSessions(projectId: string): ReadonlyArray<SessionSummary> {
+export function useProjectSessions(
+  projectId: string,
+  { archived = false, enabled = true }: { archived?: boolean; enabled?: boolean } = {},
+) {
   const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
-  const { data } = useQuery({
-    ...orpcQueryUtils.session.list.queryOptions({ input: { projectId } }),
+  return useQuery({
+    ...orpcQueryUtils.session.list.queryOptions({ input: { projectId, archived } }),
+    enabled,
     staleTime: 30_000,
     select: selectNewestFirst,
   });
-  return data ?? NO_SESSIONS;
 }

--- a/apps/app/src/features/projects/use-session-list-sync.ts
+++ b/apps/app/src/features/projects/use-session-list-sync.ts
@@ -22,11 +22,11 @@ export function useSessionListSync(): void {
   useEffect(() => {
     const abort = new AbortController();
 
-    // The exact key the sidebar's `session.list` query reads — the `queryOptions`
-    // key carries `type: "query"`, which the bare `.key({ input })` omits, so
-    // setQueryData must use this or it writes a phantom entry nothing renders.
-    const listKeyFor = (projectId: string) =>
-      orpcQueryUtils.session.list.queryOptions({ input: { projectId } }).queryKey;
+    // The exact keys the sidebar's active/archived queries read. `queryOptions`
+    // carries `type: "query"`, which the bare `.key({ input })` omits, so cache
+    // writes must use these or they land in phantom entries nothing renders.
+    const listKeyFor = (projectId: string, archived: boolean) =>
+      orpcQueryUtils.session.list.queryOptions({ input: { projectId, archived } }).queryKey;
 
     const run = async () => {
       while (!abort.signal.aborted) {

--- a/apps/app/src/routes/draft.tsx
+++ b/apps/app/src/routes/draft.tsx
@@ -162,7 +162,7 @@ function DraftRoute() {
       // `.key({ input })` — the latter omits `type` and setQueryData would write
       // a phantom entry the sidebar never reads.
       const listKey = orpcQueryUtils.session.list.queryOptions({
-        input: { projectId: ref.projectId },
+        input: { projectId: ref.projectId, archived: false },
       }).queryKey;
 
       // Optimistic title: seed the row with the prompt text so it appears named
@@ -178,6 +178,7 @@ function DraftRoute() {
           harnessAgentId: ref.harnessAgentId,
           sessionId: ref.sessionId,
           title: text,
+          archived: false,
           // Placeholder ordering key (≈ now); the real createdAt loads on reload.
           createdAt: new Date().toISOString(),
           historyAvailable: true,

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -198,6 +198,7 @@ export type SessionScopedEventType = (typeof SessionScopedEventTypes)[number];
 export const CollectionEventTypes = [
   "session.created",
   "session.updated",
+  "session.archived",
   "session.deleted",
   "session.renamed",
 ] as const;
@@ -269,6 +270,7 @@ export type CollectionEvent = { readonly ref: SessionRef } & (
   // from the first prompt). Carries the new value so clients patch the row in
   // place instead of clobbering an optimistic title with a refetch.
   | { readonly type: "session.updated"; readonly title?: string }
+  | { readonly type: "session.archived"; readonly archived: boolean }
   | { readonly type: "session.deleted" }
   | { readonly type: "session.renamed"; readonly name: string }
 );
@@ -607,6 +609,7 @@ export type CreateSessionInput = typeof CreateSessionInputSchema.Type;
 
 export const ListSessionsInputSchema = Schema.Struct({
   projectId: Schema.String.check(Schema.isUUID()),
+  archived: Schema.optionalKey(Schema.Boolean),
 });
 export type ListSessionsInput = typeof ListSessionsInputSchema.Type;
 
@@ -615,6 +618,7 @@ export type SessionSummary = {
   readonly harnessAgentId: HarnessAgentId;
   readonly sessionId: string;
   readonly title?: string;
+  readonly archived: boolean;
   readonly createdAt: string;
   readonly updatedAt?: string;
   readonly historyAvailable: boolean;
@@ -629,6 +633,12 @@ export const RenameSessionInputSchema = Schema.Struct({
   name: Schema.NonEmptyString,
 });
 export type RenameSessionInput = typeof RenameSessionInputSchema.Type;
+
+export const ArchiveSessionInputSchema = Schema.Struct({
+  ref: SessionRefSchema,
+  archived: Schema.Boolean,
+});
+export type ArchiveSessionInput = typeof ArchiveSessionInputSchema.Type;
 
 export const RefInputSchema = Schema.Struct({ ref: SessionRefSchema });
 export type RefInput = typeof RefInputSchema.Type;

--- a/packages/contract/src/session.ts
+++ b/packages/contract/src/session.ts
@@ -1,6 +1,7 @@
 import { eventIterator, oc, type } from "@orpc/contract";
 
 import {
+  ArchiveSessionInputSchema,
   CreateSessionInputSchema,
   serverErrors,
   ListSessionsInputSchema,
@@ -46,6 +47,7 @@ export const sessionContract = {
   // history / index
   list: base.input(toStandardSchema(ListSessionsInputSchema)).output(type<ListSessionsOutput>()),
   rename: base.input(toStandardSchema(RenameSessionInputSchema)),
+  archive: base.input(toStandardSchema(ArchiveSessionInputSchema)),
   delete: base.input(toStandardSchema(RefInputSchema)),
   getMessages: base.input(toStandardSchema(RefInputSchema)).output(type<SessionMessages>()),
   // sessionId (a bookmarked URL) → full SessionRef via server-side reverse lookup.

--- a/packages/contract/test/schema.test.ts
+++ b/packages/contract/test/schema.test.ts
@@ -2,10 +2,12 @@ import { Exit, Schema } from "effect";
 import { describe, expect, it } from "vitest";
 
 import {
+  ArchiveSessionInputSchema,
   CollectionEventTypes,
   HarnessListOutputSchema,
   HarnessProbeInputSchema,
   HarnessProbeOutputSchema,
+  ListSessionsInputSchema,
   type ServerEvent,
   serverErrors,
   ServerErrorCodes,
@@ -37,6 +39,21 @@ describe("SessionRef", () => {
 
   it("rejects an unknown harness agent", () => {
     expect(accepts(SessionRefSchema, { ...ref, harnessAgentId: "gpt" })).toBe(false);
+  });
+});
+
+describe("ArchiveSessionInput", () => {
+  it("requires an explicit archived state", () => {
+    expect(accepts(ArchiveSessionInputSchema, { ref, archived: true })).toBe(true);
+    expect(accepts(ArchiveSessionInputSchema, { ref })).toBe(false);
+  });
+});
+
+describe("ListSessionsInput", () => {
+  it("accepts an archived filter and lets callers omit it for the active default", () => {
+    expect(accepts(ListSessionsInputSchema, { projectId: UUID, archived: false })).toBe(true);
+    expect(accepts(ListSessionsInputSchema, { projectId: UUID, archived: true })).toBe(true);
+    expect(accepts(ListSessionsInputSchema, { projectId: UUID })).toBe(true);
   });
 });
 

--- a/packages/server/src/harness/session-repository.ts
+++ b/packages/server/src/harness/session-repository.ts
@@ -18,6 +18,7 @@ const SessionSchema = Schema.Struct({
   createdAt: Schema.String,
   cwd: Schema.optionalKey(Schema.String),
   title: Schema.optionalKey(Schema.String),
+  archived: Schema.optionalKey(Schema.Boolean),
   updatedAt: Schema.optionalKey(Schema.String),
   historyAvailable: Schema.optionalKey(Schema.Boolean),
 });

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -129,8 +129,13 @@ export type HarnessAgentSessionServiceShape = {
     ref: SessionRef,
     name: string,
   ) => Effect.Effect<void, SessionNotFound | SessionRefMismatch | StoreReadError>;
+  readonly archive: (
+    ref: SessionRef,
+    archived: boolean,
+  ) => Effect.Effect<void, SessionNotFound | SessionRefMismatch | StoreReadError | StoreWriteError>;
   readonly list: (
     projectId: string,
+    archived: boolean,
   ) => Effect.Effect<ReadonlyArray<SessionSummary>, StoreReadError>;
   /**
    * The session's native history as final-form UIMessages, then trimmed of the
@@ -413,6 +418,7 @@ export const makeHarnessAgentSessionService = (deps: {
                 // so an imported/rehomed session stays self-contained and a
                 // resume has cwd before it can call getSessionInfo.
                 cwd,
+                archived: false,
               };
               return repo.write(metadata).pipe(
                 // A failed metadata write must not leak the native session.
@@ -467,13 +473,27 @@ export const makeHarnessAgentSessionService = (deps: {
         Effect.andThen(bus.publish({ ref, type: "session.renamed", name })),
       ),
 
+    archive: (ref, archived) =>
+      readChecked(ref).pipe(
+        Effect.flatMap((metadata) =>
+          (metadata.archived ?? false) === archived
+            ? Effect.void
+            : repo
+                .write({ ...metadata, archived })
+                .pipe(Effect.andThen(bus.publish({ ref, type: "session.archived", archived }))),
+        ),
+      ),
+
     // A pure read of our own records — display data is self-owned (title from
     // the first prompt, createdAt/cwd from create), so no per-session backend
     // lookup. `status` is the one overlay, and it comes from the manager's
     // live sessions, not the harness index: a row with no status is one this
     // process has not touched, which is different from one sitting idle.
-    list: (projectId) =>
+    list: (projectId, archived) =>
       repo.list(projectId).pipe(
+        Effect.map((sessions) =>
+          sessions.filter((metadata) => (metadata.archived ?? false) === archived),
+        ),
         Effect.flatMap((sessions) =>
           Effect.forEach(sessions, (metadata) =>
             manager
@@ -489,6 +509,7 @@ export const makeHarnessAgentSessionService = (deps: {
                       projectId: metadata.projectId,
                       harnessAgentId: metadata.harnessAgentId,
                       sessionId: metadata.sessionId,
+                      archived: metadata.archived ?? false,
                       createdAt: metadata.createdAt,
                       // We own the record, so the session exists as far as we
                       // know; a resume (or a getMessages read) proves

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -475,13 +475,19 @@ export const makeHarnessAgentSessionService = (deps: {
 
     archive: (ref, archived) =>
       readChecked(ref).pipe(
-        Effect.flatMap((metadata) =>
-          (metadata.archived ?? false) === archived
-            ? Effect.void
-            : repo
-                .write({ ...metadata, archived })
-                .pipe(Effect.andThen(bus.publish({ ref, type: "session.archived", archived }))),
-        ),
+        Effect.flatMap((metadata) => {
+          const changed = (metadata.archived ?? false) !== archived;
+          const persist = changed ? repo.write({ ...metadata, archived }) : Effect.void;
+          // Archive is also a lifecycle boundary: persist first so a failed
+          // metadata write never kills live work. Restore stays cold until open.
+          const close = archived
+            ? manager.close(ref).pipe(Effect.andThen(bus.closeSession(ref, "session_closed")))
+            : Effect.void;
+          const publish = changed
+            ? bus.publish({ ref, type: "session.archived", archived })
+            : Effect.void;
+          return persist.pipe(Effect.andThen(close), Effect.andThen(publish));
+        }),
       ),
 
     // A pure read of our own records — display data is self-owned (title from

--- a/packages/server/src/rpc/session.ts
+++ b/packages/server/src/rpc/session.ts
@@ -109,7 +109,7 @@ export const sessionRouter = orpc.router({
     const projects = yield* ProjectService;
     const sessions = yield* HarnessAgentSessionService;
     return yield* projects.findById(input.projectId).pipe(
-      Effect.andThen(sessions.list(input.projectId)),
+      Effect.andThen(sessions.list(input.projectId, input.archived ?? false)),
       Effect.catchTags({
         ProjectNotFound: (e) =>
           Effect.fail(errors.NOT_FOUND({ message: `project ${e.projectId} not found` })),
@@ -119,6 +119,19 @@ export const sessionRouter = orpc.router({
   rename: orpc.rename.effect(function* ({ input, errors }) {
     const sessions = yield* HarnessAgentSessionService;
     yield* sessions.rename(input.ref, input.name).pipe(
+      Effect.catchTags({
+        SessionNotFound: (e) =>
+          Effect.fail(errors.NOT_FOUND({ message: `session ${e.sessionId} not found` })),
+        SessionRefMismatch: (e) =>
+          Effect.fail(
+            errors.INVALID_ARGUMENT({ message: `ref mismatch for session ${e.sessionId}` }),
+          ),
+      }),
+    );
+  }),
+  archive: orpc.archive.effect(function* ({ input, errors }) {
+    const sessions = yield* HarnessAgentSessionService;
+    yield* sessions.archive(input.ref, input.archived).pipe(
       Effect.catchTags({
         SessionNotFound: (e) =>
           Effect.fail(errors.NOT_FOUND({ message: `session ${e.sessionId} not found` })),

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -45,6 +45,8 @@ export interface Session {
   readonly cwd?: string;
   /** Display title, set from the session's first prompt. */
   readonly title?: string;
+  /** Whether the session is hidden from the project's primary session list. */
+  readonly archived?: boolean;
   /** Recency (ISO). Reserved — not written yet (see the type doc). */
   readonly updatedAt?: string;
   /** Whether the backend still has the transcript. Reserved — not written yet. */

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -192,6 +192,7 @@ describe("HarnessAgentSessionService", () => {
     expect(result.stored.harnessSessionId).toBe("native-1");
     expect(result.stored.projectId).toBe("proj-a");
     expect(result.stored.cwd).toBe("/tmp/vibest-app");
+    expect(result.stored.archived).toBe(false);
   });
 
   it("create surfaces AgentUnavailable and writes no metadata", async () => {
@@ -269,7 +270,7 @@ describe("HarnessAgentSessionService", () => {
       Effect.gen(function* () {
         const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
         yield* fixture.service.delete(ref);
-        const listed = yield* fixture.service.list("proj-a");
+        const listed = yield* fixture.service.list("proj-a", false);
         return { listed, closeSpy: fixture.spy.close };
       }),
     );
@@ -282,7 +283,7 @@ describe("HarnessAgentSessionService", () => {
       Effect.gen(function* () {
         const a = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
         const b = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
-        const listed = yield* fixture.service.list("proj-a");
+        const listed = yield* fixture.service.list("proj-a", false);
         return { a, b, listed };
       }),
     );
@@ -292,6 +293,47 @@ describe("HarnessAgentSessionService", () => {
     );
     // We own the record, so a session we created reads as history-available.
     expect(result.listed.every((summary) => summary.historyAvailable)).toBe(true);
+    expect(result.listed.every((summary) => !summary.archived)).toBe(true);
+  });
+
+  it("archives and restores a session, publishing each changed state", async () => {
+    const result = await run({}, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        return yield* Effect.scoped(
+          Effect.gen(function* () {
+            const stream = yield* fixture.bus.subscribe({ kind: "global" });
+            yield* fixture.service.archive(ref, true);
+            const archived = yield* fixture.service.list("proj-a", true);
+            const activeWhileArchived = yield* fixture.service.list("proj-a", false);
+            yield* fixture.service.archive(ref, true); // idempotent: no duplicate event
+            yield* fixture.service.archive(ref, false);
+            const restored = yield* fixture.service.list("proj-a", false);
+            const archivedAfterRestore = yield* fixture.service.list("proj-a", true);
+            const items = yield* Stream.runCollect(Stream.take(stream, 2));
+            return {
+              archived,
+              activeWhileArchived,
+              restored,
+              archivedAfterRestore,
+              items: Array.from(items),
+            };
+          }),
+        );
+      }),
+    );
+
+    expect(result.archived[0]?.archived).toBe(true);
+    expect(result.activeWhileArchived).toEqual([]);
+    expect(result.restored[0]?.archived).toBe(false);
+    expect(result.archivedAfterRestore).toEqual([]);
+    expect(
+      result.items.map((item) =>
+        item.type === "event" && item.event.type === "session.archived"
+          ? item.event.archived
+          : undefined,
+      ),
+    ).toEqual([true, false]);
   });
 
   it("getMessages reopens a closed session and reads through the live instance", async () => {
@@ -471,7 +513,7 @@ describe("HarnessAgentSessionService", () => {
           ref,
           parts: [{ type: "text", text: "  Fix the  login  bug " }],
         });
-        return yield* fixture.service.list("proj-a");
+        return yield* fixture.service.list("proj-a", false);
       }),
     );
     expect(listed).toHaveLength(1);
@@ -628,7 +670,7 @@ describe("HarnessAgentSessionService", () => {
         const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
         yield* fixture.service.prompt({ ref, parts: [{ type: "text", text: "first" }] });
         yield* fixture.service.prompt({ ref, parts: [{ type: "text", text: "second" }] });
-        return yield* fixture.service.list("proj-a");
+        return yield* fixture.service.list("proj-a", false);
       }),
     );
     expect(listed[0]?.title).toBe("first");
@@ -638,7 +680,7 @@ describe("HarnessAgentSessionService", () => {
     const listed = await run({}, (fixture) =>
       Effect.gen(function* () {
         yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
-        return yield* fixture.service.list("proj-a");
+        return yield* fixture.service.list("proj-a", false);
       }),
     );
     expect(listed).toHaveLength(1);

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -484,7 +484,7 @@ describe("HarnessAgentSessionService", () => {
         yield* restarted.service.prepare(ref, "/tmp/vibest-app");
         const status = yield* restarted.service.getStatus(ref);
         const snapshot = yield* restarted.service.getSnapshot(ref);
-        const listed = yield* restarted.service.list("proj-a");
+        const listed = yield* restarted.service.list("proj-a", false);
         const messages = yield* restarted.service.getMessages(ref, "/tmp/vibest-app");
         return { ref, status, snapshot, listed, messages, spy: fixture.spy };
       }),

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -374,6 +374,24 @@ describe("HarnessAgentSessionService", () => {
       }
     });
 
+  it("archives a running session and closes its live instance", async () => {
+    const result = await run({ turn: "open" }, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        yield* waitForTurn(fixture, ref, (turn) => turn !== null && !turn.complete);
+        yield* fixture.service.archive(ref, true);
+        const active = yield* fixture.service.list("proj-a", false);
+        const archived = yield* fixture.service.list("proj-a", true);
+        return { active, archived, closed: fixture.spy.close.slice() };
+      }),
+    );
+
+    expect(result.active).toEqual([]);
+    expect(result.archived).toHaveLength(1);
+    expect(result.archived[0]?.status).toBeUndefined();
+    expect(result.closed).toEqual(["native-1"]);
+  });
+
   it("getMessages trims the last user segment while a turn is in flight", async () => {
     const messages = await run({ history: fourTurnHistory, turn: "open" }, (fixture) =>
       Effect.gen(function* () {

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -174,27 +174,39 @@ describe("session router", () => {
     }
   });
 
-  it("lists sessions with live status and drops them on delete", async () => {
+  it("lists, archives, restores, and deletes sessions", async () => {
     const { client, workspace, dispose } = await setup();
     try {
       const project = await client.project.create({ path: workspace });
       const ref = await client.session.create({ projectId: project.id, harnessAgentId: "codex" });
 
       // Active session: list carries the live phase from the running runtime.
+      // Omitted `archived` defaults to the active-session listing.
       const active = await client.session.list({ projectId: project.id });
       expect(active).toHaveLength(1);
       expect(active[0]?.sessionId).toBe(ref.sessionId);
       expect(active[0]?.status?.phase).toBeDefined();
+      expect(active[0]?.archived).toBe(false);
+
+      await client.session.archive({ ref, archived: true });
+      const archived = await client.session.list({ projectId: project.id, archived: true });
+      expect(archived[0]?.archived).toBe(true);
+      expect(await client.session.list({ projectId: project.id, archived: false })).toEqual([]);
+
+      await client.session.archive({ ref, archived: false });
+      const restored = await client.session.list({ projectId: project.id, archived: false });
+      expect(restored[0]?.archived).toBe(false);
+      expect(await client.session.list({ projectId: project.id, archived: true })).toEqual([]);
 
       // Closed but not deleted: metadata stays, the runtime is gone → no status.
       await client.session.close({ ref });
-      const idle = await client.session.list({ projectId: project.id });
+      const idle = await client.session.list({ projectId: project.id, archived: false });
       expect(idle).toHaveLength(1);
       expect(idle[0]?.status).toBeUndefined();
 
       // Delete: metadata removed → the session leaves the listing entirely.
       await client.session.delete({ ref });
-      const empty = await client.session.list({ projectId: project.id });
+      const empty = await client.session.list({ projectId: project.id, archived: false });
       expect(empty).toHaveLength(0);
     } finally {
       await dispose();


### PR DESCRIPTION
## Summary

- persist an archived flag in session metadata and expose archive/unarchive through the session contract
- filter session.list by an optional archived input that defaults to false
- add Archive and Restore actions plus a lazily loaded Archived section in each project group
- keep active and archived TanStack Query caches converged through collection events

## Validation

- `pnpm lint:check`
- `pnpm format:check`
- `pnpm turbo run typecheck --filter=@vibest/contract --filter=@vibest/server --filter=@vibest/app --force`
- `pnpm turbo run test --filter=@vibest/contract --filter=@vibest/app --force` — 113 passed
- `pnpm turbo run test --filter=@vibest/server --force` — 363 passed, 2 skipped
- `pnpm turbo run build --filter=@vibest/app --filter=@vibest/server --force`
- React Doctor against `origin/main`: 100/100
- verified archive, lazy archived-list loading, restore, and project collapsing in the browser