### PR TITLE
test(server): isolate Codex agent workspaces

### DIFF
--- a/packages/server/test/harness/codex/agent.test.ts
+++ b/packages/server/test/harness/codex/agent.test.ts
@@ -1,11 +1,10 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { layer } from "@effect/vitest";
-import { Deferred, Effect, Fiber, Ref, Stream } from "effect";
+import { Deferred, Effect, Fiber, FileSystem, Ref, Stream } from "effect";
 
 import type { CodexTransport } from "../../../src/harness/codex";
 import { makeCodexAdapter } from "../../../src/harness/codex/adapter";
@@ -94,13 +93,19 @@ rl.on("line", (line) => {
 });
 `;
 
-function makeFake(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-codex-"));
+const makeTempDirectory = (prefix: string) =>
+  FileSystem.FileSystem.pipe(
+    Effect.flatMap((fileSystem) => fileSystem.makeTempDirectoryScoped({ prefix })),
+  );
+
+const makeFakeAgent = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const dir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "fake-codex-" });
   const file = path.join(dir, "fake-codex.js");
-  fs.writeFileSync(file, FAKE);
-  fs.chmodSync(file, 0o755);
-  return file;
-}
+  yield* fileSystem.writeFileString(file, FAKE);
+  yield* fileSystem.chmod(file, 0o755);
+  return yield* makeCodexAgent({ executablePath: file });
+});
 
 layer(NodeServices.layer)("CodexAgent", (it) => {
   it.effect("does not let an old transport generation evict new sessions", () =>
@@ -184,8 +189,9 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("creates a thread and streams a full turn", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
+      const cwd = yield* makeTempDirectory("codex-agent-");
+      const agent = yield* makeFakeAgent;
+      const { sessionId } = yield* agent.session.create({ cwd });
       assert.equal(sessionId, "th_1");
 
       const prompt = yield* agent.session.prompt({ sessionId, text: "ping" });
@@ -203,8 +209,8 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
       // Codex fixes a model at thread/start and has no set-model call, so a
       // create-time choice can only reach it as a turn override. If this
       // regresses, picking a model silently does nothing.
-      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-model-"));
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const workspace = yield* makeTempDirectory("codex-model-");
+      const agent = yield* makeFakeAgent;
       const session = yield* makeCodexAdapter(agent).open({
         cwd: workspace,
         model: "gpt-5.6-luna",
@@ -218,8 +224,8 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("leaves the model unset when nothing was chosen", () =>
     Effect.gen(function* () {
-      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-model-"));
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const workspace = yield* makeTempDirectory("codex-model-");
+      const agent = yield* makeFakeAgent;
       const session = yield* makeCodexAdapter(agent).open({ cwd: workspace });
 
       yield* session.prompt({ parts: [{ type: "text", text: "ping" }] });
@@ -232,7 +238,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("surfaces thread metadata as session info", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const agent = yield* makeFakeAgent;
       const result = yield* makeCodexAdapter(agent).getSessionInfo("th_1");
       assert.equal(result._tag, "found");
       if (result._tag === "found") {
@@ -245,7 +251,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("falls back to the thread preview when it has no title", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const agent = yield* makeFakeAgent;
       const result = yield* makeCodexAdapter(agent).getSessionInfo("th_untitled");
       assert.equal(result._tag, "found");
       if (result._tag === "found") assert.equal(result.info.title, "first message");
@@ -254,7 +260,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("maps an unknown thread to missing session info", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const agent = yield* makeFakeAgent;
       const result = yield* makeCodexAdapter(agent).getSessionInfo("th_missing");
       assert.equal(result._tag, "missing");
     }),
@@ -262,7 +268,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("reports a transport crash while the adapter session is idle", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const agent = yield* makeFakeAgent;
       const session = yield* makeCodexAdapter(agent).open({ cwd: "/tmp/idle-crash" });
       const crashSeen = yield* Deferred.make<void>();
       yield* Stream.runForEach(session.events, (event) =>
@@ -297,8 +303,8 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("interrupts a turn requested while turn/start is still pending", () =>
     Effect.gen(function* () {
-      const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "codex-starting-interrupt-"));
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const cwd = yield* makeTempDirectory("codex-starting-interrupt-");
+      const agent = yield* makeFakeAgent;
       const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* Effect.forkChild(
         agent.session.prompt({ sessionId, text: "slow-start" }),
@@ -327,8 +333,8 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("interrupts the native turn when the prompt caller cancels during turn/start", () =>
     Effect.gen(function* () {
-      const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "codex-starting-cancel-"));
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
+      const cwd = yield* makeTempDirectory("codex-starting-cancel-");
+      const agent = yield* makeFakeAgent;
       const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* Effect.forkChild(
         agent.session.prompt({ sessionId, text: "slow-start" }),
@@ -364,8 +370,9 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("unblocks a waiting prompt when the transport crashes", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
+      const cwd = yield* makeTempDirectory("codex-agent-");
+      const agent = yield* makeFakeAgent;
+      const { sessionId } = yield* agent.session.create({ cwd });
       yield* agent.session.prompt({ sessionId, text: "hold" });
       const secondDone = yield* Deferred.make<void>();
       yield* agent.session.prompt({ sessionId, text: "steer-after-crash" }).pipe(
@@ -400,8 +407,9 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("exposes prompt output through the unified adapter event stream", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const session = yield* makeCodexAdapter(agent).open({ cwd: "/tmp" });
+      const cwd = yield* makeTempDirectory("codex-agent-");
+      const agent = yield* makeFakeAgent;
+      const session = yield* makeCodexAdapter(agent).open({ cwd });
       const collected = yield* Effect.forkChild(
         Stream.runCollect(
           session.events.pipe(
@@ -432,8 +440,9 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("keeps a retryable error inside the active turn", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
+      const cwd = yield* makeTempDirectory("codex-agent-");
+      const agent = yield* makeFakeAgent;
+      const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* agent.session.prompt({ sessionId, text: "retry" });
       const chunks = yield* Stream.runCollect(prompt.output);
 
@@ -445,14 +454,13 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("does not let an abandoned session stall the shared transport", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
+      const cwd = yield* makeTempDirectory("codex-agent-");
+      const agent = yield* makeFakeAgent;
+      const { sessionId } = yield* agent.session.create({ cwd });
 
       const prompt = yield* agent.session.prompt({ sessionId, text: "flood" });
       yield* Stream.runHead(prompt.output);
-      const replacement = yield* agent.session
-        .create({ cwd: "/tmp" })
-        .pipe(Effect.timeout("2 seconds"));
+      const replacement = yield* agent.session.create({ cwd }).pipe(Effect.timeout("2 seconds"));
       assert.equal(replacement.sessionId, "th_1");
       yield* agent.session.abort(replacement.sessionId);
     }),
@@ -460,8 +468,9 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
 
   it.effect("crashes existing sessions and lazily starts a replacement transport", () =>
     Effect.gen(function* () {
-      const agent = yield* makeCodexAgent({ executablePath: makeFake() });
-      const { sessionId } = yield* agent.session.create({ cwd: "/tmp" });
+      const cwd = yield* makeTempDirectory("codex-agent-");
+      const agent = yield* makeFakeAgent;
+      const { sessionId } = yield* agent.session.create({ cwd });
       const prompt = yield* agent.session.prompt({ sessionId, text: "crash" });
       const chunks = yield* Stream.runCollect(prompt.output);
       assert.deepEqual(
@@ -469,7 +478,7 @@ layer(NodeServices.layer)("CodexAgent", (it) => {
         ["start", "text-start", "text-delta", "error"],
       );
 
-      const replacement = yield* agent.session.create({ cwd: "/tmp" });
+      const replacement = yield* agent.session.create({ cwd });
       const replacementPrompt = yield* agent.session.prompt({
         sessionId: replacement.sessionId,
         text: "ping",


### PR DESCRIPTION
## Summary

- create a scoped temporary workspace for each Codex agent test instead of writing fixtures directly into global /tmp
- create and clean up fake Codex executables through Effect FileSystem
- prevent local root test runs from leaving files that the github-runner user cannot overwrite

## Root cause

The self-hosted runner executes as github-runner, while local agent work runs as root. A test used /tmp as its session cwd, so a local run created /tmp/turn-model as root:root with mode 0644. Subsequent CI runs failed with EACCES when the fake Codex process tried to overwrite it.

## Verification

- pnpm turbo run test --filter=@vibest/server -- test/harness/codex/agent.test.ts
- pnpm turbo run build test typecheck --filter=@vibest/server --force
- pnpm turbo run build test typecheck
- pnpm run lint:check
- pnpm run format:check