### PR TITLE
fix(app): read composer content through the controller, not useEditorState

### DIFF
--- a/apps/app/src/features/chat/components/chat-input-composer.tsx
+++ b/apps/app/src/features/chat/components/chat-input-composer.tsx
@@ -1,4 +1,3 @@
-import { useEditorState } from "@tiptap/react";
 import {
   PromptInput,
   PromptInputSubmit,
@@ -15,8 +14,8 @@ import { ChatInput } from "./input/chat-input";
 import { ChatInputProvider } from "./input/chat-input-provider";
 import { createChatBaseExtensions } from "./input/extensions/chat-base-extensions";
 import { createSubmitKeymap } from "./input/extensions/keymaps";
-import { hasChatContent } from "./input/serialize";
 import { useChatInputController } from "./input/use-chat-input-controller";
+import { useChatInputHasContent } from "./input/use-chat-input-has-content";
 
 // Live-session input bar on the TipTap chat-input kit: Enter sends (IME-safe,
 // handled by the submit keymap) / Shift+Enter breaks the line; an in-flight
@@ -44,10 +43,7 @@ export function ChatInputComposer({ toolbar }: { toolbar?: ReactNode }) {
     },
   });
 
-  const hasContent = useEditorState({
-    editor: controller?.editor ?? null,
-    selector: ({ editor }) => (editor ? hasChatContent(editor) : false),
-  });
+  const hasContent = useChatInputHasContent(controller);
 
   return (
     <PromptInput

--- a/apps/app/src/features/chat/components/input/chat-input-controller.test.ts
+++ b/apps/app/src/features/chat/components/input/chat-input-controller.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+// Tiptap builds its document through `elementFromString`, so these need a DOM;
+// the rest of this package's tests are node-env, hence the per-file override.
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatInputController } from "./chat-input-controller";
+import { createChatBaseExtensions } from "./extensions/chat-base-extensions";
+
+const makeController = () =>
+  new ChatInputController({
+    extensions: () => createChatBaseExtensions(),
+    onSubmit: () => {},
+  });
+
+describe("ChatInputController", () => {
+  it("reports content on the same threshold submit() uses", () => {
+    const controller = makeController();
+
+    expect(controller.hasContent()).toBe(false);
+
+    controller.editor.commands.setContent("<p>   </p>");
+    expect(controller.hasContent()).toBe(false);
+
+    controller.editor.commands.setContent("<p>hi</p>");
+    expect(controller.hasContent()).toBe(true);
+    expect(controller.getText()).toBe("hi");
+
+    controller.dispose();
+  });
+
+  it("notifies subscribers on edits and stops on unsubscribe", () => {
+    const controller = makeController();
+    const listener = vi.fn<() => void>();
+    const unsubscribe = controller.onChange(listener);
+
+    controller.editor.commands.setContent("<p>hi</p>");
+    expect(listener).toHaveBeenCalled();
+
+    unsubscribe();
+    listener.mockClear();
+    controller.editor.commands.setContent("<p>bye</p>");
+    expect(listener).not.toHaveBeenCalled();
+
+    controller.dispose();
+  });
+
+  // The state React hands the committed `useSyncExternalStore` snapshot when a
+  // route match suspends: the controller effect's cleanup has already disposed
+  // this instance, but the last committed render still closes over it. Reading
+  // the destroyed editor is what threw `Cannot read properties of null
+  // (reading 'extensions')` — `Editor.destroy()` nulls `extensionManager`, and
+  // serialization walks it first.
+  it("answers false instead of throwing once disposed", () => {
+    const controller = makeController();
+    controller.editor.commands.setContent("<p>hi</p>");
+    expect(controller.hasContent()).toBe(true);
+
+    controller.dispose();
+
+    expect(() => controller.hasContent()).not.toThrow();
+    expect(controller.hasContent()).toBe(false);
+  });
+});

--- a/apps/app/src/features/chat/components/input/chat-input-controller.ts
+++ b/apps/app/src/features/chat/components/input/chat-input-controller.ts
@@ -1,6 +1,6 @@
 import { Editor, type Extensions } from "@tiptap/react";
 
-import { getChatText } from "./serialize";
+import { getChatText, hasChatContent } from "./serialize";
 
 export interface ChatInputControllerOptions {
   /** Factory receives self so it can close () => self.submit() into keymap extensions. */
@@ -33,6 +33,30 @@ export class ChatInputController {
 
   getText() {
     return getChatText(this.editor);
+  }
+
+  /**
+   * Whether `submit()` would send anything — the same threshold, read off the
+   * same document, so the send button and the send path can't drift apart.
+   *
+   * A disposed controller answers `false` rather than throwing: React can hand
+   * a `useSyncExternalStore` snapshot the outgoing controller *after* this
+   * effect's cleanup has already run (see `useChatInputHasContent`), and
+   * "destroyed editor" is genuinely "nothing to send".
+   */
+  hasContent(): boolean {
+    return this.editor.isDestroyed ? false : hasChatContent(this.editor);
+  }
+
+  /**
+   * Subscribe to document changes. Every transaction fires — callers that only
+   * care about a derived value re-read it and compare there.
+   */
+  onChange(listener: () => void): () => void {
+    this.editor.on("transaction", listener);
+    return () => {
+      this.editor.off("transaction", listener);
+    };
   }
 
   async submit() {

--- a/apps/app/src/features/chat/components/input/use-chat-input-has-content.test.ts
+++ b/apps/app/src/features/chat/components/input/use-chat-input-has-content.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+// Plain `.ts` + createElement on purpose: apps/app's vitest config carries no
+// JSX transform, and one element isn't worth adding a babel pass to every test.
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ChatInputController } from "./chat-input-controller";
+import { createChatBaseExtensions } from "./extensions/chat-base-extensions";
+import { useChatInputHasContent } from "./use-chat-input-has-content";
+
+// What `act` checks for before it will flush React work.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const makeController = (html?: string) => {
+  const controller = new ChatInputController({
+    extensions: () => createChatBaseExtensions(),
+    onSubmit: () => {},
+  });
+  if (html) controller.editor.commands.setContent(html);
+  return controller;
+};
+
+function Probe({ controller }: { controller: ChatInputController | null }) {
+  return createElement("span", null, String(useChatInputHasContent(controller)));
+}
+
+let root: Root | undefined;
+let host: HTMLDivElement | undefined;
+
+const render = (controller: ChatInputController | null): string => {
+  if (!host) {
+    host = document.createElement("div");
+    document.body.append(host);
+    root = createRoot(host);
+  }
+  const mounted = root;
+  act(() => mounted?.render(createElement(Probe, { controller })));
+  return host.textContent ?? "";
+};
+
+afterEach(() => {
+  const mounted = root;
+  act(() => mounted?.unmount());
+  host?.remove();
+  root = undefined;
+  host = undefined;
+});
+
+describe("useChatInputHasContent", () => {
+  it("starts false while the controller is still being created", () => {
+    expect(render(null)).toBe("false");
+  });
+
+  it("tracks edits on the mounted controller", () => {
+    const controller = makeController();
+    expect(render(controller)).toBe("false");
+
+    act(() => {
+      controller.editor.commands.setContent("<p>hi</p>");
+    });
+    expect(host?.textContent).toBe("true");
+
+    act(() => {
+      controller.editor.commands.clearContent();
+    });
+    expect(host?.textContent).toBe("false");
+
+    controller.dispose();
+  });
+
+  // The session-switch window: React tears the controller effect down and back
+  // up while this component stays mounted (a route match suspending on its
+  // loader, StrictMode, <Activity>), so one editor is destroyed and another
+  // built between two renders of the same fiber. Both halves have to hold —
+  // rendering the outgoing, already-disposed controller must not throw, and the
+  // incoming one must be read immediately rather than waiting for its first
+  // transaction. `useEditorState` failed both: its cached snapshot still
+  // pointed at the destroyed editor.
+  it("survives the disposed outgoing controller and reads the incoming one at once", () => {
+    const outgoing = makeController("<p>typed before switching</p>");
+    expect(render(outgoing)).toBe("true");
+
+    outgoing.dispose();
+    expect(() => render(outgoing)).not.toThrow();
+    expect(host?.textContent).toBe("false");
+
+    const incoming = makeController("<p>restored draft</p>");
+    expect(render(incoming)).toBe("true");
+
+    incoming.dispose();
+  });
+});

--- a/apps/app/src/features/chat/components/input/use-chat-input-has-content.ts
+++ b/apps/app/src/features/chat/components/input/use-chat-input-has-content.ts
@@ -1,0 +1,34 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+import type { ChatInputController } from "./chat-input-controller";
+
+const NO_UNSUBSCRIBE = () => {};
+
+/**
+ * Whether the composer holds something submittable — subscribed to the
+ * controller, not to a Tiptap editor.
+ *
+ * Not `useEditorState`: its `EditorStateManager` caches the last snapshot and
+ * refreshes it only when its own transaction counter moves. Swapping the
+ * `editor` prop updates the manager's field but leaves the cached snapshot
+ * pointing at the *previous* instance, so the selector keeps being handed an
+ * editor the controller has already destroyed — and `Editor.destroy()` nulls
+ * `extensionManager`, which is the first thing serialization reads.
+ *
+ * That swap is not exotic: React tears the controller effect down and back up
+ * while this component stays mounted (a route match suspending on its loader,
+ * StrictMode, `<Activity>`), so `useChatInputController` disposes one editor
+ * and builds another between two renders of the same fiber. Reading through
+ * the controller keeps that impossible — there is no editor reference held
+ * across the swap — and it also drops the staleness the cache caused, where
+ * the send button reflected the old editor until the new one first changed.
+ */
+export function useChatInputHasContent(controller: ChatInputController | null): boolean {
+  return useSyncExternalStore(
+    useCallback(
+      (onStoreChange: () => void) => controller?.onChange(onStoreChange) ?? NO_UNSUBSCRIBE,
+      [controller],
+    ),
+    useCallback(() => controller?.hasContent() ?? false, [controller]),
+  );
+}

--- a/apps/app/src/routes/draft.tsx
+++ b/apps/app/src/routes/draft.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEditorState } from "@tiptap/react";
 import type { ListSessionsOutput, SessionSummary } from "@vibest/contract";
 import {
   HARNESS_AGENT_IDS,
@@ -33,8 +32,8 @@ import { ChatInput } from "@/features/chat/components/input/chat-input";
 import { ChatInputProvider } from "@/features/chat/components/input/chat-input-provider";
 import { createChatBaseExtensions } from "@/features/chat/components/input/extensions/chat-base-extensions";
 import { createSubmitKeymap } from "@/features/chat/components/input/extensions/keymaps";
-import { hasChatContent } from "@/features/chat/components/input/serialize";
 import { useChatInputController } from "@/features/chat/components/input/use-chat-input-controller";
+import { useChatInputHasContent } from "@/features/chat/components/input/use-chat-input-has-content";
 import { ModelSelect } from "@/features/chat/components/model-select";
 import { PermissionModeSelect } from "@/features/chat/components/permission-mode-select";
 import { orderPermissionModes } from "@/features/chat/harness/permission-modes";
@@ -224,10 +223,7 @@ function DraftRoute() {
     },
   });
 
-  const hasContent = useEditorState({
-    editor: controller?.editor ?? null,
-    selector: ({ editor }) => (editor ? hasChatContent(editor) : false),
-  });
+  const hasContent = useChatInputHasContent(controller);
 
   // Every branch below renders instead of the composer, because a composer that
   // can never submit is worse than saying why. `data === undefined` must be

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/node": "catalog:",
     "agent-cli-detector": "^0.1.4",
     "eslint-plugin-react-you-might-not-need-an-effect": "^1.0.1",
+    "jsdom": "^26.1.0",
     "lint-staged": "^17.1.0",
     "oxfmt": "^0.58.0",
     "oxlint": "^1.74.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       eslint-plugin-react-you-might-not-need-an-effect:
         specifier: ^1.0.1
         version: 1.0.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0(supports-color@10.2.2)
       lint-staged:
         specifier: ^17.1.0
         version: 17.1.0
@@ -305,7 +308,7 @@ importers:
         version: 0.1.48(react@19.2.7)
       react-scan:
         specifier: 'catalog:'
-        version: 0.5.7(patch_hash=3db48cf39ae98df6cc3c03ce20b2445004e89a6dd46e078b75ca8e795db568a9)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.24.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.2.0)(rollup@4.57.1)(supports-color@10.2.2)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@10.2.2))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 0.5.7(patch_hash=3db48cf39ae98df6cc3c03ce20b2445004e89a6dd46e078b75ca8e795db568a9)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.24.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.2.0)(rollup@4.57.1)(supports-color@10.2.2)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@10.2.2))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/desktop:
     dependencies:
@@ -5433,8 +5436,8 @@ packages:
   deslop-js@0.9.2:
     resolution: {integrity: sha512-rGhQ17gHnmsjG5KFJM4+oN4bOxktHiPGqzJxKqWt0Qw/NLZIsEgLH1wIo1tTXRyN/MNwhchKbfUieFiWyAh0pQ==}
 
-  deslop-js@0.9.4:
-    resolution: {integrity: sha512-tiUyzTadQM0BWSGaP0u347c4q2vDIHyY0GUg0jY3Py6nEU0uaB6P0fKevWJmaYK4N+i+H7oE3GYdumfx/AcsUw==}
+  deslop-js@0.9.5:
+    resolution: {integrity: sha512-PzxOcLcU/k1crrgjjxKcYH09ZILME0bnDgb0tToXjhIRhJT8e1e8i0/FL7kt6iMVVptFelws0tX/UQRgUoo2qg==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -6035,10 +6038,6 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  has-flag@5.0.1:
-    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
-    engines: {node: '>=12'}
-
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -6198,12 +6197,6 @@ packages:
   ini@7.0.0:
     resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
-
-  ink-link@5.0.0:
-    resolution: {integrity: sha512-TFDXc/0mwUW7LMjsr0/LeLxPVV5BnHDuDQff9RCgP4rb3R+V/4dIwGBZbCevcJZtQnVcW+Iz1LUrUbpq+UDwYA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      ink: '>=6'
 
   ink-spinner@5.0.0:
     resolution: {integrity: sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==}
@@ -7196,8 +7189,8 @@ packages:
     resolution: {integrity: sha512-fTciSOgAGe/KAgvFDKLz9crjxHyAuu0BvT5sXfSdo2B5QmY5Y/j3nliqX6FaGr7Wud1SYvkAky+/m+58b6K6fQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
-  oxlint-plugin-react-doctor@0.9.4:
-    resolution: {integrity: sha512-JydpWgYo2nZPAO+9Zc3H7SzwPaqsCMTPHMRHHbtXdjL440y/aU/89gV8hfNCXhoNBafVRAg9Z9Jjl9uGg1hfWA==}
+  oxlint-plugin-react-doctor@0.9.5:
+    resolution: {integrity: sha512-fwFrQy/93dqN+n873buCc+GsfPZznemW/X3dUtVClckB63amby+nA0xcz398vRFist7GQMXeNz1lYaxlE6sd5Q==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@0.24.0:
@@ -7585,8 +7578,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
-  react-doctor@0.9.4:
-    resolution: {integrity: sha512-Zq8dmmLOyuyJselHQVJhsfCATjYN5+TeXSJmbC1IUH2kfmD8hC4NomV5A4ZrarSG5lqIwlar4ehYGlXDMBNokw==}
+  react-doctor@0.9.5:
+    resolution: {integrity: sha512-RQPueMP8kdmJj0jryjmWtsmQAq8ZGFVprgGK6Hkdy1SozkGBJXL6zkzIsZ7ZTrIvETJIoPOa4maY1IlTXchhSw==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -8112,10 +8105,6 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  supports-hyperlinks@4.5.0:
-    resolution: {integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==}
-    engines: {node: '>=20'}
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -8156,10 +8145,6 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
-
-  terminal-link@5.0.0:
-    resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
-    engines: {node: '>=20'}
 
   terminal-size@4.0.1:
     resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
@@ -9002,7 +8987,6 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
-    optional: true
 
   '@astrojs/compiler@4.0.0': {}
 
@@ -9576,14 +9560,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@csstools/color-helpers@5.1.0':
-    optional: true
+  '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-    optional: true
 
   '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -9591,15 +9573,12 @@ snapshots:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-    optional: true
 
   '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
-    optional: true
 
-  '@csstools/css-tokenizer@3.0.4':
-    optional: true
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@date-fns/tz@1.2.0': {}
 
@@ -13538,7 +13517,6 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
-    optional: true
 
   csstype@3.2.3: {}
 
@@ -13732,7 +13710,6 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-    optional: true
 
   date-fns-jalali@4.1.0-0: {}
 
@@ -13756,8 +13733,7 @@ snapshots:
     optionalDependencies:
       supports-color: 7.2.0
 
-  decimal.js@10.6.0:
-    optional: true
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -13812,7 +13788,7 @@ snapshots:
       oxc-resolver: 11.24.2
       typescript: 5.9.3
 
-  deslop-js@0.9.4:
+  deslop-js@0.9.5:
     dependencies:
       '@oxc-project/types': 0.142.0
       fast-glob: 3.3.3
@@ -14598,8 +14574,6 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  has-flag@5.0.1: {}
-
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -14731,7 +14705,6 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
-    optional: true
 
   html-url-attributes@3.0.1: {}
 
@@ -14815,11 +14788,6 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@7.0.0: {}
-
-  ink-link@5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5)):
-    dependencies:
-      ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
-      terminal-link: 5.0.0
 
   ink-spinner@5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -14916,8 +14884,7 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -14998,7 +14965,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   jsesc@3.1.0: {}
 
@@ -15898,8 +15864,7 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
-  nwsapi@2.2.23:
-    optional: true
+  nwsapi@2.2.23: {}
 
   object-assign@4.1.1: {}
 
@@ -16140,7 +16105,7 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       oxc-parser: 0.141.0
 
-  oxlint-plugin-react-doctor@0.9.4:
+  oxlint-plugin-react-doctor@0.9.5:
     dependencies:
       '@shaderfrog/glsl-parser': 7.0.1
       '@typescript-eslint/types': 8.63.0
@@ -16665,7 +16630,7 @@ snapshots:
       - utf-8-validate
       - vite-plus
 
-  react-doctor@0.9.4(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.24.0)(supports-color@10.2.2)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@10.2.2))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
+  react-doctor@0.9.5(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.24.0)(supports-color@10.2.2)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@10.2.2))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@babel/code-frame': 7.29.7
@@ -16673,34 +16638,27 @@ snapshots:
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.9.4
+      deslop-js: 0.9.5
       eslint-plugin-react-hooks: 7.1.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
       figures: 6.1.0
-      ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
-      ink-link: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))
-      ink-spinner: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5)
       jiti: 2.7.0
       magicast: 0.5.3
       oxc-resolver: 11.24.2
       oxlint: 1.76.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@10.2.2))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint-plugin-react-doctor: 0.9.4
+      oxlint-plugin-react-doctor: 0.9.5
       prompts: 2.4.2
-      react: 19.2.5
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
       yaml: 2.9.0
+      yoga-layout: 3.2.1
     transitivePeerDependencies:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
-      - '@types/react'
-      - bufferutil
       - eslint
       - oxlint-tsgolint
-      - react-devtools-core
       - supports-color
-      - utf-8-validate
       - vite-plus
 
   react-dom@19.2.7(react@19.2.7):
@@ -16734,7 +16692,7 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
-  react-scan@0.5.7(patch_hash=3db48cf39ae98df6cc3c03ce20b2445004e89a6dd46e078b75ca8e795db568a9)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.24.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.2.0)(rollup@4.57.1)(supports-color@10.2.2)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@10.2.2))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  react-scan@0.5.7(patch_hash=3db48cf39ae98df6cc3c03ce20b2445004e89a6dd46e078b75ca8e795db568a9)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.24.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.2.0)(rollup@4.57.1)(supports-color@10.2.2)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@10.2.2))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
@@ -16746,7 +16704,7 @@ snapshots:
       preact: 10.29.7
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.9.4(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.24.0)(supports-color@10.2.2)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@10.2.2))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      react-doctor: 0.9.5(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(oxlint-tsgolint@0.24.0)(supports-color@10.2.2)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@26.1.0(supports-color@10.2.2))(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.50(react@19.2.7)
     optionalDependencies:
@@ -16757,18 +16715,14 @@ snapshots:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
       - '@rspack/core'
-      - '@types/react'
-      - bufferutil
       - bun-types-no-globals
       - eslint
       - oxlint-tsgolint
       - preact-render-to-string
-      - react-devtools-core
       - rolldown
       - rollup
       - supports-color
       - unloader
-      - utf-8-validate
       - vite
       - vite-plus
       - webpack
@@ -17036,8 +16990,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rrweb-cssom@0.8.0:
-    optional: true
+  rrweb-cssom@0.8.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -17064,7 +17017,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    optional: true
 
   scheduler@0.27.0: {}
 
@@ -17370,19 +17322,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  supports-color@10.2.2: {}
+  supports-color@10.2.2:
+    optional: true
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
-  supports-hyperlinks@4.5.0:
-    dependencies:
-      has-flag: 5.0.1
-      supports-color: 10.2.2
-
-  symbol-tree@3.2.4:
-    optional: true
+  symbol-tree@3.2.4: {}
 
   tabbable@6.5.0: {}
 
@@ -17433,11 +17380,6 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terminal-link@5.0.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      supports-hyperlinks: 4.5.0
-
   terminal-size@4.0.1: {}
 
   tiny-async-pool@1.3.0:
@@ -17459,13 +17401,11 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@6.1.86:
-    optional: true
+  tldts-core@6.1.86: {}
 
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
-    optional: true
 
   tmp-promise@3.0.3:
     dependencies:
@@ -17487,12 +17427,10 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
-    optional: true
 
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -17966,7 +17904,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-    optional: true
 
   wcwidth@1.0.1:
     dependencies:
@@ -17984,24 +17921,20 @@ snapshots:
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  webidl-conversions@7.0.0:
-    optional: true
+  webidl-conversions@7.0.0: {}
 
   webpack-virtual-modules@0.6.2: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
-    optional: true
 
-  whatwg-mimetype@4.0.0:
-    optional: true
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@14.2.0:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-    optional: true
 
   when-exit@2.1.5: {}
 
@@ -18050,13 +17983,11 @@ snapshots:
 
   ws@8.21.1: {}
 
-  xml-name-validator@5.0.0:
-    optional: true
+  xml-name-validator@5.0.0: {}
 
   xmlbuilder@15.1.1: {}
 
-  xmlchars@2.2.0:
-    optional: true
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## The bug

Navigating between sessions inside the SPA (sidebar click, no reload) could
hand the route's error boundary this, thrown out of `<ChatInputComposer>`:

```
TypeError: Cannot read properties of null (reading 'extensions')
```

The `null` is **`editor.extensionManager`**, which `Editor.destroy()` nulls out
(`@tiptap/core@3.28`). So the selector was being handed a *destroyed* editor,
not a null one — which is why the existing `editor ? … : false` guard never
fired. `serialize.ts` walks `editor.extensionManager.extensions` first thing.

## Why it happened

Three things have to line up, which is why it was intermittent:

1. **The route component is not remounted across sessions.** TanStack Router's
   `Outlet` renders `<Match>` without a key, and `MatchInner`'s own key comes
   from `remountDeps`, which this app doesn't configure. So the composer keeps
   its fiber — and its hook state — when `sessionId` changes.
2. **Its effects are torn down and put back while it stays mounted.**
   `MatchInner` throws the loader promise while the match is pending, and
   `defaultPendingComponent` makes that a real Suspense boundary; hiding and
   revealing an already-mounted subtree disconnects and reconnects passive
   effects. `useChatInputController` therefore disposes one editor and builds
   another between two renders of the same fiber. Both `setController` calls
   batch into a single render, so `controller` is never observed as `null`
   in between — the window contains a *dead editor*, not a null one.
3. **`useEditorState` cached the dead editor.** `EditorStateManager` refreshes
   its snapshot only when its own transaction counter moves; `watch()` swaps
   the editor field and leaves the counter alone. That counter only leaves `0`
   once the user has typed — which is exactly why the crash needed a
   typed-in composer, and why a slow loader (cold resume after a server
   restart, say) was what tipped it over.

Reproduced deterministically by holding the session loader open for 2.5s, then
typing and switching sessions. Instrumented trace:

```
composer.render 1  controller=2
selector 1  snapshotEditor=live       propEditor=2
hook.effect.cleanup 2 → controller.dispose 2     ← editor A destroyed, composer still #1
controller.new 3 → hook.effect.setup 3
composer.render 1  controller=3
selector 1  snapshotEditor=DESTROYED  propEditor=3   ← boom
```

## The fix

Fix the reference rather than guard the read. `hasContent()` and `onChange()`
move onto `ChatInputController` — the editor belongs inside that facade
anyway; the composer was reaching past it to `controller.editor` and
re-deriving emptiness itself. `useChatInputHasContent` then subscribes via
`useSyncExternalStore`, reading the controller of the *current* render, so
nothing holds an editor across the swap.

That also removes a silent staleness bug: the send button used to reflect the
outgoing editor until the incoming one first changed.

`hasContent()` returning `false` for a destroyed editor is load-bearing, not
padding — on reconnect React re-runs the last committed `getSnapshot`, which
closes over the controller its own cleanup just disposed. Deleting that line
makes both new tests fail with the original `TypeError`.

`draft.tsx` carried an identical copy of the old code and gets the same
treatment.

## Tests

Tiptap builds its document through `elementFromString`, so these need a DOM —
hence `jsdom` at the root and a per-file `// @vitest-environment jsdom`
docblock rather than a shared config change. Written as `.ts` with
`createElement` so no JSX/babel pass is added to every test in the package.

- `chat-input-controller.test.ts` — content threshold matches `submit()`;
  `onChange` subscribe/unsubscribe; **a disposed controller answers `false`
  instead of throwing**.
- `use-chat-input-has-content.test.ts` — pins the window with
  `react-dom/client` + `act`: render the outgoing controller, dispose it,
  render it again (which is what React actually does) — must not throw; then
  swap in the incoming one — must read `true` immediately, not after its first
  transaction.

Checked in reverse: with the hook restored to `useEditorState`, that second
test fails with `TypeError: Cannot read properties of null (reading 'extensions')`.

## Verification

- `pnpm run check` (lint + format + typecheck) and `turbo run test` green
  (apps/app 80, server 362).
- Runtime, `VIBEST_PORT=4181` + vite on 4190: the deterministic repro path no
  longer throws; send button toggles correctly on `/draft` and `/session/*`
  (empty → disabled, typed → enabled, cleared → disabled); send → reply →
  composer clears end to end. Instrumentation and the artificial loader delay
  were reverted before committing.

## Out of scope

`packages/ui/src/components/tiptap/suggestion-menu.tsx` also reads
`extensionManager.extensions`, but from a live editor inside a suggestion
callback — and that directory is vendored, so untouched.


## A note on the lockfile

`jsdom` is pinned at `^26.1.0` — the version the tree already resolved as an
optional peer of vitest — so nothing else moves on its account. Of the 133
lockfile lines, roughly 100 are the mechanical consequence of jsdom going from
optional-only to a declared dependency (`optional: true` markers dropping off
its transitive deps).

The remaining ~30 are `react-doctor` 0.9.4 → 0.9.5, plus `deslop-js` /
`oxlint-plugin-react-doctor` and the entries 0.9.5 drops with its `ink`
dependency. That is not this change: `apps/app` declares `react-doctor: ^0.9.2`,
and pnpm re-resolves that caret whenever any manifest in the workspace changes —
a plain `pnpm install` with no manifest edit produces a zero-line lockfile diff,
and adding *any* dependency reproduces this one. Left in rather than hand-edited
back, since a hand-trimmed lockfile would just float again on the next install.
