### PR TITLE
fix(app): tell an unread transcript from an empty one

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: bare sessionId as a wire identity
 The agent-native session identity (Claude session UUID, Codex thread ID) held in the session's metadata. Internal plumbing for resume/history — never exposed as wire identity.
 _Avoid_: native id
 
+**Attach**:
+A client connecting to a session's live event stream — `session.subscribe` plus the snapshot taken at connect, surfaced to the chat runtime as the synthetic `"attached"` event (whose terminal counterpart is `"closed"`). Reserved for that: nothing else in the session domain attaches. Opening a session page is `session.prepare` (validate the ref, backfill cwd, ask the harness whether the native session is still there — starts nothing); getting the client-side `Chat` instance for a ref is `ChatManager.chatFor`.
+_Avoid_: attach for the cold pre-flight (its former name) or for taking a Chat instance; resume (`session.prepare` starts nothing — only a prompt does)
+
 **Session metadata**:
 The server-owned recovery record for a session: which Project, which harness agent, which harness session id. Distinct from conversation history, which stays in the agent's native storage.
 

--- a/apps/app/src/features/chat/components/chat-transcript.tsx
+++ b/apps/app/src/features/chat/components/chat-transcript.tsx
@@ -7,12 +7,35 @@ import {
   ConversationScrollButton,
 } from "@/components/conversation";
 import type { AgentResponse } from "@/features/chat/runtime/agent-requests";
-import type { ChatStoreState } from "@/features/chat/runtime/chat-state";
+import type { ChatStoreState, HistoryStatus } from "@/features/chat/runtime/chat-state";
 
 import { useChatSession } from "./chat-session-context";
 import { AgentRequestView } from "./transcript/agent-request";
 import { MessageView } from "./transcript/message-view";
 import { TranscriptRenderProvider } from "./transcript/transcript-render-provider";
+
+// What an empty transcript means, in one place: nothing until the settled
+// history floor has landed, so an unread session shows the read rather than a
+// verdict about the conversation. "settled" renders nothing — a session with no
+// messages simply has none yet.
+function EmptyTranscript({ historyStatus }: { historyStatus: HistoryStatus }) {
+  if (historyStatus === "loading") {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader />
+      </div>
+    );
+  }
+  if (historyStatus === "unavailable") {
+    return (
+      <div className="text-muted-foreground mx-auto max-w-md py-12 text-center text-sm">
+        Earlier messages couldn&apos;t be loaded. The agent still has its own context, so you can
+        pick up where you left off.
+      </div>
+    );
+  }
+  return null;
+}
 
 // Pure view over a store snapshot: message stream, then the error line, then
 // pending agent request cards. Only the last message can be streaming, so only
@@ -26,11 +49,6 @@ function ChatTranscriptView({
 }) {
   const lastIndex = snapshot.messages.length - 1;
   const turnInProgress = snapshot.status === "submitted" || snapshot.status === "streaming";
-  // A reopened session hydrates its transcript from native history where the
-  // harness supports it (pi today) — then this notice never shows. It remains
-  // for the harnesses without a history read: the agent still resumes with its
-  // own context, so the conversation continues regardless.
-  const showEmptyNotice = snapshot.messages.length === 0 && snapshot.status === "ready";
   return (
     <Conversation>
       {/* Width cap lives here, inside the scroller, so the scrollbar stays at
@@ -39,11 +57,8 @@ function ChatTranscriptView({
         scrollClassName="scrollbar-thin"
         className="mx-auto w-full max-w-4xl min-w-80"
       >
-        {showEmptyNotice && (
-          <div className="text-muted-foreground mx-auto max-w-md py-12 text-center text-sm">
-            Past messages can&apos;t be replayed yet. The agent still has its own context, so you
-            can pick up where you left off.
-          </div>
+        {snapshot.messages.length === 0 && (
+          <EmptyTranscript historyStatus={snapshot.historyStatus} />
         )}
         {snapshot.messages.map((message, index) => (
           <MessageView

--- a/apps/app/src/features/chat/runtime/chat-manager.ts
+++ b/apps/app/src/features/chat/runtime/chat-manager.ts
@@ -6,11 +6,11 @@ import type { ChatSessionTransportFactory } from "./chat-transport-port";
 // The narrow surface features are allowed to touch. Orchestration internals
 // (the session map, disposal) stay on the class.
 export interface ChatManagerApi {
-  attach(sessionRef: SessionRef): Chat;
+  chatFor(sessionRef: SessionRef): Chat;
 }
 
 // Owns the live Chat instances keyed by the session's uuid. Sessions survive
-// route switches: attach() is get-or-create, and nothing disposes a Chat on
+// route switches: chatFor() is get-or-create, and nothing disposes a Chat on
 // navigation — its store keeps the transcript for the next mount. Each Chat
 // gets its own transport, minted from the injected factory and bound to its
 // SessionRef; the manager knows nothing about oRPC or the wire client.
@@ -21,11 +21,11 @@ export class ChatManager implements ChatManagerApi {
 
   constructor(private readonly createTransport: ChatSessionTransportFactory) {}
 
-  // The harness is fixed at first attach (a session's harness never changes);
-  // later attaches return the existing Chat. The harness travels on the
-  // SessionRef, so cold-loaded session routes and the session-creating caller
-  // alike carry the real harness rather than a default.
-  attach(sessionRef: SessionRef): Chat {
+  // The harness is fixed at the first call for a session (a session's harness
+  // never changes); later calls return the existing Chat. The harness travels
+  // on the SessionRef, so cold-loaded session routes and the session-creating
+  // caller alike carry the real harness rather than a default.
+  chatFor(sessionRef: SessionRef): Chat {
     const existing = this.#chats.get(sessionRef.sessionId);
     if (existing) return existing;
     const chat = new Chat({

--- a/apps/app/src/features/chat/runtime/chat-state.ts
+++ b/apps/app/src/features/chat/runtime/chat-state.ts
@@ -3,12 +3,22 @@ import { createStore, type StoreApi } from "zustand/vanilla";
 
 import type { AgentRequest } from "./agent-requests";
 
+// Where the settled-history floor stands. A Chat is born "loading", so an empty
+// transcript means "not read yet" rather than "nothing was ever said"; only
+// once the floor lands does an empty transcript mean the session really is
+// empty. "unavailable" covers both ways the read can come back with nothing to
+// lay down — the harness has no history read, or the read failed — which are
+// the same fact to a reader: the transcript starts here, the agent's own
+// context does not.
+export type HistoryStatus = "loading" | "settled" | "unavailable";
+
 // Each Chat owns its own store: messages + status + error + pendingRequests.
 export type ChatStoreState = {
   messages: UIMessage[];
   status: ChatStatus;
   error?: Error;
   pendingRequests: AgentRequest[];
+  historyStatus: HistoryStatus;
 };
 
 // The slice of ai-sdk's ChatState this runtime still honors — the shared data
@@ -30,6 +40,7 @@ export class ChatState implements AiChatStateSlice {
       status: "ready",
       error: undefined,
       pendingRequests: [],
+      historyStatus: "loading",
     }));
   }
 
@@ -45,6 +56,13 @@ export class ChatState implements AiChatStateSlice {
   }
   set status(status: ChatStatus) {
     this.store.setState({ status });
+  }
+
+  get historyStatus(): HistoryStatus {
+    return this.store.getState().historyStatus;
+  }
+  set historyStatus(historyStatus: HistoryStatus) {
+    this.store.setState({ historyStatus });
   }
 
   get error(): Error | undefined {

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -303,6 +303,51 @@ describe("Chat hydration", () => {
   });
 });
 
+// An empty transcript means two different things before and after the floor
+// lands, and the transcript renders a verdict on it — so the state is asserted
+// rather than inferred from `messages.length`.
+describe("Chat history floor state", () => {
+  it("stays 'loading' until the floor lands, then settles even on an empty read", async () => {
+    const { chat, transport, attach } = makeChat();
+    let openGate: () => void = () => undefined;
+    transport.historyGate = new Promise((resolve) => {
+      openGate = resolve;
+    });
+    transport.history = [];
+    expect(chat.store.getState().historyStatus).toBe("loading");
+    await attach({});
+    expect(chat.store.getState().historyStatus).toBe("loading");
+    openGate();
+    await settle();
+    expect(chat.store.getState().historyStatus).toBe("settled");
+  });
+
+  // Both ways a read comes back with no floor — capability absent, read threw —
+  // land on the same state: the transcript says so instead of showing a blank
+  // that would read as "nothing was ever said".
+  it("marks the history unavailable when the harness has no read", async () => {
+    const { chat, transport, attach } = makeChat();
+    transport.history = null;
+    await attach({});
+    expect(chat.store.getState().historyStatus).toBe("unavailable");
+  });
+
+  it("marks the history unavailable when the read fails", async () => {
+    const { chat, transport, attach } = makeChat();
+    transport.getMessages = async () => {
+      throw new Error("rpc failed");
+    };
+    await attach({});
+    expect(chat.store.getState().historyStatus).toBe("unavailable");
+  });
+
+  it("stops loading when the session terminates before any floor landed", async () => {
+    const { chat, emit } = makeChat();
+    emit({ type: "closed", reason: "session_deleted" });
+    expect(chat.store.getState().historyStatus).toBe("settled");
+  });
+});
+
 describe("Chat prompting", () => {
   it("pushes the optimistic message, submits fire-and-forget, and dedupes its echo", async () => {
     const { chat, transport, attach, live } = makeChat();

--- a/apps/app/src/features/chat/runtime/chat.ts
+++ b/apps/app/src/features/chat/runtime/chat.ts
@@ -214,6 +214,9 @@ export class Chat {
     for (const fold of this.#turnFolds.values()) fold.close();
     this.#turnFolds.clear();
     this.#queuedEvents = null;
+    // Terminal before the floor ever landed (or attached): no history is coming,
+    // so stop rendering a spinner that would never resolve.
+    this.#state.historyStatus = "settled";
     this.#state.clearPendingRequests();
     this.#state.error = new Error(
       reason === "session_deleted" ? "Session deleted" : "Session closed",
@@ -256,8 +259,15 @@ export class Chat {
       if (history !== null && history.length > 0 && this.#state.messages.length === 0) {
         this.#state.messages = Array.from(history);
       }
+      // An empty read is still a floor: the session simply has nothing settled
+      // yet. Only the absent capability (null) leaves the transcript unfounded.
+      this.#state.historyStatus = history === null ? "unavailable" : "settled";
     } catch (historyError) {
       console.error("Failed to load session history", historyError);
+      // A failed read is still a finished one — the spinner has to stop — but an
+      // unannotated blank would claim the session is empty. A later reconcile
+      // clears this when the read succeeds.
+      this.#state.historyStatus = "unavailable";
     }
     const snapshot = this.#floorSnapshot;
     this.#floorSnapshot = null;
@@ -446,6 +456,9 @@ export class Chat {
   async #reconcileHistory(): Promise<void> {
     try {
       const history = await this.#transport.getMessages();
+      // Same read as the floor's, so it answers the same question: a reconcile
+      // that lands clears a floor read that failed earlier.
+      this.#state.historyStatus = history === null ? "unavailable" : "settled";
       if (history === null) {
         // Capability absent: no settled transcript will ever materialize, so
         // a deferred reconcile must not retry forever.

--- a/apps/app/src/features/chat/runtime/use-chat-handle.ts
+++ b/apps/app/src/features/chat/runtime/use-chat-handle.ts
@@ -11,16 +11,16 @@ import type { ChatStoreState } from "./chat-state";
 export const selectTurnInProgress = (s: ChatStoreState): boolean =>
   s.status === "submitted" || s.status === "streaming";
 
-// Get-or-attach a Chat by SessionRef and return it with a stable identity.
+// Get-or-create a Chat by SessionRef and return it with a stable identity.
 // This hook does not subscribe to the store — consumers that read state do
 // their own useStore(chat.store, selector).
 export function useChatHandle(sessionRef: SessionRef): Chat {
   const manager = useChatManager();
   // Depend on the primitive fields, not the (per-render) ref object identity, so
-  // attach runs once per distinct session rather than on every render.
+  // the lookup runs once per distinct session rather than on every render.
   const { projectId, harnessAgentId, sessionId } = sessionRef;
   return useMemo(
-    () => manager.attach({ projectId, harnessAgentId, sessionId }),
+    () => manager.chatFor({ projectId, harnessAgentId, sessionId }),
     [manager, projectId, harnessAgentId, sessionId],
   );
 }

--- a/apps/app/src/routes/draft.tsx
+++ b/apps/app/src/routes/draft.tsx
@@ -142,7 +142,7 @@ function DraftRoute() {
   const permissionMode = resolvePermissionMode(harnessAgent, search.permission);
 
   // Create the session and start its first turn against the manager's persisted
-  // store, then navigate — the session route re-attaches the same Chat with the
+  // store, then navigate — the session route picks up the same Chat with the
   // turn already streaming.
   const startSession = useMutation({
     mutationFn: async ({ text }: { text: string }) => {
@@ -155,7 +155,7 @@ function DraftRoute() {
         ...(model !== undefined ? { providerId: model.providerId, modelId: model.modelId } : {}),
         ...(permissionMode !== undefined ? { permissionMode } : {}),
       });
-      void manager.attach(ref).prompt(text);
+      void manager.chatFor(ref).prompt(text);
       return ref;
     },
     onSuccess: (ref, { text }) => {

--- a/apps/app/src/routes/session/$sessionId.tsx
+++ b/apps/app/src/routes/session/$sessionId.tsx
@@ -35,7 +35,7 @@ export const Route = createFileRoute("/session/$sessionId")({
   loader: async ({ context, params, deps }) => {
     const { session } = context.orpcQueryUtils;
 
-    // Fast path: the link handed us a whole ref, so attach can go first. We
+    // Fast path: the link handed us a whole ref, so prepare can go first. We
     // return what the server answers with, not what the URL claimed.
     if (deps.projectId !== undefined && deps.harness !== undefined) {
       const hinted: SessionRef = {
@@ -43,13 +43,13 @@ export const Route = createFileRoute("/session/$sessionId")({
         harnessAgentId: deps.harness,
         sessionId: params.sessionId,
       };
-      const attached = await session.attach.call({ ref: hinted }).catch((error: unknown) => {
+      const prepared = await session.prepare.call({ ref: hinted }).catch((error: unknown) => {
         // A bad hint and a session the harness has forgotten both fall through
         // to the lookup; only this line tells them apart afterwards.
-        console.warn("Attach from URL ref failed, falling back to lookup", error);
+        console.warn("Preparing the URL's ref failed, falling back to lookup", error);
         return undefined;
       });
-      if (attached) return attached;
+      if (prepared) return prepared;
     }
 
     // An unresolvable sessionId (pruned storage, hand-edited URL) would
@@ -69,10 +69,10 @@ export const Route = createFileRoute("/session/$sessionId")({
     // native history was cleaned up fails here — surface it instead of leaving
     // a silently dead chat. The page still renders, so keep the console trail
     // for diagnosis after the toast auto-dismisses.
-    await session.attach.call({ ref }).catch((error: unknown) => {
-      console.error("Failed to attach to session", error);
+    await session.prepare.call({ ref }).catch((error: unknown) => {
+      console.error("Failed to prepare session", error);
       toast.error(
-        `Failed to attach to session: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to prepare session: ${error instanceof Error ? error.message : String(error)}`,
       );
     });
     return ref;

--- a/packages/contract/src/session.ts
+++ b/packages/contract/src/session.ts
@@ -36,10 +36,11 @@ export const sessionContract = {
   create: base
     .input(toStandardSchema(CreateSessionInputSchema))
     .output(toStandardSchema(SessionRefSchema)),
-  // Not "resume": it validates the ref, backfills the session's cwd, and
-  // checks the harness still knows the native session. It starts nothing —
-  // only a prompt does that.
-  attach: base.input(toStandardSchema(RefInputSchema)).output(toStandardSchema(SessionRefSchema)),
+  // Neither "resume" nor "attach": it validates the ref, backfills the
+  // session's cwd, and checks the harness still knows the native session. It
+  // starts nothing and connects nothing — only a prompt starts a runtime, and
+  // only `subscribe` attaches to the event stream.
+  prepare: base.input(toStandardSchema(RefInputSchema)).output(toStandardSchema(SessionRefSchema)),
   close: base.input(toStandardSchema(RefInputSchema)),
 
   // history / index

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -105,7 +105,7 @@ export type HarnessAgentSessionServiceShape = {
    * own, and this is the only path that learns the project's path for a
    * session created before we stored one.
    */
-  readonly attach: (
+  readonly prepare: (
     ref: SessionRef,
     cwd: string,
   ) => Effect.Effect<
@@ -425,7 +425,7 @@ export const makeHarnessAgentSessionService = (deps: {
         }),
       ),
 
-    attach: (ref, cwd) =>
+    prepare: (ref, cwd) =>
       readChecked(ref).pipe(
         Effect.tap((metadata) =>
           metadata.cwd === cwd ? Effect.void : repo.write({ ...metadata, cwd }),

--- a/packages/server/src/rpc/session.ts
+++ b/packages/server/src/rpc/session.ts
@@ -68,12 +68,12 @@ export const sessionRouter = orpc.router({
   }),
   // Opening a session page: validate, backfill cwd, confirm the harness still
   // has the native session. No process is started here — that is the whole
-  // point of the rename.
-  attach: orpc.attach.effect(function* ({ input, errors }) {
+  // point of the name.
+  prepare: orpc.prepare.effect(function* ({ input, errors }) {
     const projects = yield* ProjectService;
     const sessions = yield* HarnessAgentSessionService;
     return yield* projects.findById(input.ref.projectId).pipe(
-      Effect.flatMap((project) => sessions.attach(input.ref, project.path)),
+      Effect.flatMap((project) => sessions.prepare(input.ref, project.path)),
       Effect.as(input.ref),
       Effect.catchTags({
         SessionNotFound: (e) =>

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -208,7 +208,7 @@ describe("HarnessAgentSessionService", () => {
     expect(result.listed).toHaveLength(0);
   });
 
-  it("attach backfills the cwd and starts nothing", async () => {
+  it("prepare backfills the cwd and starts nothing", async () => {
     const result = await run({}, (fixture) =>
       Effect.gen(function* () {
         const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
@@ -218,21 +218,21 @@ describe("HarnessAgentSessionService", () => {
         const { cwd: _dropped, ...withoutCwd } = stored;
         yield* fixture.repo.write(withoutCwd);
 
-        yield* fixture.service.attach(ref, "/tmp/vibest-app");
+        yield* fixture.service.prepare(ref, "/tmp/vibest-app");
         const after = yield* fixture.repo.read(ref.projectId, ref.sessionId);
         return { cwd: after.cwd, resume: fixture.spy.resume, open: fixture.spy.open };
       }),
     );
     expect(result.cwd).toBe("/tmp/vibest-app");
-    // Opening a session page costs no process — the whole point of `attach`.
+    // Opening a session page costs no process — the whole point of `prepare`.
     expect(result.resume).toEqual([]);
     expect(result.open).toHaveLength(1);
   });
 
-  it("attach fails with SessionNotFound for an unknown session", async () => {
+  it("prepare fails with SessionNotFound for an unknown session", async () => {
     const err = await run({}, (fixture) =>
       Effect.flip(
-        fixture.service.attach(
+        fixture.service.prepare(
           { projectId: "proj-a", harnessAgentId: "claude-code", sessionId: "missing" },
           "/tmp/vibest-app",
         ),
@@ -241,12 +241,12 @@ describe("HarnessAgentSessionService", () => {
     expect(err._tag).toBe("SessionNotFound");
   });
 
-  it("attach fails with SessionRefMismatch when the ref's agent disagrees with metadata", async () => {
+  it("prepare fails with SessionRefMismatch when the ref's agent disagrees with metadata", async () => {
     const err = await run({}, (fixture) =>
       Effect.gen(function* () {
         const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
         return yield* Effect.flip(
-          fixture.service.attach({ ...ref, harnessAgentId: "codex" }, "/tmp/vibest-app"),
+          fixture.service.prepare({ ...ref, harnessAgentId: "codex" }, "/tmp/vibest-app"),
         );
       }),
     );
@@ -421,7 +421,7 @@ describe("HarnessAgentSessionService", () => {
         const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
         const restarted = yield* fixture.restart;
 
-        yield* restarted.service.attach(ref, "/tmp/vibest-app");
+        yield* restarted.service.prepare(ref, "/tmp/vibest-app");
         const status = yield* restarted.service.getStatus(ref);
         const snapshot = yield* restarted.service.getSnapshot(ref);
         const listed = yield* restarted.service.list("proj-a");
@@ -452,7 +452,7 @@ describe("HarnessAgentSessionService", () => {
       Effect.gen(function* () {
         const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
         const restarted = yield* fixture.restart;
-        yield* restarted.service.attach(ref, "/tmp/vibest-app");
+        yield* restarted.service.prepare(ref, "/tmp/vibest-app");
 
         yield* restarted.service.prompt({ ref, parts: [{ type: "text", text: "hello" }] });
         yield* restarted.service.prompt({ ref, parts: [{ type: "text", text: "again" }] });

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -158,13 +158,14 @@ describe("session router", () => {
       const ref = await client.session.create({ projectId: project.id, harnessAgentId: "codex" });
       await client.session.close({ ref });
 
-      // The reattach a browser does after a server restart. None of it used to
-      // be answerable without a live runtime, so the client retried forever.
-      const attached = await client.session.attach({ ref });
+      // What a browser does when it reopens the page after a server restart.
+      // None of it used to be answerable without a live runtime, so the client
+      // retried forever.
+      const prepared = await client.session.prepare({ ref });
       const status = await client.session.getStatus({ ref });
       const snapshot = await client.session.getSnapshot({ ref });
 
-      expect(attached).toEqual(ref);
+      expect(prepared).toEqual(ref);
       expect(status).toEqual({ phase: "idle" });
       expect(snapshot.cursor).toBe(0);
       expect(snapshot.activeTurn).toBeNull();


### PR DESCRIPTION
每次打开一个此前没打开过的会话，transcript 都会闪出一句 `Past messages can't be replayed yet. The agent still has its own context…`。

## 为什么

`Chat` 出生时 `messages: []` + `status: "ready"`，而历史地板（`getMessages`）要等 transport attach 之后才异步读。这段窗口里空 transcript 被当成了结论。那句文案本身也早就过时——三个 harness 现在都能读历史（claude-code 冷读 transcript 文件、codex 走 `thread/read`、pi 走活会话的 `get_entries`）。

## 改了什么

**把"还没读"和"读完了确实没有"分开**：Chat store 新增 `historyStatus: "loading" | "settled" | "unavailable"`。`unavailable` 同时覆盖两种"没有地板"——harness 没有历史读、或者读失败——对读的人是同一个事实，区别只活在 `Chat` 内部（`history === null` 决定要不要停止 reconcile 重试）。

transcript 的整个空态收进一个 `EmptyTranscript`：读的过程显示 loader，读不到显示一行说明，`settled` 返回 `null`——新会话就该是白的。

**顺带修一处词汇**：三个东西都叫 attach，只有一个真的 attach。

| | | |
|---|---|---|
| `session.attach` | → `session.prepare` | 校验 ref、回填 cwd、冷问 harness 还认不认得 native session。不启动进程、不建立连接。loader 的 toast 原文是 "Failed to attach to session"，会把人往网络问题上带 |
| `ChatManager.attach` | → `chatFor` | Map 上的 get-or-create，无 I/O |
| transport 的 `"attached"` 事件 | 不动 | 这才是真的连上事件流，且与 `"closed"` 对仗 |

`CONTEXT.md` 补了 `Attach` 词条钉住这条线。

## 验证

- `turbo run typecheck test`：server 372 例、app 79 例，全绿
- `lint:check` / `format:check` 干净
- `chat.test.ts` 新增 `Chat history floor state`（4 例）：gate 住的读期间保持 loading、空读也算 settled、`null` → unavailable、读失败 → unavailable、未 attach 就 terminate 时停止 loading

## 待议（不在本 PR）

`session.prepare` 的三件事里，只有"验证 URL hint"是它独占的——cwd 回填与存在性探测都能折进 `getMessages`（那个 RPC 已经解析了同一个 cwd，冷读本身也会因 native session 不在而失败）。折进去之后这个 procedure 可以整个删掉，应用内导航的 loader 变成零 RPC。单独开一刀。