### PR TITLE
fix(app): load history in place instead of under a centered spinner

### DIFF
--- a/apps/app/src/features/chat/components/chat-transcript.tsx
+++ b/apps/app/src/features/chat/components/chat-transcript.tsx
@@ -1,4 +1,5 @@
 import { Loader } from "@vibest/ui/ai-elements/loader";
+import { Shimmer } from "@vibest/ui/ai-elements/shimmer";
 import { useStore } from "zustand";
 
 import {
@@ -20,11 +21,11 @@ import { TranscriptRenderProvider } from "./transcript/transcript-render-provide
 // messages simply has none yet.
 function EmptyTranscript({ historyStatus }: { historyStatus: HistoryStatus }) {
   if (historyStatus === "loading") {
-    return (
-      <div className="flex justify-center py-12">
-        <Loader />
-      </div>
-    );
+    // Reads as a turn that hasn't produced text yet: the shimmer sits where the
+    // first message will land, so the transcript settles in place instead of a
+    // centered spinner claiming the panel and then vanishing. Same thinking
+    // indicator the tool batches use.
+    return <Shimmer className="text-sm">Loading earlier messages…</Shimmer>;
   }
   if (historyStatus === "unavailable") {
     return (

--- a/apps/app/src/features/chat/components/chat-transcript.tsx
+++ b/apps/app/src/features/chat/components/chat-transcript.tsx
@@ -21,10 +21,6 @@ import { TranscriptRenderProvider } from "./transcript/transcript-render-provide
 // messages simply has none yet.
 function EmptyTranscript({ historyStatus }: { historyStatus: HistoryStatus }) {
   if (historyStatus === "loading") {
-    // Reads as a turn that hasn't produced text yet: the shimmer sits where the
-    // first message will land, so the transcript settles in place instead of a
-    // centered spinner claiming the panel and then vanishing. Same thinking
-    // indicator the tool batches use.
     return <Shimmer className="text-sm">Loading earlier messages…</Shimmer>;
   }
   if (historyStatus === "unavailable") {


### PR DESCRIPTION
## What

Opening a session used to show a centered spinner (`flex justify-center py-12` + the ai-elements `Loader`) while the settled history floor loaded. It claimed the whole panel, then disappeared once messages landed — the eye moves to the middle, then back to the top-left.

Replaced with the `Shimmer` text already used as the tool batches' thinking indicator: left-aligned at exactly the x position where the first message renders, so history settles in place rather than replacing a spinner somewhere else.

## Why this component

`tool-batch.tsx` states it outright — the trigger shimmer is the only thinking indicator this app surfaces. Reusing it keeps the loading state and the streaming state speaking the same visual language, instead of introducing a third idiom.

## Verification

- `oxlint --deny-warnings`, `oxfmt --check`, `turbo run typecheck --filter=@vibest/app` all pass
- Driven at runtime with a temporary 6s delay injected into `Chat#loadHistoryFloor` and recorded: the shimmer sweeps left to right on a 2s cycle, and messages replace it with no layout shift. The delay was not committed.

## Not in scope

The `unavailable` branch right below is still centered (`mx-auto text-center py-12`). The two never render at the same time, so this leaves it alone — worth a follow-up if we want the whole empty-transcript surface left-aligned.