### PR TITLE
feat(app): show harness as icon only in live sessions

### DIFF
--- a/apps/app/src/features/chat/chat.tsx
+++ b/apps/app/src/features/chat/chat.tsx
@@ -1,13 +1,13 @@
 import type { SessionRef } from "@vibest/contract";
 import { cn } from "@vibest/ui/lib/utils";
 
+import { ChatHarnessIcon } from "@/features/chat/components/chat-harness-icon";
 import { ChatInputComposer } from "@/features/chat/components/chat-input-composer";
 import { ChatModelSelect } from "@/features/chat/components/chat-model-select";
 import { ChatPermissionModeSelect } from "@/features/chat/components/chat-permission-mode-select";
 import { ChatReasoningEffortSelect } from "@/features/chat/components/chat-reasoning-effort-select";
 import { ChatSessionProvider } from "@/features/chat/components/chat-session-provider";
 import { ChatTranscript } from "@/features/chat/components/chat-transcript";
-import { HarnessBadge } from "@/features/chat/components/harness-badge";
 
 // Default assembly of the compositional chat pieces: ChatSessionProvider owns
 // the session context; transcript, composer, and config slots compose as
@@ -35,8 +35,9 @@ export function Chat({
             toolbar={
               <>
                 {/* Same slot the draft surface puts the harness picker in, so
-                    the toolbar reads the same before and after creation. */}
-                <HarnessBadge />
+                    the toolbar keeps its shape across creation — the picker
+                    collapses to its icon once the choice is settled. */}
+                <ChatHarnessIcon />
                 <ChatModelSelect />
                 {/* Cascades from the model above: appears only when the
                     selected model declares reasoningEffort levels. */}

--- a/apps/app/src/features/chat/components/chat-harness-icon.tsx
+++ b/apps/app/src/features/chat/components/chat-harness-icon.tsx
@@ -3,14 +3,16 @@ import { useHarnessAgent } from "@/features/chat/harness/use-harness";
 import { useChatSession } from "./chat-session-context";
 import { HarnessIcon } from "./harness-icon";
 
-// Which agent this session runs on. Deliberately a static badge, not a disabled
-// dropdown: the harness is part of the SessionRef and can never change, and a
-// disabled control would suggest it might under some other condition.
+// Session-config slot: which agent this session runs on. Deliberately static,
+// not a disabled dropdown — the harness is part of the SessionRef and can never
+// change, and a disabled control would suggest it might under some other
+// condition.
 //
-// Icon only: the harness never changes for a live session, so the name is
-// reference information the toolbar doesn't need to spend width on. The name
-// stays reachable through the tooltip and the accessible label.
-export function HarnessBadge() {
+// That fixedness is also why this is the icon alone: a value that cannot change
+// is reference information, and the toolbar's width belongs to the controls
+// next to it. The name stays reachable through the tooltip and the accessible
+// label.
+export function ChatHarnessIcon() {
   const { harnessAgentId } = useChatSession();
   const harnessAgent = useHarnessAgent(harnessAgentId);
   const name = harnessAgent?.name ?? harnessAgentId;

--- a/apps/app/src/features/chat/components/harness-badge.tsx
+++ b/apps/app/src/features/chat/components/harness-badge.tsx
@@ -6,13 +6,21 @@ import { HarnessIcon } from "./harness-icon";
 // Which agent this session runs on. Deliberately a static badge, not a disabled
 // dropdown: the harness is part of the SessionRef and can never change, and a
 // disabled control would suggest it might under some other condition.
+//
+// Icon only: the harness never changes for a live session, so the name is
+// reference information the toolbar doesn't need to spend width on. The name
+// stays reachable through the tooltip and the accessible label.
 export function HarnessBadge() {
   const { harnessAgentId } = useChatSession();
   const harnessAgent = useHarnessAgent(harnessAgentId);
+  const name = harnessAgent?.name ?? harnessAgentId;
   return (
-    <span className="text-muted-foreground inline-flex min-h-8 items-center gap-2 px-1 text-sm">
+    <span
+      aria-label={name}
+      className="text-muted-foreground inline-flex min-h-8 items-center px-1"
+      title={name}
+    >
       <HarnessIcon className="size-4 shrink-0" harnessAgentId={harnessAgentId} />
-      {harnessAgent?.name ?? harnessAgentId}
     </span>
   );
 }

--- a/apps/app/src/features/chat/components/harness-select.tsx
+++ b/apps/app/src/features/chat/components/harness-select.tsx
@@ -13,7 +13,7 @@ import { HarnessIcon } from "./harness-icon";
 
 // Which agent runs the session. Only offered before the session exists: the
 // harness is part of the SessionRef, so it is fixed at create time (see
-// HarnessBadge for how a live session shows it).
+// ChatHarnessIcon for how a live session shows it).
 //
 // Harnesses whose CLI is missing stay in the list, disabled and labelled with
 // the declared `reason` — hiding them turns "why is Codex not here?" into a


### PR DESCRIPTION
## What

In a live session's chat toolbar, the harness renders as its icon alone — no name text. `HarnessBadge` is renamed to `ChatHarnessIcon` to match.

## Why

The harness is part of the `SessionRef` and can never change for a running session. A value that cannot change is reference information, and the toolbar's width belongs to the controls next to it — model, reasoning effort, permission mode.

The name is still reachable: it's on both `title` (tooltip) and `aria-label`, so nothing is lost for hover or screen readers.

## Why the rename

Once it renders the icon alone, "badge" describes something the component no longer is, and "icon only" reads as behaviour hidden inside a badge rather than as what the component is.

The new name also puts it in line with the other session-config slots beside it — `ChatModelSelect`, `ChatPermissionModeSelect`, `ChatReasoningEffortSelect` — which share the same shape: read `ChatSession` context, render one control. `HarnessBadge` was the only slot in that directory not following the convention.

No presentational/binding split here, unlike model and permission mode: those are split because the draft surface drives them from URL search params with no session yet. The draft surface uses `HarnessSelect`, so this slot has a single consumer and a second layer would be symmetry for its own sake.

## Scope

Live sessions only. `HarnessSelect` (draft surface) keeps its labels — there the name distinguishes options you're actively choosing between.

## Checks

`pnpm run check` (oxlint + oxfmt + typecheck) passes.