### PR TITLE
fix(app): truncate long project names in the sidebar session list

### DIFF
--- a/apps/app/src/features/projects/project-sessions-group.tsx
+++ b/apps/app/src/features/projects/project-sessions-group.tsx
@@ -33,15 +33,8 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
   return (
     <Collapsible defaultOpen>
       <section className="relative min-w-0" aria-labelledby={`project-${project.id}`}>
-        {/*
-         * pe-8 keeps a long name from running under the absolutely positioned
-         * action. w-full is what makes that — and the name's own `truncate` —
-         * bite at all: the label renders as a <button>, and a button in a block
-         * box is shrink-to-fit even at `display: flex`, so without a width it
-         * grows to the name and spills out of the sidebar. The label is a div
-         * everywhere else, and a div does fill its block parent, which is why
-         * this only bites here.
-         */}
+        {/* pe-8 keeps a long name off the absolutely positioned action; w-full is what
+            makes it and `truncate` bite, since the label renders as a shrink-to-fit <button>. */}
         <SidebarGroupLabel
           className="text-sidebar-accent-foreground h-7 w-full min-w-0 pe-8 text-sm"
           id={`project-${project.id}`}

--- a/apps/app/src/features/projects/project-sessions-group.tsx
+++ b/apps/app/src/features/projects/project-sessions-group.tsx
@@ -35,7 +35,7 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
       <section className="relative min-w-0" aria-labelledby={`project-${project.id}`}>
         {/* pe-8 keeps a long name from running under the absolutely positioned action. */}
         <SidebarGroupLabel
-          className="text-sidebar-accent-foreground h-7 min-w-0 pe-8 text-sm"
+          className="text-sidebar-accent-foreground h-7 pe-8 text-sm"
           id={`project-${project.id}`}
           title={project.path}
           render={

--- a/apps/app/src/features/projects/project-sessions-group.tsx
+++ b/apps/app/src/features/projects/project-sessions-group.tsx
@@ -33,9 +33,17 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
   return (
     <Collapsible defaultOpen>
       <section className="relative min-w-0" aria-labelledby={`project-${project.id}`}>
-        {/* pe-8 keeps a long name from running under the absolutely positioned action. */}
+        {/*
+         * pe-8 keeps a long name from running under the absolutely positioned
+         * action. w-full is what makes that — and the name's own `truncate` —
+         * bite at all: the label renders as a <button>, and a button in a block
+         * box is shrink-to-fit even at `display: flex`, so without a width it
+         * grows to the name and spills out of the sidebar. The label is a div
+         * everywhere else, and a div does fill its block parent, which is why
+         * this only bites here.
+         */}
         <SidebarGroupLabel
-          className="text-sidebar-accent-foreground h-7 pe-8 text-sm"
+          className="text-sidebar-accent-foreground h-7 w-full min-w-0 pe-8 text-sm"
           id={`project-${project.id}`}
           title={project.path}
           render={

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -442,11 +442,7 @@ export function SidebarGroupLabel({
 }: useRender.ComponentProps<"div">): React.ReactElement {
   const defaultProps = {
     className: cn(
-      // `w-full min-w-0`: a `render`ed <button> shrinks to fit its content even
-      // at `display: flex`, so a long label would overflow the sidebar instead
-      // of letting a `truncate`d child clip. Div renders already fill the row,
-      // so this only pins down the control case.
-      "text-sidebar-foreground ring-sidebar-ring flex h-8 w-full min-w-0 shrink-0 items-center rounded-lg px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+      "text-sidebar-foreground ring-sidebar-ring flex h-8 shrink-0 items-center rounded-lg px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
       "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
       className,
     ),

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -442,7 +442,11 @@ export function SidebarGroupLabel({
 }: useRender.ComponentProps<"div">): React.ReactElement {
   const defaultProps = {
     className: cn(
-      "text-sidebar-foreground ring-sidebar-ring flex h-8 shrink-0 items-center rounded-lg px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+      // `w-full min-w-0`: a `render`ed <button> shrinks to fit its content even
+      // at `display: flex`, so a long label would overflow the sidebar instead
+      // of letting a `truncate`d child clip. Div renders already fill the row,
+      // so this only pins down the control case.
+      "text-sidebar-foreground ring-sidebar-ring flex h-8 w-full min-w-0 shrink-0 items-center rounded-lg px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
       "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
       className,
     ),


### PR DESCRIPTION
## Problem

A long project name in the sidebar session list ran past the sidebar edge and under the "New chat" action instead of truncating.

The row already had `truncate` on the name span, but that never bit: `SidebarGroupLabel` is `render`ed as a `CollapsibleTrigger`, i.e. a real `<button>`, and its parent `<section>` is a plain block box — so the button is shrink-to-fit even at `display: flex` and grew to the name rather than clipping it. A `truncate`d span with room to spare clips nothing.

Measured in the running app (sidebar content 228px wide, 57-char project name):

| | label width |
| --- | --- |
| before | 453px |
| after | 228px |

Two neighbours that look like counterexamples but aren't: the `Projects` group label is also a `<button>`, but it sits directly in `SidebarGroup` (`flex flex-col`), so flex stretch already gives it the full row; and `SidebarMenuButton` — the session rows — carries `w-full` in its variants, which is why session titles truncated all along.

## Fix

`w-full` (plus the `min-w-0` that was already there) on the label at the `ProjectSessionsGroup` call site.

The tempting fix is `w-full` on `SidebarGroupLabel`'s base class in `packages/ui`, but ADR 0001 makes those files vendored from the coss registry — local edits get discarded on the next `shadcn add --overwrite`. This is the only place that renders the label as a control inside a block box, so the call site is where it belongs anyway.

## Verification

Ran the app (`@vibest/cli dev` + `@vibest/app dev`) and drove a real browser with a 57-char project name injected into the sidebar. Before, the name overflowed the sidebar and collided with the action icon; after, it ellipsises and the action stays clickable. Every other group label measured unchanged at 228px.

`pnpm check` (lint + format + typecheck) passes.