### PR TITLE
docs: catch the harness architecture notes up to HarnessAgentSession

### DIFF
--- a/.agents/rules/architecture.md
+++ b/.agents/rules/architecture.md
@@ -61,6 +61,10 @@ app-server generate-ts`) and is in the lint/format ignore lists. Don't hand-edit
   inside a directory it is handed and deliberately has no default of its own.
 - `HarnessAgentIdSchema` in `packages/contract/src/domain.ts` is the whitelist:
   `claude-code`, `codex`, `pi` and nothing else. A fourth harness needs a literal
-  there, a `packages/server/src/harness/<agent>/` transform, and a server adapter
-  registered in `packages/server/src/harness/registry.ts` — all three, or it is
-  unreachable at runtime.
+  there, a `packages/server/src/harness/<agent>/` transform, and its adapter added
+  to the `RegistryLayer` in `packages/server/src/rpc/runtime.ts` — all three, or it
+  is unreachable at runtime. `harness/registry.ts` is only the lookup table's
+  factory (`makeHarnessAgentRegistry(adapters)`) and names no harness; that
+  composition root is the single place the adapters are constructed, and it wraps
+  each in `cacheAvailability` so a `--version` probe costs one spawn per server
+  rather than one per call.

--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -111,5 +111,5 @@ already written" is not a reason to add to the list:
 
 `node:path` is not on this list because it never needed an exemption — see
 "Where the boundary is" above. Path math is pure, so it stays `node:path`
-everywhere, and thirteen files in `packages/server/src` import it for exactly
+everywhere, and ten files in `packages/server/src` import it for exactly
 that.

--- a/docs/wayfinder/session-streaming-refactor/map.md
+++ b/docs/wayfinder/session-streaming-refactor/map.md
@@ -19,6 +19,11 @@ labels: [wayfinder:map]
 2. **一个全局 EventBus**，纯 fan-out + 过滤，不承担发号；订阅只有两个维度：`{kind:'session'; ref}`（单会话，有 cursor/重放语义）和 `{kind:'global'}`（firehose，透传所有事件，无 after、无重放、断线不补）。**没有 project 维度。**
 3. **snapshot 主动获取**（`session.getSnapshot`），不在订阅流里返回。无丢失边界靠固定顺序：先 subscribe 缓冲 → 后 getSnapshot 拿 cursor → 丢弃缓冲中 `seq ≤ cursor` → 排干 → live。
 4. **只有 session 事件带 seq**：由各 SessionRuntime 在 projection 折叠处自增（会话内连续），global/集合事件不带序号、不重放。`StreamingCursor = { turnId, lastAppliedSeq }`。
+   **勘误（2026-08-05）**：决策本身不变，两个词已改名。发号者现在叫
+   `HarnessAgentSession`（`harness/session.ts`，每个 SessionRef 一个，可选持有
+   runtime）；折叠不叫 projection 而是 `harness/session-fold.ts` 的纯 fold——见
+   `CONTEXT.md` 的 _Avoid_ 清单。自增仍在 fold 处，且与 publish 同持一个信号量，
+   否则两个 fiber 可能先发 n+1 再发 n，客户端的 `seq ≤ cursor` 守卫会永久丢掉 n。
 5. **慢消费者**：订阅者有界队列满 → 发终止性 `closed(slow_consumer)` 踢掉，删除现有 gap 折叠 / `degraded` / `REPLAY_CAPACITY` 机制；active-turn buffer 不设上限，只记 count/bytes 指标，turn 结束释放。
 6. **create**：入参 `{projectId, harnessAgentId, ...}` → 出参 `SessionRef {projectId, harnessAgentId, sessionId}`；sessionId 由 server 生成，adapter 原生 ID 降级为元数据字段 `harnessSessionId`；元数据文件 `~/.vibest/storage/sessions/<projectId>/<sessionId>.json` 原子写；adapter 只见 cwd 不见 projectId；任一步失败不留半初始化状态。
 7. **恢复三路径**：刷新（无 cursor，全量重建）/ 短暂断线（带 cursor 续传，turn 变更先用历史收敛旧 projection）/ 服务重启（`SESSION_NOT_ACTIVE` → resume → 走刷新路径），客户端收敛为单个 reconcile 入口。

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -176,10 +176,10 @@ export type SessionStatus = typeof SessionStatusSchema.Type;
 // Events
 //
 // Session-scoped events carry `seq`: contiguous per session, stamped by the
-// SessionRuntime, starting at 1. Collection events are unnumbered — they are
-// invalidation signals recovered via list methods, never replayed. Events are
-// TypeScript types, not Schemas: they are produced by the server and never
-// validated as RPC input.
+// server's `HarnessAgentSession`, starting at 1. Collection events are
+// unnumbered — they are invalidation signals recovered via list methods, never
+// replayed. Events are TypeScript types, not Schemas: they are produced by the
+// server and never validated as RPC input.
 // ---------------------------------------------------------------------------
 
 export const SessionScopedEventTypes = [
@@ -246,16 +246,16 @@ export type SessionScopedEventBody =
     }
   | { readonly type: "session.crashed"; readonly reason: string };
 
-/** A session-scoped event before the SessionRuntime stamps its `seq`. */
+/** A session-scoped event before the server's `HarnessAgentSession` stamps its `seq`. */
 export type SessionScopedEventDraft = { readonly ref: SessionRef } & SessionScopedEventBody;
 
 export type SessionScopedEvent = {
   readonly seq: number;
   /**
-   * The session's phase *after* this event applied, stamped by the
-   * SessionRuntime alongside `seq`. Consumers copy it (sidebar status, chat
-   * composer state) instead of re-deriving phase from event types — the
-   * runtime is the only place that knows the full transition table
+   * The session's phase *after* this event applied, stamped by the server's
+   * `HarnessAgentSession` alongside `seq`. Consumers copy it (sidebar status,
+   * chat composer state) instead of re-deriving phase from event types — the
+   * server-side fold is the only place that knows the full transition table
    * (`requires_action` in particular is invisible to a client-side mapping).
    * Absent only on chunk events replayed from a snapshot's retained buffer;
    * there the snapshot's own `status` is the phase source.

--- a/packages/server/src/harness/events/framework.ts
+++ b/packages/server/src/harness/events/framework.ts
@@ -12,7 +12,7 @@ import { Schema } from "effect";
  * Harness-internal event vocabulary. The public `@vibest/contract` wire model is
  * a flat tagged union (`SessionScopedEvent` keyed by `SessionRef`); this module
  * keeps the harness's own ergonomic `defineEvent`/`SessionEnvelope` shape, keyed
- * by the agent-native `sessionId`. The server SessionRuntime translates these
+ * by the agent-native `sessionId`. `HarnessAgentSession` translates these
  * drafts into the wire model at the fan-out boundary (attaching the `SessionRef`
  * and stamping the per-session `seq`).
  */


### PR DESCRIPTION
## What

Started as a question about whether the server really has one `HarnessAgentSession` abstraction with an optional per-harness runtime. It does — `cb9a559` (#212) landed exactly that, and `.agents/rules/architecture.md` + `CONTEXT.md` were updated with it. So this PR does **not** rewrite them. It fixes what checking the code against the docs turned up.

**One wrong pointer.** The rules told a fourth harness to register its adapter in `packages/server/src/harness/registry.ts`. That file names no harness at all (`grep -c "claude\|codex\|pi"` → 0) — it only exports `makeHarnessAgentRegistry(adapters)`. The three adapters are constructed in `rpc/runtime.ts:92`'s `RegistryLayer`, which also wraps each in `cacheAvailability`. Following the old text sends you to the wrong file and invites a second availability cache inside the adapter.

**Three stale comment names, one of them a reversed fact.** `contract/src/domain.ts` (×3) and `harness/events/framework.ts` still called the seq stamper "the SessionRuntime". `domain.ts`'s phase comment went further and said "the runtime is the only place that knows the full transition table" — backwards now: `HarnessAgentRuntime` is the live execution resource (prompt/events/close) and knows nothing about phase; `session-fold.ts` owns the table.

**One drifted count.** `stack.md` said thirteen files under `packages/server/src` import `node:path`; it is ten. That number exists to be an anchor for "don't add to this", so a drifted one stops doing its job.

**One errata note.** `map.md`'s decision 4 reads "由各 SessionRuntime 在 projection 折叠处自增" — both words are stale, and `projection` is on `CONTEXT.md`'s _Avoid_ list. That file's convention is a dated 勘误 rather than editing the recorded decision (two already exist from 2026-08-04), so this follows it. The note also records why the increment shares a semaphore with the publish — `session.ts:222` explains that a split would let two fibers publish n+1 before n and lose n to the client's `seq <= cursor` guard, but that reason was not findable at map level.

## Not in scope

`docs/2026-*.md`, `docs/plans/`, and the `tickets/` files still say `SessionRuntime`. Those are dated records of what was decided then, not live docs — editing them would falsify the history.

## Verification

`pnpm check` (lint:check + format:check + typecheck) green, 10/10 tasks. Comments and markdown only; no behaviour touched.