### PR TITLE
fix(server): resolve the harness CLIs a deployment PATH cannot see

### DIFF
--- a/.agents/rules/architecture.md
+++ b/.agents/rules/architecture.md
@@ -66,5 +66,5 @@ app-server generate-ts`) and is in the lint/format ignore lists. Don't hand-edit
   is unreachable at runtime. `harness/registry.ts` is only the lookup table's
   factory (`makeHarnessAgentRegistry(adapters)`) and names no harness; that
   composition root is the single place the adapters are constructed, and it wraps
-  each in `cacheAvailability` so a `--version` probe costs one spawn per server
+  each in `cacheAvailability` so a `--version` check costs one spawn per server
   rather than one per call.

--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -107,7 +107,7 @@ already written" is not a reason to add to the list:
 | `apps/desktop/src/main`'s Electron-bound files                            | `app-protocol`, `main-window`, `desktop-config`, `lib/utils` are tied to the Electron lifecycle      |
 | `node:os.homedir` (`config/paths.ts`, `rpc/fs.ts`)                        | Effect has no OS/home-directory service                                                              |
 | `node:module.createRequire` (`harness/claude-code/executable.ts`)         | no Effect equivalent                                                                                 |
-| `daemon/port.ts`, and the `process.kill` signals in `liveness`/`launcher` | Effect has no port-probe or process-signal service                                                   |
+| `daemon/port.ts`, and the `process.kill` signals in `liveness`/`launcher` | Effect has no free-port or process-signal service                                                    |
 
 `node:path` is not on this list because it never needed an exemption — see
 "Where the boundary is" above. Path math is pure, so it stays `node:path`

--- a/.agents/rules/toolchain.md
+++ b/.agents/rules/toolchain.md
@@ -6,7 +6,11 @@
   `vitest`, `effect`, or `@effect/*` does nothing. Several pins are caret-free
   because a caret breaks the runtime. The reasons are commented inline; read them
   before changing versions. `packages/server` pins the Claude SDK as a literal
-  while `packages/vibest` uses `catalog:` — bump both together.
+  while `packages/vibest` uses `catalog:` — bump both together. Same for pi
+  (`@earendil-works/pi-coding-agent`), literally pinned in **both**: the CLI
+  declares it so the bundled `dist/cli.mjs` can resolve the copy it spawns
+  (`harness/pi/executable.ts`), which a `packages/server`-only dependency is
+  invisible to. Two literals, one version.
 - **Lint:** `lint:check` runs `--deny-warnings`, so the whole `suspicious`
   category fails CI while only warning locally. oxfmt reorders imports.
 - **Commits rewrite files:** pre-commit runs lint-staged (`oxlint --fix` + `oxfmt`)

--- a/.agents/rules/ui-components.md
+++ b/.agents/rules/ui-components.md
@@ -84,7 +84,7 @@ className={cn(
 
 Colors and spacing come from semantic design tokens (`--background`,
 `--primary`, `--primary-foreground`…), never hardcoded values — tokens name
-what something *is*, not how it looks, so themes swap under them. For dynamic
+what something _is_, not how it looks, so themes swap under them. For dynamic
 values use CSS variables (`bg-[var(--color)]` + `style={{ "--color": x }}`),
 never interpolated class names.
 
@@ -93,11 +93,11 @@ never interpolated class names.
 Never expose per-state className props (`openClassName`, `classes={{...}}`).
 Expose state as attributes and let consumers style with selectors:
 
-| Mechanism    | Carries                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------- |
-| `data-state` | Visual/layout state: `open`/`closed`, `active`, loading, `data-orientation`, `data-side`     |
+| Mechanism    | Carries                                                                                                     |
+| ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `data-state` | Visual/layout state: `open`/`closed`, `active`, loading, `data-orientation`, `data-side`                    |
 | `data-slot`  | Stable identity for parent/global targeting — kebab-case, purpose-named (`submit-button`, not `blueButton`) |
-| props        | Variants (`variant`, `size`), behavior config, event handlers                                 |
+| props        | Variants (`variant`, `size`), behavior config, event handlers                                               |
 
 ```tsx
 <div data-slot="dialog" data-state={isOpen ? "open" : "closed"} ... />

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,7 +39,7 @@ _Avoid_: SessionService (its dissolved predecessor in `session/service.ts`)
 The sole owner of live session state: the table of sessions keyed by ref (each `Live` or `Closing`), and the `acquire` a session runs when it decides it needs a runtime. Sole caller of `adapter.open`/`adapter.resume` — adapters may assume single-flight per session id, which the session's own acquisition ticket guarantees. A ref with nothing live reads as idle at cursor 0 rather than failing, so a client can attach, snapshot and subscribe without starting anything.
 
 **HarnessAgentAdapter / HarnessAgentRuntime** (`harness/adapter.ts`):
-The per-harness door (descriptor, availability, probes, open/resume factory, cold reads) and the live execution resource it produces (prompt/events/config/close) — a pi child, a Claude SDK handle, a Codex thread. The per-agent `XxxAgent` façades under `harness/<agent>/` are private protocol plumbing below the adapter, not shared abstractions.
+The per-harness door (descriptor, availability, model catalogue, open/resume factory, cold reads) and the live execution resource it produces (prompt/events/config/close) — a pi child, a Claude SDK handle, a Codex thread. The per-agent `XxxAgent` façades under `harness/<agent>/` are private protocol plumbing below the adapter, not shared abstractions.
 _Avoid_: HarnessAgentSession for the runtime (it is the in-memory session; see below)
 
 **Private modules** (no Context tags, never wired directly):

--- a/apps/app/src/features/chat/chat.tsx
+++ b/apps/app/src/features/chat/chat.tsx
@@ -22,7 +22,7 @@ export function Chat({
   /**
    * The session's working directory. Resolved by the route, not here: that
    * lookup belongs to the projects feature, and features don't reach sideways.
-   * Undefined until the project list lands, which only delays the model probe.
+   * Undefined until the project list lands, which only delays the model list.
    */
   cwd: string | undefined;
 }) {

--- a/apps/app/src/features/chat/components/chat-session-context.ts
+++ b/apps/app/src/features/chat/components/chat-session-context.ts
@@ -19,7 +19,7 @@ export interface ChatSessionValue {
   respondToRequest: (requestId: string, response: AgentResponse) => void | Promise<void>;
   /** A turn is producing a reply (submitted / streaming). */
   turnInProgress: boolean;
-  /** Probed model providers; empty when the harness has no model switch. */
+  /** The model providers this harness offers; empty when it has no model switch. */
   providers: ReadonlyArray<ProviderInfo>;
   /** The selected model pair — always both or neither. */
   providerId: string | undefined;

--- a/apps/app/src/features/chat/components/chat-session-provider.tsx
+++ b/apps/app/src/features/chat/components/chat-session-provider.tsx
@@ -9,7 +9,7 @@ import {
   resolveModel,
   resolvePermissionMode,
 } from "@/features/chat/harness/session-config";
-import { useHarnessAgent, useHarnessProbe } from "@/features/chat/harness/use-harness";
+import { useHarnessAgent, useHarnessModels } from "@/features/chat/harness/use-harness";
 import { selectTurnInProgress, useChatHandle } from "@/features/chat/runtime/use-chat-handle";
 
 import { ChatSessionContext, type ChatSessionValue } from "./chat-session-context";
@@ -48,9 +48,9 @@ export function ChatSessionProvider({
   const harnessAgent = useHarnessAgent(chat.harnessAgentId);
   // What this harness offers *in this session's directory* — a project's own
   // settings can remap what a model id resolves to, so the providers have to
-  // be probed per project, not once per harness.
-  const probe = useHarnessProbe(chat.harnessAgentId, cwd);
-  const providers = probe.data?.providers ?? NO_PROVIDERS;
+  // be read per project, not once per harness.
+  const models = useHarnessModels(chat.harnessAgentId, cwd);
+  const providers = models.data?.providers ?? NO_PROVIDERS;
   // Each dimension resolves on its own; reasoningEffort cascades from the resolved model.
   const model = resolveModel(providers, picked.providerId, picked.modelId);
   const modelInfo = findModelInfo(providers, model?.providerId, model?.modelId);
@@ -95,7 +95,7 @@ export function ChatSessionProvider({
 
   const reasoningEfforts = modelInfo?.reasoningEfforts ?? NO_REASONING_EFFORTS;
   // orderPermissionModes builds a new array on every call, so it is memoised on
-  // the harness's declared list — which only changes when the probe does.
+  // the harness's declared list — which only changes when the harness does.
   const declaredPermissionModes = harnessAgent?.permissionModes;
   const permissionModes = useMemo(
     () => orderPermissionModes(declaredPermissionModes ?? []),

--- a/apps/app/src/features/chat/components/input/use-chat-input-has-content.test.ts
+++ b/apps/app/src/features/chat/components/input/use-chat-input-has-content.test.ts
@@ -21,7 +21,7 @@ const makeController = (html?: string) => {
   return controller;
 };
 
-function Probe({ controller }: { controller: ChatInputController | null }) {
+function Spy({ controller }: { controller: ChatInputController | null }) {
   return createElement("span", null, String(useChatInputHasContent(controller)));
 }
 
@@ -35,7 +35,7 @@ const render = (controller: ChatInputController | null): string => {
     root = createRoot(host);
   }
   const mounted = root;
-  act(() => mounted?.render(createElement(Probe, { controller })));
+  act(() => mounted?.render(createElement(Spy, { controller })));
   return host.textContent ?? "";
 };
 

--- a/apps/app/src/features/chat/components/model-select.tsx
+++ b/apps/app/src/features/chat/components/model-select.tsx
@@ -11,7 +11,7 @@ import {
 // a session (ChatModelSelect binds it to ChatSession context) and on the draft
 // surface (URL search params, no session yet).
 //
-// The options come from the probed providers, never from a list in here: the
+// The options come from the fetched providers, never from a list in here: the
 // catalogue follows the signed-in account and the installed CLI, so a hardcoded
 // one is a claim the provider never made. Model ids are opaque and atomic —
 // this component renders `label ?? id` and echoes the providerId/modelId pair

--- a/apps/app/src/features/chat/components/reasoning-effort-select.tsx
+++ b/apps/app/src/features/chat/components/reasoning-effort-select.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/features/chat/harness/reasoning-efforts";
 
 // Presentational reasoning-reasoningEffort picker. Its candidates cascade from the
-// selected model's probed traits — not from the harness — so the caller passes
+// selected model's own traits — not from the harness — so the caller passes
 // them in; an empty list means the current model has no reasoningEffort switch and no
 // control is rendered. Labels and ordering are client-owned: reasoningEffort names are
 // vibest's vocabulary, like permission modes.

--- a/apps/app/src/features/chat/harness/reasoning-efforts.ts
+++ b/apps/app/src/features/chat/harness/reasoning-efforts.ts
@@ -4,7 +4,7 @@ import type { ReasoningEffort } from "@vibest/contract";
  * Display knowledge for the reasoning-reasoningEffort union. Like permission modes,
  * reasoningEffort names are vibest's vocabulary — adapters translate native levels into
  * it — so their labels and ordering are client-owned. Which members a given
- * model offers comes from that model's probed traits (`ModelInfo.reasoningEfforts`).
+ * model offers comes from that model's own traits (`ModelInfo.reasoningEfforts`).
  */
 export const REASONING_EFFORT_LABELS: Record<ReasoningEffort, string> = {
   minimal: "Minimal",

--- a/apps/app/src/features/chat/harness/session-config.test.ts
+++ b/apps/app/src/features/chat/harness/session-config.test.ts
@@ -18,7 +18,7 @@ const claudeCode: HarnessAgentInfo = {
   defaultPermissionMode: "full",
 };
 
-// The other half, probed per directory rather than declared once. Models live
+// The other half, fetched per directory rather than declared once. Models live
 // inside their provider — the built-in provider carries the harness's id.
 const claudeProviders: ReadonlyArray<ProviderInfo> = [
   {
@@ -42,11 +42,11 @@ describe("resolveModel", () => {
 
   it("resolves to nothing when the user picked nothing", () => {
     // No fabricated default: the wire omits the field, so the session runs on
-    // the harness's own configured default — which is not probeable.
+    // the harness's own configured default — which we cannot ask for.
     expect(resolveModel(claudeProviders, undefined, undefined)).toBeUndefined();
   });
 
-  it("drops a pick the probe doesn't vouch for", () => {
+  it("drops a pick the catalog doesn't vouch for", () => {
     // The shape of "switched harness with a stale model in the URL": never
     // display or submit a pair that isn't in this harness's providers.
     expect(resolveModel(claudeProviders, "codex", "gpt-5.6-sol")).toBeUndefined();
@@ -58,7 +58,7 @@ describe("resolveModel", () => {
     expect(resolveModel(claudeProviders, "codex", "sonnet")).toBeUndefined();
   });
 
-  it("ignores a URL-supplied pick until the probe can vouch for it", () => {
+  it("ignores a URL-supplied pick until the catalog can vouch for it", () => {
     // Passing it through unchecked would send `session.create` a pair this
     // directory may not resolve at all; omitting it means "harness default".
     expect(resolveModel([], "claude-code", "sonnet")).toBeUndefined();
@@ -100,7 +100,7 @@ describe("reasoningEffort cascades from the selected model", () => {
     expect(resolveReasoningEffort(sol, "max")).toBe("medium");
   });
 
-  it("resolves to nothing while the probe is still in flight", () => {
+  it("resolves to nothing while the catalog is still in flight", () => {
     expect(resolveReasoningEffort(undefined, "high")).toBeUndefined();
   });
 });

--- a/apps/app/src/features/chat/harness/session-config.ts
+++ b/apps/app/src/features/chat/harness/session-config.ts
@@ -29,7 +29,7 @@ export function pickDefaultHarnessAgentId(
 /**
  * Each session-config dimension resolves on its own — their option sources are
  * different endpoints (permission modes are declared by `harness.list`, the
- * model catalog is probed by `harness.probe`, reasoningEffort candidates are read off
+ * model catalog comes from `harness.models`, reasoningEffort candidates are read off
  * the resolved model), so there is no combined "config" object to name. What
  * the resolvers share is one rule: a pick that isn't offered is dropped, never
  * passed through, and an absent pick falls back to the declared default. Stale
@@ -38,13 +38,13 @@ export function pickDefaultHarnessAgentId(
  *
  * A dimension nothing declared has no options and no value, so its control
  * isn't rendered and `session.create` omits the field — which is how the
- * harness ends up using its own configured default. A probe that simply hasn't
+ * harness ends up using its own configured default. A catalog that simply hasn't
  * arrived yet lands there too, and that is deliberate: the user can submit
  * before it does, and gets the harness's default rather than a wait.
  */
 
 /** The traits behind a providerId/modelId pair — undefined when the pair is
- * absent or points outside the probed catalog. Both halves must match: a
+ * absent or points outside the fetched catalog. Both halves must match: a
  * modelId is only unique within its provider. */
 export const findModelInfo = (
   providers: ReadonlyArray<ProviderInfo>,
@@ -58,7 +58,7 @@ export const findModelInfo = (
 /** The picked pair while the catalog still offers it, else nothing. There is
  * deliberately no default to fall back to: a catalog's "default" marker is the
  * provider's suggestion, not what an unconfigured session actually runs — the
- * harness's own user config decides that, and it is not probeable. No pick →
+ * harness's own user config decides that, and there is no way to ask for it. No pick →
  * the control shows its placeholder and the wire omits the field, so the
  * harness decides. */
 export const resolveModel = (

--- a/apps/app/src/features/chat/harness/use-harness.ts
+++ b/apps/app/src/features/chat/harness/use-harness.ts
@@ -4,7 +4,7 @@ import type {
   HarnessAgentId,
   HarnessAgentInfo,
   HarnessListOutput,
-  HarnessProbeOutput,
+  HarnessModelsOutput,
 } from "@vibest/contract";
 import { useCallback } from "react";
 
@@ -44,30 +44,30 @@ export function useHarnessAgent(harnessAgentId: HarnessAgentId): HarnessAgentInf
 }
 
 /**
- * The probed model providers for one harness in one directory. Returns the
- * whole query, because its failure is meaningful: a failed probe must stay
+ * The model providers one harness offers in one directory. Returns the
+ * whole query, because its failure is meaningful: a failed read must stay
  * distinguishable from "this harness has no models" (empty providers), so the
  * UI can render a retryable degraded state instead of silently hiding the
  * picker.
  *
  * While `cwd` is unknown the input is `skipToken`, not a fabricated value:
  * unlike `enabled: false`, a skipped query cannot be forced to run by
- * `refetch()`, so the retry affordance can never fire a probe against a
+ * `refetch()`, so the retry affordance can never fire a request against a
  * made-up directory.
  *
  * Unlike the list this is fetched lazily and costs a CLI spawn, so it is held
  * far longer than TanStack's defaults would: without a `staleTime` every
- * window focus would re-probe. The server de-duplicates concurrent asks and
+ * window focus would re-fetch. The server de-duplicates concurrent asks and
  * holds its own short-lived answer, so a stale read here is cheap to correct
  * and an eager one is not.
  */
-export function useHarnessProbe(
+export function useHarnessModels(
   harnessAgentId: HarnessAgentId,
   cwd: string | undefined,
-): UseQueryResult<HarnessProbeOutput> {
+): UseQueryResult<HarnessModelsOutput> {
   const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
   return useQuery({
-    ...orpcQueryUtils.harness.probe.queryOptions({
+    ...orpcQueryUtils.harness.models.queryOptions({
       input: cwd === undefined ? skipToken : { harnessAgentId, cwd },
     }),
     staleTime: 5 * 60_000,

--- a/apps/app/src/routes/draft.tsx
+++ b/apps/app/src/routes/draft.tsx
@@ -45,7 +45,7 @@ import {
 import {
   useHarnessAgent,
   useHarnessAgents,
-  useHarnessProbe,
+  useHarnessModels,
 } from "@/features/chat/harness/use-harness";
 import { useChatManager } from "@/features/chat/runtime/chat-context";
 import { ImportProjectDialog } from "@/features/projects/import-project-dialog";
@@ -128,14 +128,14 @@ function DraftRoute() {
   const harnessAgent = useHarnessAgent(harnessAgentId);
   // The selected project's directory decides what its harness can offer — a
   // project's own settings can remap what a model id resolves to. No project
-  // picked means no cwd to probe, so the model picker has nothing to offer;
-  // the composer blocks on project selection anyway. Undefined until the probe
-  // lands is not a wait either: submitting meanwhile omits `model` — which is
-  // exactly what "the user didn't pick one" already means.
-  const probe = useHarnessProbe(harnessAgentId, selected?.path);
+  // picked means no cwd to ask about, so the model picker has nothing to
+  // offer; the composer blocks on project selection anyway. Undefined until
+  // the answer lands is not a wait either: submitting meanwhile omits `model` —
+  // which is exactly what "the user didn't pick one" already means.
+  const models = useHarnessModels(harnessAgentId, selected?.path);
   // Each dimension resolves on its own — a stale URL pick is dropped, an
   // absent one falls back to the declared default.
-  const providers = probe.data?.providers ?? [];
+  const providers = models.data?.providers ?? [];
   const model = resolveModel(providers, search.provider, search.model);
   const permissionModes = orderPermissionModes(harnessAgent?.permissionModes ?? []);
   const permissionMode = resolvePermissionMode(harnessAgent, search.permission);

--- a/apps/desktop/src/main/server/daemon-server-process.ts
+++ b/apps/desktop/src/main/server/daemon-server-process.ts
@@ -14,7 +14,7 @@ const DEFAULT_POLL_INTERVAL_MS = 2_000;
 const MAX_HEALTH_MISSES = 3;
 
 export type DaemonServerProcessOptions = {
-  /** How often to probe the attached daemon's liveness. */
+  /** How often to check the attached daemon's liveness. */
   readonly pollIntervalMs?: number;
 };
 
@@ -76,7 +76,7 @@ export function makeDaemonServerProcess(
             while (true) {
               yield* Effect.sleep(pollIntervalMs);
               if (!pidAlive(handle.pid)) return { exitCode: null };
-              // Tolerate transient probe failures; a wedged-but-alive daemon
+              // Tolerate transient check failures; a wedged-but-alive daemon
               // still counts as dead after enough consecutive misses.
               misses = (yield* healthy(handle.address)) ? 0 : misses + 1;
               if (misses >= MAX_HEALTH_MISSES) return { exitCode: null };

--- a/apps/desktop/src/main/server/login-shell-environment.test.ts
+++ b/apps/desktop/src/main/server/login-shell-environment.test.ts
@@ -45,7 +45,7 @@ describe("resolveLoginShellEnvironment", () => {
     });
   });
 
-  it("runs the environment probe through the interactive login shell", async () => {
+  it("reads the environment through the interactive login shell", async () => {
     const command = vi.fn<RunCommand>(() => Effect.succeed(fenced({ PATH: "/usr/bin" })));
 
     await resolve(command, {
@@ -112,7 +112,7 @@ describe("resolveLoginShellEnvironment", () => {
     });
   });
 
-  it("uses the inherited environment when the shell probe fails on linux", async () => {
+  it("uses the inherited environment when the shell read fails on linux", async () => {
     const command = vi.fn<RunCommand>(() => Effect.fail(new Error("shell exploded")));
 
     await expect(
@@ -138,7 +138,7 @@ describe("resolveLoginShellEnvironment", () => {
     expect(command).not.toHaveBeenCalled();
   });
 
-  it("keeps the inherited environment when every darwin probe fails", async () => {
+  it("keeps the inherited environment when every darwin attempt fails", async () => {
     const command = vi.fn<RunCommand>(() => Effect.fail(new Error("nope")));
 
     await expect(

--- a/apps/desktop/src/main/server/login-shell-environment.ts
+++ b/apps/desktop/src/main/server/login-shell-environment.ts
@@ -20,7 +20,7 @@ const LAUNCHCTL_KEYS = [
   "no_proxy",
 ] as const;
 
-// The error stays `unknown` on purpose: every probe failure is swallowed into
+// The error stays `unknown` on purpose: every failure here is swallowed into
 // the base-environment fallback and never crosses this module's boundary.
 export type RunCommand = (file: string, args: readonly string[]) => Effect.Effect<string, unknown>;
 

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -416,7 +416,7 @@ export type ModelInfo = typeof ModelInfoSchema.Type;
 // of the composite key that makes `modelId` meaningful.
 // No default marker on purpose: a catalog's "default" flag is the provider's
 // suggestion, not what an unconfigured session actually runs (the harness's
-// own user config decides that, and it is not probeable). The default is
+// own user config decides that, and there is no way to ask for it). The default is
 // expressed by absence — no pick on the wire means the harness decides.
 export const ProviderInfoSchema = Schema.Struct({
   id: Schema.String,
@@ -455,21 +455,21 @@ export type HarnessListOutput = typeof HarnessListOutputSchema.Type;
 // what a project is (see `session/port.ts` — "the port speaks ... a resolved
 // `cwd` only"), and the directory is what the answer actually depends on. It
 // also makes the cache key right for free: two projects registered at the same
-// path share one probe instead of spawning twice for the same answer.
-export const HarnessProbeInputSchema = Schema.Struct({
+// path share one cache entry instead of spawning twice for the same answer.
+export const HarnessModelsInputSchema = Schema.Struct({
   harnessAgentId: HarnessAgentIdSchema,
   cwd: Schema.String,
 });
-export type HarnessProbeInput = typeof HarnessProbeInputSchema.Type;
+export type HarnessModelsInput = typeof HarnessModelsInputSchema.Type;
 
-// What probing one harness in one directory yielded. Empty `providers` means
-// the harness has no model catalogue at all (pi). A failed probe is an error,
+// What one harness offers in one directory. Empty `providers` means the
+// harness has no model catalogue at all (pi). A failed read is an error,
 // never an empty result — an expired login must stay distinguishable from
 // "this harness has no model picker".
-export const HarnessProbeOutputSchema = Schema.Struct({
+export const HarnessModelsOutputSchema = Schema.Struct({
   providers: Schema.Array(ProviderInfoSchema),
 });
-export type HarnessProbeOutput = typeof HarnessProbeOutputSchema.Type;
+export type HarnessModelsOutput = typeof HarnessModelsOutputSchema.Type;
 
 export type SessionRuntimeSnapshot = {
   readonly ref: SessionRef;
@@ -593,7 +593,7 @@ export const BrowseResultSchema = Schema.Struct({
 // via the dedicated setters — never carried on a prompt turn. The two channels
 // fail differently on purpose: `permissionMode` is our closed union (a bad
 // value is a client bug → INVALID_ARGUMENT), while the model pair and `reasoningEffort`
-// come from probed lists that go stale, so applying them is best-effort — a
+// come from fetched lists that go stale, so applying them is best-effort — a
 // miss falls back to the harness default and the session still opens.
 // `providerId`/`modelId` must be given together; a half pair is a client bug
 // the RPC boundary rejects.

--- a/packages/contract/src/harness.ts
+++ b/packages/contract/src/harness.ts
@@ -3,8 +3,8 @@ import { Schema } from "effect";
 
 import {
   HarnessListOutputSchema,
-  HarnessProbeInputSchema,
-  HarnessProbeOutputSchema,
+  HarnessModelsInputSchema,
+  HarnessModelsOutputSchema,
   serverErrors,
   toStandardSchema,
 } from "./domain";
@@ -27,13 +27,13 @@ export const harnessContract = {
    * CLI spawn and the answer changes per directory, so it is fetched lazily,
    * for the selected harness only, off the startup path.
    *
-   * A failed probe fails the call — it is never collapsed into an empty
+   * A failed read fails the call — it is never collapsed into an empty
    * result. An expired login answering "no models" would be cached as "this
    * harness has no model picker", which is the worst kind of silent error; the
    * client renders a retryable degraded state instead.
    */
-  probe: oc
+  models: oc
     .errors(serverErrors)
-    .input(toStandardSchema(HarnessProbeInputSchema))
-    .output(toStandardSchema(HarnessProbeOutputSchema)),
+    .input(toStandardSchema(HarnessModelsInputSchema))
+    .output(toStandardSchema(HarnessModelsOutputSchema)),
 };

--- a/packages/contract/src/harness.ts
+++ b/packages/contract/src/harness.ts
@@ -5,6 +5,7 @@ import {
   HarnessListOutputSchema,
   HarnessProbeInputSchema,
   HarnessProbeOutputSchema,
+  serverErrors,
   toStandardSchema,
 } from "./domain";
 
@@ -32,6 +33,7 @@ export const harnessContract = {
    * client renders a retryable degraded state instead.
    */
   probe: oc
+    .errors(serverErrors)
     .input(toStandardSchema(HarnessProbeInputSchema))
     .output(toStandardSchema(HarnessProbeOutputSchema)),
 };

--- a/packages/contract/test/schema.test.ts
+++ b/packages/contract/test/schema.test.ts
@@ -5,8 +5,8 @@ import {
   ArchiveSessionInputSchema,
   CollectionEventTypes,
   HarnessListOutputSchema,
-  HarnessProbeInputSchema,
-  HarnessProbeOutputSchema,
+  HarnessModelsInputSchema,
+  HarnessModelsOutputSchema,
   ListSessionsInputSchema,
   type ServerEvent,
   serverErrors,
@@ -157,26 +157,26 @@ describe("HarnessListOutput", () => {
   });
 });
 
-describe("HarnessProbeOutput", () => {
+describe("HarnessModelsOutput", () => {
   const output = (providers: unknown) => ({ providers });
 
   it("keeps models inside their provider", () => {
     expect(
       accepts(
-        HarnessProbeOutputSchema,
+        HarnessModelsOutputSchema,
         output([{ id: "codex", models: [{ id: "gpt-5.6-sol", label: "GPT 5.6 Sol" }] }]),
       ),
     ).toBe(true);
   });
 
   it("accepts an empty provider list — how a harness says it has no model switch", () => {
-    expect(accepts(HarnessProbeOutputSchema, output([]))).toBe(true);
+    expect(accepts(HarnessModelsOutputSchema, output([]))).toBe(true);
   });
 
   it("carries normalized traits next to the opaque id", () => {
     expect(
       accepts(
-        HarnessProbeOutputSchema,
+        HarnessModelsOutputSchema,
         output([
           {
             id: "codex",
@@ -197,7 +197,7 @@ describe("HarnessProbeOutput", () => {
   it("rejects an reasoningEffort outside the vocabulary — adapters must drop what they can't translate", () => {
     expect(
       accepts(
-        HarnessProbeOutputSchema,
+        HarnessModelsOutputSchema,
         output([{ id: "codex", models: [{ id: "m", reasoningEfforts: ["turbo"] }] }]),
       ),
     ).toBe(false);
@@ -205,14 +205,14 @@ describe("HarnessProbeOutput", () => {
 
   it("rejects a model without an id", () => {
     expect(
-      accepts(HarnessProbeOutputSchema, output([{ id: "codex", models: [{ label: "Sonnet" }] }])),
+      accepts(HarnessModelsOutputSchema, output([{ id: "codex", models: [{ label: "Sonnet" }] }])),
     ).toBe(false);
   });
 
-  it("addresses a probe by directory, not by project", () => {
-    expect(accepts(HarnessProbeInputSchema, { harnessAgentId: "codex", cwd: "/work/app" })).toBe(
+  it("addresses a model catalogue by directory, not by project", () => {
+    expect(accepts(HarnessModelsInputSchema, { harnessAgentId: "codex", cwd: "/work/app" })).toBe(
       true,
     );
-    expect(accepts(HarnessProbeInputSchema, { harnessAgentId: "codex" })).toBe(false);
+    expect(accepts(HarnessModelsInputSchema, { harnessAgentId: "codex" })).toBe(false);
   });
 });

--- a/packages/effect-json-store/test/typing.test.ts
+++ b/packages/effect-json-store/test/typing.test.ts
@@ -10,7 +10,7 @@ describe("makeJsonDocument typing", () => {
   it("infers each migrate input from its sibling schema and the store value from `schema`", () => {
     // Constructing the effect is pure — nothing touches the filesystem here.
     const effect = makeJsonDocument({
-      path: "/tmp/probe.json",
+      path: "/tmp/store.json",
       schema: V2,
       migrations: [
         {
@@ -34,7 +34,7 @@ describe("makeJsonDocument typing", () => {
 
   it("accepts a store without migrations", () => {
     const effect = makeJsonDocument({
-      path: "/tmp/probe.json",
+      path: "/tmp/store.json",
       schema: V1,
       defaults: { theme: "light" },
     });

--- a/packages/server/src/daemon/liveness.ts
+++ b/packages/server/src/daemon/liveness.ts
@@ -4,7 +4,7 @@ import type { DaemonRecord } from "./record";
 
 const HEALTH_TIMEOUT_MS = 1_000;
 
-/** True if a process with this pid exists (signal 0 probes without killing). */
+/** True if a process with this pid exists (signal 0 tests without killing). */
 export function pidAlive(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
@@ -19,7 +19,7 @@ export function pidAlive(pid: number): boolean {
 /**
  * True if `${address}/api/health` answers `ok`. Always bounded: a wedged
  * daemon that accepts connections but never responds must read as unhealthy,
- * not hang the probe (and with it every liveness poll built on top).
+ * not hang the check (and with it every liveness poll built on top).
  */
 export const healthy = (address: string, signal?: AbortSignal): Effect.Effect<boolean> =>
   Effect.promise(async () => {

--- a/packages/server/src/daemon/port.ts
+++ b/packages/server/src/daemon/port.ts
@@ -10,7 +10,7 @@ import { DaemonLaunchError } from "./errors";
  * OS-assigned ephemeral port. The launcher passes the result to the server and
  * records it, so callers never guess the port — they read it from `daemon.pid`.
  *
- * There is an inherent TOCTOU gap between closing this probe socket and the
+ * There is an inherent TOCTOU gap between closing this listener and the
  * daemon binding: acceptable for a single-user loopback daemon (a lost race
  * makes the daemon fail to bind, the health poll times out, and the launcher
  * reports it) and matched by how the SSH launch script picks a port.
@@ -27,12 +27,12 @@ export const reservePort = (preferred: number): Effect.Effect<number, DaemonLaun
 
 function tryListen(port: number): Promise<number> {
   return new Promise((resolve, reject) => {
-    const probe = net.createServer();
-    probe.once("error", reject);
-    probe.listen(port, "127.0.0.1", () => {
-      const address = probe.address();
+    const listener = net.createServer();
+    listener.once("error", reject);
+    listener.listen(port, "127.0.0.1", () => {
+      const address = listener.address();
       const resolved = typeof address === "object" && address ? address.port : port;
-      probe.close(() => resolve(resolved));
+      listener.close(() => resolve(resolved));
     });
   });
 }

--- a/packages/server/src/harness/adapter.ts
+++ b/packages/server/src/harness/adapter.ts
@@ -142,11 +142,16 @@ export interface HarnessAgentAdapter {
   readonly id: HarnessAgentId;
   readonly descriptor: AgentDescriptor;
   /**
-   * A PATH lookup, so it reads the filesystem — the requirement rides the `R`
-   * channel out to whoever builds the service that calls it (list, session
-   * service), which binds the platform layers at its own construction.
+   * Whether this harness can be used right now, and why not when it cannot.
+   *
+   * Locating the CLI reads the filesystem, so the requirement rides the `R`
+   * channel out to whoever builds the service that calls it (list, the
+   * registry's gate), which binds the platform layers at its own construction.
+   *
+   * Answered off the agent's own cached resolve, so it cannot disagree with
+   * what the transport goes on to spawn — see `harness/executable.ts`.
    */
-  readonly checkAvailability: Effect.Effect<AvailabilityResult, never, FileSystem.FileSystem>;
+  readonly availability: Effect.Effect<AvailabilityResult, never, FileSystem.FileSystem>;
   /**
    * The subset of vibest's permission vocabulary this harness can honour, and
    * which member to preselect. Plain values, not effects: they follow from the

--- a/packages/server/src/harness/adapter.ts
+++ b/packages/server/src/harness/adapter.ts
@@ -16,7 +16,7 @@ import type {
   AgentOperationError,
   AgentRequestUnavailable,
   AgentUnavailable,
-  CapabilityProbeFailed,
+  ModelListFailed,
   CapabilityUnsupported,
   ExecutableNotFound,
   SessionClosed,
@@ -163,24 +163,23 @@ export interface HarnessAgentAdapter {
   readonly permissionModes: ReadonlyArray<PermissionMode>;
   readonly defaultPermissionMode?: PermissionMode;
   /**
-   * Probe this harness's built-in model provider in one working directory. It
-   * follows the signed-in account, the installed version *and* the directory's
-   * own config, so it can only be probed — never hardcoded, and never probed
-   * once for everyone. Absent for harnesses with no model catalogue (pi).
+   * Ask this harness's built-in model provider what it offers in one working
+   * directory. The answer follows the signed-in account, the installed version
+   * *and* the directory's own config, so it can only be asked for — never
+   * hardcoded, and never asked once for everyone. Absent for harnesses with no
+   * model catalogue (pi).
    *
    * `cwd` is honoured where it matters: claude-code passes it to the SDK
    * because a project's settings can remap what a model id resolves to. Codex
    * ignores it — its `model/list` is app-server-global — but still takes it, so
    * callers never have to know which is which.
    *
-   * The error channel is the point: a probe that fails has to stay
+   * The error channel is the point: a failed read has to stay
    * distinguishable from a harness that genuinely has no models, otherwise an
    * expired login gets cached as "this harness has no model picker".
-   * {@link HarnessProbeService} owns the timeout, caching and de-duplication.
+   * {@link HarnessModelsService} owns the timeout, caching and de-duplication.
    */
-  readonly probeModels?: (
-    cwd: string,
-  ) => Effect.Effect<ReadonlyArray<ModelInfo>, CapabilityProbeFailed>;
+  readonly listModels?: (cwd: string) => Effect.Effect<ReadonlyArray<ModelInfo>, ModelListFailed>;
   readonly open: (
     input: CreateSessionInput,
   ) => Effect.Effect<

--- a/packages/server/src/harness/claude-code/adapter.ts
+++ b/packages/server/src/harness/claude-code/adapter.ts
@@ -439,7 +439,12 @@ export const makeClaudeCodeAdapter = (agent: ClaudeCodeAgent): HarnessAgentAdapt
   // the SDK bundles reports as unavailable, so a too-old install fails fast
   // (AgentUnavailable → UNSUPPORTED) instead of launching against a CLI whose
   // wire protocol the harness types no longer match.
-  checkAvailability: checkClaudeAvailability(),
+  // `resolve` handed in, so finding the binary happens once and both this check
+  // and the SDK launch use that answer; the version floor on top stays
+  // claude-code's own (see `checkClaudeAvailability`).
+  checkAvailability: checkClaudeAvailability({
+    resolve: Effect.suspend(() => agent.executable),
+  }),
   open: (input) =>
     agent.session.create({ cwd: input.cwd }).pipe(
       Effect.mapError((cause) => new AgentOpenError({ harnessAgentId: "claude-code", cause })),

--- a/packages/server/src/harness/claude-code/adapter.ts
+++ b/packages/server/src/harness/claude-code/adapter.ts
@@ -24,7 +24,7 @@ import {
 import type { SessionEnvelopeDraft, SessionEvent } from "../events/framework";
 import { streamFromQueueOne } from "../queue-stream";
 import type { ClaudeCodeAgent, ToolPermissionRequest } from "./agent";
-import { checkClaudeAvailability } from "./executable";
+import { claudeAvailability } from "./executable";
 import { sessionMessagesToUIMessages } from "./history";
 import { toSessionEvent } from "./to-session-event";
 import { createTransform } from "./transform";
@@ -441,8 +441,8 @@ export const makeClaudeCodeAdapter = (agent: ClaudeCodeAgent): HarnessAgentAdapt
   // wire protocol the harness types no longer match.
   // `resolve` handed in, so finding the binary happens once and both this check
   // and the SDK launch use that answer; the version floor on top stays
-  // claude-code's own (see `checkClaudeAvailability`).
-  checkAvailability: checkClaudeAvailability({
+  // claude-code's own (see `claudeAvailability`).
+  availability: claudeAvailability({
     resolve: Effect.suspend(() => agent.executable),
   }),
   open: (input) =>

--- a/packages/server/src/harness/claude-code/adapter.ts
+++ b/packages/server/src/harness/claude-code/adapter.ts
@@ -16,7 +16,7 @@ import {
   AgentOpenError,
   AgentOperationError,
   AgentRequestUnavailable,
-  CapabilityProbeFailed,
+  ModelListFailed,
   SessionClosed,
   SessionNotResumable,
   TurnAlreadyRunning,
@@ -420,7 +420,7 @@ export const makeClaudeCodeAdapter = (agent: ClaudeCodeAgent): HarnessAgentAdapt
   // Codex defaults lower because its "full" also drops the sandbox; this one
   // only bypasses the prompts.
   defaultPermissionMode: "full",
-  probeModels: (cwd) =>
+  listModels: (cwd) =>
     agent.listModels(cwd).pipe(
       // No `reasoningEfforts` traits on purpose: the SDK exposes the levels in its
       // catalogue but offers no runtime call to apply one, and declaring a
@@ -431,9 +431,7 @@ export const makeClaudeCodeAdapter = (agent: ClaudeCodeAgent): HarnessAgentAdapt
       Effect.map((models) =>
         models.map((model) => ({ id: model.value, label: model.displayName })),
       ),
-      Effect.mapError(
-        (cause) => new CapabilityProbeFailed({ harnessAgentId: "claude-code", cause }),
-      ),
+      Effect.mapError((cause) => new ModelListFailed({ harnessAgentId: "claude-code", cause })),
     ),
   // Present AND new enough: a resolvable binary that is older than the version
   // the SDK bundles reports as unavailable, so a too-old install fails fast

--- a/packages/server/src/harness/claude-code/agent.ts
+++ b/packages/server/src/harness/claude-code/agent.ts
@@ -10,6 +10,7 @@ import { v7 as uuid } from "uuid";
 import {
   AgentRequestUnavailable,
   ClaudeSdkError,
+  type ExecutableNotFound,
   HarnessSessionNotFound,
   SessionNotResumable,
   TurnAlreadyRunning,
@@ -73,6 +74,14 @@ type ResumeDecision =
     };
 
 export interface ClaudeCodeAgent {
+  /**
+   * The absolute path this agent hands the SDK, resolved once and cached.
+   *
+   * Exposed so the adapter's `checkAvailability` answers off the *same* resolve
+   * the SDK launches — see the note in `harness/executable.ts` on why one
+   * search, not two, is the invariant here.
+   */
+  readonly executable: Effect.Effect<string, ExecutableNotFound>;
   /**
    * The models a session started in `cwd` could run, read without opening a
    * session. The catalog follows the user's account and the resolved CLI, so
@@ -179,27 +188,32 @@ export const makeClaudeCodeAgent = ({
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
     // Locating the `claude` binary reads the filesystem. Bind the platform
-    // services once here so the agent's own methods stay R-free; a machine
-    // with no Claude Code install is a defect at this point, since the
-    // adapter's availability check has already gated on it.
+    // services once here so the agent's own methods stay R-free.
     // `Effect.provideService`, not `Effect.provide(Effect.context())`: the
     // latter captures the whole layer-build context — including the `Scope`
     // above — and wins the merge, so it would override a caller's scope.
     const fileSystem = yield* FileSystem.FileSystem;
     // Cached: the answer is fixed for the process, and both `buildSession` and
     // `listModels` ask, so an uncached Effect re-walks PATH on every session.
-    const claudeExecutable = yield* Effect.cached(
+    //
+    // A miss is a failure, not a defect. It used to die on an invariant
+    // ("the executable vanished after the availability check gated on it") —
+    // but the model-list path reached this without ever passing that gate, so
+    // the invariant was false and an uninstalled harness took the endpoint
+    // down instead of degrading itself. The gate is real now
+    // (`HarnessAgentRegistry.require`), and even so this stays recoverable:
+    // a binary that is renamed, uninstalled or on an unmounted network share
+    // between the check and the call is an environment fault, and both callers
+    // already carry `ClaudeSdkError`.
+    const executable = yield* Effect.cached(
       resolveClaudeExecutable({ env }).pipe(
-        Effect.catchTag("ClaudeExecutableNotFound", (cause) =>
-          Effect.die(
-            new Error(
-              "invariant: the claude executable vanished after the availability check gated on it",
-              { cause },
-            ),
-          ),
-        ),
         Effect.provideService(FileSystem.FileSystem, fileSystem),
       ),
+    );
+    // The same cached answer, wearing the error type this file's two callers
+    // already carry — not a second resolve.
+    const claudeExecutable = Effect.mapError(executable, (cause) =>
+      sdkError("resolve-executable", cause),
     );
     const sessions = yield* Ref.make(new Map<string, SessionState>());
     const resumes = yield* Ref.make(
@@ -751,5 +765,6 @@ export const makeClaudeCodeAgent = ({
             yield* closeSession(session);
           }),
       },
+      executable,
     } satisfies ClaudeCodeAgent;
   });

--- a/packages/server/src/harness/claude-code/agent.ts
+++ b/packages/server/src/harness/claude-code/agent.ts
@@ -77,7 +77,7 @@ export interface ClaudeCodeAgent {
   /**
    * The absolute path this agent hands the SDK, resolved once and cached.
    *
-   * Exposed so the adapter's `checkAvailability` answers off the *same* resolve
+   * Exposed so the adapter's `availability` answers off the *same* resolve
    * the SDK launches — see the note in `harness/executable.ts` on why one
    * search, not two, is the invariant here.
    */

--- a/packages/server/src/harness/claude-code/agent.ts
+++ b/packages/server/src/harness/claude-code/agent.ts
@@ -85,7 +85,8 @@ export interface ClaudeCodeAgent {
   /**
    * The models a session started in `cwd` could run, read without opening a
    * session. The catalog follows the user's account and the resolved CLI, so
-   * it can only be probed — never hardcoded. The directory is not incidental:
+   * it can only be read from the CLI — never hardcoded. The directory is not
+   * incidental:
    * a project's `.claude/settings.json` can remap what an id resolves to, so
    * the same `sonnet` is a different model in two projects.
    */
@@ -544,10 +545,10 @@ export const makeClaudeCodeAgent = ({
     // `settingSources` it is what makes the answer specific to the project the
     // user is about to work in: a project that sets
     // `env.ANTHROPIC_DEFAULT_SONNET_MODEL` (or runs through Bedrock/Vertex)
-    // keeps the same ids but changes what they resolve to, so a catalog probed
+    // keeps the same ids but changes what they resolve to, so a catalog read
     // in some other directory is a catalog for someone else's project.
     //
-    // Two things *are* stripped, because a probe should cost as little as a
+    // Two things *are* stripped, because a question should cost as little as a
     // question. Medians of five runs on a developer machine:
     //
     //   4.3s  a session's own options
@@ -586,14 +587,14 @@ export const makeClaudeCodeAgent = ({
             catch: (cause) => sdkError("list-models", cause),
           }),
         ),
-        (probe) =>
+        (session) =>
           Effect.tryPromise({
-            try: () => probe.supportedModels(),
+            try: () => session.supportedModels(),
             catch: (cause) => sdkError("list-models", cause),
           }),
-        // Returning the generator is what tears the child process down; a probe
+        // Returning the generator is what tears the child process down; a read
         // that leaked one per call would be a process leak per directory.
-        (probe) => Effect.promise(() => probe.return()).pipe(Effect.ignore),
+        (session) => Effect.promise(() => session.return()).pipe(Effect.ignore),
       );
 
     return {

--- a/packages/server/src/harness/claude-code/executable.ts
+++ b/packages/server/src/harness/claude-code/executable.ts
@@ -1,44 +1,40 @@
 import childProcess from "node:child_process";
 import module from "node:module";
-import os from "node:os";
 import path from "node:path";
 import util from "node:util";
 
-import { Data, Effect, FileSystem } from "effect";
+import { Effect, FileSystem } from "effect";
 
-import { isExecutableFile, pathDelimiter } from "../executable";
+import type { ExecutableNotFound } from "../errors";
+import {
+  type HarnessExecutableSpec,
+  type ResolveExecutableDeps,
+  resolveHarnessExecutable,
+} from "../executable";
 
 const moduleRequire = module.createRequire(import.meta.url);
 const execFileAsync = util.promisify(childProcess.execFile);
-
-/** No `claude` binary anywhere we look — carries the user-facing remedy. */
-export class ClaudeExecutableNotFound extends Data.TaggedError("ClaudeExecutableNotFound")<{
-  readonly reason: string;
-}> {
-  override get message() {
-    return this.reason;
-  }
-}
 
 const NOT_FOUND =
   "Claude Code was not found. Install it from https://claude.com/claude-code, " +
   "or set VIBEST_CLAUDE_EXECUTABLE to the path of the `claude` binary.";
 
-/** Where the native installer and the common package managers put `claude`. */
-function extraInstallDirs(home: string): string[] {
-  return [
-    path.join(home, ".local", "bin"),
-    path.join(home, ".bun", "bin"),
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
-  ];
-}
-
 /**
  * The version-matched binary the Claude Agent SDK ships as an optional platform
- * dependency. Present when running from a checkout; absent in the packaged
- * desktop app, which excludes it (it is ~230 MB — the user's own Claude Code
- * install is used there instead).
+ * dependency. Its version is pinned to the SDK's wire protocol, so it is
+ * preferred over the user's own install whenever it is really on disk — absent
+ * in the packaged desktop app, which excludes it (~230 MB) and uses the user's
+ * install instead.
+ *
+ * Resolved in two hops, and that is the whole trick: the platform package is an
+ * optionalDependency *of the SDK*, so under pnpm's strict layout it is not
+ * visible from this module at all — a direct
+ * `require.resolve("@anthropic-ai/claude-agent-sdk-linux-x64/claude")` throws
+ * MODULE_NOT_FOUND in every pnpm checkout, which is exactly what it did, so
+ * this level never once fired and every install silently fell through to PATH.
+ * Resolving the SDK's own entry first (that hop always succeeds — it is a
+ * direct dependency) and asking *from there* puts the platform package back in
+ * view.
  *
  * `module.createRequire` has no Effect equivalent, so module resolution stays raw.
  *
@@ -49,62 +45,44 @@ function extraInstallDirs(home: string): string[] {
 function sdkBinary(binary: string): string | undefined {
   const pkg = `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`;
   try {
-    const resolved = moduleRequire.resolve(`${pkg}/${binary}`);
+    const sdkEntry = moduleRequire.resolve("@anthropic-ai/claude-agent-sdk");
+    const resolved = module.createRequire(sdkEntry).resolve(`${pkg}/${binary}`);
     return resolved.includes(`.asar${path.sep}`) ? undefined : resolved;
   } catch {
     return undefined;
   }
 }
 
-export type ResolveDeps = {
-  env?: NodeJS.ProcessEnv;
-  home?: string;
-  /** The SDK's own bundled binary, if it is really on disk. */
-  bundled?: (binary: string) => string | undefined;
-  platform?: NodeJS.Platform;
+/**
+ * `VIBEST_E2E_CLAUDE_EXECUTABLE` is gated on `VIBEST_E2E` so a test fixture can
+ * never be picked up by a real install that happens to have the variable set.
+ */
+export const claudeExecutableSpec: HarnessExecutableSpec = {
+  harnessAgentId: "claude-code",
+  binaryName: "claude",
+  override: (env) =>
+    env["VIBEST_E2E"] === "1"
+      ? env["VIBEST_E2E_CLAUDE_EXECUTABLE"]
+      : env["VIBEST_CLAUDE_EXECUTABLE"],
+  bundled: sdkBinary,
+  notFoundReason: NOT_FOUND,
 };
 
-/**
- * The `claude` binary the SDK should exec.
- *
- * Prefers the SDK's own copy when it is really on disk, because its version is
- * matched to the SDK's wire protocol. Falls back to the user's install — the
- * only option in the packaged app, which is why the desktop host has to hand
- * the server a login-shell PATH: launchd gives a GUI app a bare one.
- */
+export type ResolveDeps = ResolveExecutableDeps & {
+  /** The SDK's own bundled binary, if it is really on disk. Injectable for tests. */
+  bundled?: (binary: string) => string | undefined;
+};
+
+/** The `claude` binary the SDK should exec. */
 export const resolveClaudeExecutable = (
   deps: ResolveDeps = {},
-): Effect.Effect<string, ClaudeExecutableNotFound, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const {
-      env = process.env,
-      home = os.homedir(),
-      bundled = sdkBinary,
-      platform = process.platform,
-    } = deps;
-    const fs = yield* FileSystem.FileSystem;
-    const isExecutable = (candidate: string) => isExecutableFile(fs, candidate, platform);
-
-    const override =
-      env["VIBEST_E2E"] === "1"
-        ? env["VIBEST_E2E_CLAUDE_EXECUTABLE"]
-        : env["VIBEST_CLAUDE_EXECUTABLE"];
-    if (override) return override;
-
-    const binary = platform === "win32" ? "claude.exe" : "claude";
-
-    const fromSdk = bundled(binary);
-    if (fromSdk && (yield* isExecutable(fromSdk))) return fromSdk;
-
-    const dirs = [...(env["PATH"] ?? "").split(pathDelimiter(platform)), ...extraInstallDirs(home)];
-    for (const dir of dirs) {
-      if (!dir) continue;
-      const candidate = path.join(dir, binary);
-      if (yield* isExecutable(candidate)) return candidate;
-    }
-
-    return yield* Effect.fail(new ClaudeExecutableNotFound({ reason: NOT_FOUND }));
-  });
+): Effect.Effect<string, ExecutableNotFound, FileSystem.FileSystem> => {
+  const { bundled, ...rest } = deps;
+  return resolveHarnessExecutable(
+    bundled ? { ...claudeExecutableSpec, bundled } : claudeExecutableSpec,
+    rest,
+  );
+};
 
 /**
  * The CLI version vibest is built against: the version the Agent SDK bundles,
@@ -161,6 +139,12 @@ export type AvailabilityDeps = ResolveDeps & {
   readVersion?: (executable: string) => Promise<string>;
   /** The version floor; injectable for tests. */
   requiredVersion?: () => Effect.Effect<string, Error, FileSystem.FileSystem>;
+  /**
+   * The resolve to check, so availability and the spawn can be the *same*
+   * answer rather than two walks that may disagree. Defaults to resolving on
+   * the spot, which is what tests and any standalone caller want.
+   */
+  resolve?: Effect.Effect<string, ExecutableNotFound, FileSystem.FileSystem>;
 };
 
 /**
@@ -168,12 +152,15 @@ export type AvailabilityDeps = ResolveDeps & {
  * CLI: a missing binary reports the resolve error, but an unreadable or
  * unparseable `--version` fails OPEN (available) rather than blocking on a
  * version we could not establish — the SDK will surface any real launch fault.
+ *
+ * The version floor is what stays claude-code's own: finding the binary is the
+ * shared walk, verifying it is new enough to speak the SDK's protocol is not.
  */
 export const checkClaudeAvailability = (
   deps: AvailabilityDeps = {},
 ): Effect.Effect<AvailabilityResult, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const executable = yield* resolveClaudeExecutable(deps).pipe(
+    const executable = yield* (deps.resolve ?? resolveClaudeExecutable(deps)).pipe(
       Effect.map((resolved) => ({ ok: true as const, path: resolved })),
       Effect.catch((cause) => Effect.succeed({ ok: false as const, reason: cause.message })),
     );

--- a/packages/server/src/harness/claude-code/executable.ts
+++ b/packages/server/src/harness/claude-code/executable.ts
@@ -108,7 +108,7 @@ export const requiredClaudeVersion = (): Effect.Effect<string, Error, FileSystem
  * Runs `<executable> --version`; returns its raw stdout (e.g. "2.1.216 (Claude Code)").
  *
  * Still `node:child_process`: `ChildProcessSpawner` supervises its children
- * through a `Scope`, and threading one into `checkAvailability` would push
+ * through a `Scope`, and threading one into `availability` would push
  * `Scope` onto every harness adapter's availability check for a single
  * short-lived capture. Left as a follow-up rather than widened here.
  */
@@ -156,7 +156,7 @@ export type AvailabilityDeps = ResolveDeps & {
  * The version floor is what stays claude-code's own: finding the binary is the
  * shared walk, verifying it is new enough to speak the SDK's protocol is not.
  */
-export const checkClaudeAvailability = (
+export const claudeAvailability = (
   deps: AvailabilityDeps = {},
 ): Effect.Effect<AvailabilityResult, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {

--- a/packages/server/src/harness/claude-code/executable.ts
+++ b/packages/server/src/harness/claude-code/executable.ts
@@ -5,11 +5,12 @@ import util from "node:util";
 
 import { Effect, FileSystem } from "effect";
 
-import type { ExecutableNotFound } from "../errors";
+import { ExecutableNotFound } from "../errors";
 import {
-  type HarnessExecutableSpec,
+  candidateNames,
+  executableAt,
+  searchInstallDirs,
   type ResolveExecutableDeps,
-  resolveHarnessExecutable,
 } from "../executable";
 
 const moduleRequire = module.createRequire(import.meta.url);
@@ -53,36 +54,52 @@ function sdkBinary(binary: string): string | undefined {
   }
 }
 
-/**
- * `VIBEST_E2E_CLAUDE_EXECUTABLE` is gated on `VIBEST_E2E` so a test fixture can
- * never be picked up by a real install that happens to have the variable set.
- */
-export const claudeExecutableSpec: HarnessExecutableSpec = {
-  harnessAgentId: "claude-code",
-  binaryName: "claude",
-  override: (env) =>
-    env["VIBEST_E2E"] === "1"
-      ? env["VIBEST_E2E_CLAUDE_EXECUTABLE"]
-      : env["VIBEST_CLAUDE_EXECUTABLE"],
-  bundled: sdkBinary,
-  notFoundReason: NOT_FOUND,
-};
-
 export type ResolveDeps = ResolveExecutableDeps & {
   /** The SDK's own bundled binary, if it is really on disk. Injectable for tests. */
   bundled?: (binary: string) => string | undefined;
 };
 
-/** The `claude` binary the SDK should exec. */
+/**
+ * The `claude` binary the SDK should exec.
+ *
+ * The order is claude-code's own: an explicit override wins unverified (naming
+ * a path is the user saying "this one" — reporting it missing is more confusing
+ * than letting the SDK fail on it), then the SDK's version-matched copy,
+ * then whatever the machine has installed.
+ *
+ * `VIBEST_E2E_CLAUDE_EXECUTABLE` is gated on `VIBEST_E2E` so a test fixture can
+ * never be picked up by a real install that happens to have the variable set.
+ */
 export const resolveClaudeExecutable = (
   deps: ResolveDeps = {},
-): Effect.Effect<string, ExecutableNotFound, FileSystem.FileSystem> => {
-  const { bundled, ...rest } = deps;
-  return resolveHarnessExecutable(
-    bundled ? { ...claudeExecutableSpec, bundled } : claudeExecutableSpec,
-    rest,
-  );
-};
+): Effect.Effect<string, ExecutableNotFound, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const env = deps.env ?? process.env;
+
+    const override =
+      env["VIBEST_E2E"] === "1"
+        ? env["VIBEST_E2E_CLAUDE_EXECUTABLE"]
+        : env["VIBEST_CLAUDE_EXECUTABLE"];
+    if (override) return override;
+
+    for (const name of candidateNames("claude", deps.platform ?? process.platform)) {
+      const bundled = (deps.bundled ?? sdkBinary)(name);
+      if (!bundled) continue;
+      const verified = yield* executableAt(bundled, deps);
+      if (verified) return verified;
+    }
+
+    const installed = yield* searchInstallDirs("claude", deps);
+    if (installed) return installed;
+
+    return yield* Effect.fail(
+      new ExecutableNotFound({
+        harnessAgentId: "claude-code",
+        executable: "claude",
+        reason: NOT_FOUND,
+      }),
+    );
+  });
 
 /**
  * The CLI version vibest is built against: the version the Agent SDK bundles,

--- a/packages/server/src/harness/codex/adapter.ts
+++ b/packages/server/src/harness/codex/adapter.ts
@@ -6,6 +6,7 @@ import { Effect, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 
 import {
+  type AvailabilityResult,
   type HarnessAgentAdapter,
   type HarnessAgentRuntime,
   type SessionInfoResult,
@@ -22,7 +23,6 @@ import {
   TurnAlreadyRunning,
 } from "../errors";
 import type { SessionEnvelopeDraft, SessionEvent } from "../events/framework";
-import { findExecutable } from "../executable";
 import { streamFromQueueOne } from "../queue-stream";
 import type { CodexAgent } from "./agent";
 import { turnsToUIMessages } from "./history";
@@ -325,10 +325,7 @@ const makeRuntime = (
     } satisfies HarnessAgentRuntime;
   });
 
-export const makeCodexAdapter = (
-  agent: CodexAgent,
-  options: { readonly executablePath?: string } = {},
-): HarnessAgentAdapter => ({
+export const makeCodexAdapter = (agent: CodexAgent): HarnessAgentAdapter => ({
   id: "codex",
   descriptor: { id: "codex", name: "Codex" },
   permissionModes: CODEX_PERMISSION_MODE_IDS,
@@ -349,11 +346,18 @@ export const makeCodexAdapter = (
       Effect.map((models) => models.map(toModelInfo)),
       Effect.mapError((cause) => new CapabilityProbeFailed({ harnessAgentId: "codex", cause })),
     ),
-  // A PATH lookup, not a spawn: negotiate has to stay cheap on machines where
+  // A filesystem walk, not a spawn: this has to stay cheap on machines where
   // codex simply isn't installed, which is the common case.
-  checkAvailability: findExecutable(options.executablePath ?? "codex").pipe(
-    Effect.map((found) =>
-      found ? { available: true } : { available: false, reason: "Codex was not found on PATH." },
+  //
+  // Answered off the agent's own cached resolve, so "available" and "what the
+  // transport spawns" cannot disagree — the reason this is not a second lookup
+  // is in `harness/executable.ts`.
+  // `suspend`, because building an adapter must stay a pure declaration that
+  // never touches its agent (`adapter-capabilities.test.ts` locks this).
+  checkAvailability: Effect.suspend(() => agent.executable).pipe(
+    Effect.as({ available: true } as AvailabilityResult),
+    Effect.catch((cause) =>
+      Effect.succeed({ available: false, reason: cause.message } as AvailabilityResult),
     ),
   ),
   open: (input) =>

--- a/packages/server/src/harness/codex/adapter.ts
+++ b/packages/server/src/harness/codex/adapter.ts
@@ -354,7 +354,7 @@ export const makeCodexAdapter = (agent: CodexAgent): HarnessAgentAdapter => ({
   // is in `harness/executable.ts`.
   // `suspend`, because building an adapter must stay a pure declaration that
   // never touches its agent (`adapter-capabilities.test.ts` locks this).
-  checkAvailability: Effect.suspend(() => agent.executable).pipe(
+  availability: Effect.suspend(() => agent.executable).pipe(
     Effect.as({ available: true } as AvailabilityResult),
     Effect.catch((cause) =>
       Effect.succeed({ available: false, reason: cause.message } as AvailabilityResult),

--- a/packages/server/src/harness/codex/adapter.ts
+++ b/packages/server/src/harness/codex/adapter.ts
@@ -16,7 +16,7 @@ import {
   AgentOpenError,
   AgentOperationError,
   AgentRequestUnavailable,
-  CapabilityProbeFailed,
+  ModelListFailed,
   CodexRpcError,
   SessionClosed,
   SessionNotResumable,
@@ -337,14 +337,14 @@ export const makeCodexAdapter = (agent: CodexAgent): HarnessAgentAdapter => ({
   // it answers for the whole app-server. Taking the argument anyway keeps the
   // seam uniform, so callers never branch on which harness cares, and the day
   // codex grows per-project config this is a one-line change here.
-  probeModels: (_cwd) =>
+  listModels: (_cwd) =>
     agent.listModels.pipe(
       // The catalog's `isDefault` flag is deliberately not forwarded: it is
       // the API's suggestion, while an unconfigured session actually runs
-      // whatever the user's own config.toml says — which is not probeable.
+      // whatever the user's own config.toml says — which we cannot ask for.
       // The default is expressed by absence, not by a marker.
       Effect.map((models) => models.map(toModelInfo)),
-      Effect.mapError((cause) => new CapabilityProbeFailed({ harnessAgentId: "codex", cause })),
+      Effect.mapError((cause) => new ModelListFailed({ harnessAgentId: "codex", cause })),
     ),
   // A filesystem walk, not a spawn: this has to stay cheap on machines where
   // codex simply isn't installed, which is the common case.

--- a/packages/server/src/harness/codex/agent.ts
+++ b/packages/server/src/harness/codex/agent.ts
@@ -13,7 +13,7 @@ import type {
   TurnSteerResponse,
   UserInput,
 } from "@vibest/contract/codex/protocol/v2";
-import { Deferred, Effect, Queue, Ref, Scope, Stream } from "effect";
+import { Deferred, Effect, FileSystem, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 import type * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
@@ -21,10 +21,13 @@ import {
   AgentOperationError,
   AgentRequestUnavailable,
   CodexTransportError,
+  type ExecutableNotFound,
   HarnessSessionNotFound,
   TurnAlreadyRunning,
 } from "../errors";
+import { resolveHarnessExecutable } from "../executable";
 import { drainQueue, streamFromQueueOne } from "../queue-stream";
+import { codexExecutableSpec } from "./executable";
 import {
   approvalSourceOf,
   buildApprovalRequest,
@@ -120,6 +123,15 @@ export interface CodexAgentDependencies<R> {
 
 export interface CodexAgent {
   /**
+   * The absolute path this agent will spawn, resolved once and cached.
+   *
+   * Exposed so the adapter's `checkAvailability` can answer off the *same*
+   * resolve the transport launches, rather than performing a second, differently
+   * scoped search. Two searches were what let "available" and "what actually
+   * runs" disagree — see the note in `harness/executable.ts`.
+   */
+  readonly executable: Effect.Effect<string, ExecutableNotFound>;
+  /**
    * The model catalog for the signed-in account, read straight from the
    * app-server. Follows the account and the installed codex version, so it can
    * only be probed — never hardcoded.
@@ -177,7 +189,7 @@ export interface CodexAgent {
 /** @internal */
 export const makeCodexAgentWithDependencies = <R>(
   dependencies: CodexAgentDependencies<R>,
-): Effect.Effect<CodexAgent, never, R | Scope.Scope> =>
+): Effect.Effect<Omit<CodexAgent, "executable">, never, R | Scope.Scope> =>
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
     const sessions = yield* Ref.make(new Map<string, SessionState>());
@@ -834,10 +846,42 @@ export const makeCodexAgentWithDependencies = <R>(
         interrupt,
         abort,
       },
-    } satisfies CodexAgent;
+    } satisfies Omit<CodexAgent, "executable">;
   });
 
+/**
+ * An explicit `executablePath` wins outright (tests point it at a fake binary);
+ * otherwise the shared four-level search answers, once, for both the transport
+ * and the adapter's availability check.
+ */
 export const makeCodexAgent = (
   options: CodexAgentOptions = {},
-): Effect.Effect<CodexAgent, never, ChildProcessSpawner.ChildProcessSpawner | Scope.Scope> =>
-  makeCodexAgentWithDependencies({ makeTransport: () => makeCodexTransport(options) });
+): Effect.Effect<
+  CodexAgent,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner | Scope.Scope | FileSystem.FileSystem
+> =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const executable = options.executablePath
+      ? Effect.succeed(options.executablePath)
+      : yield* Effect.cached(
+          resolveHarnessExecutable(codexExecutableSpec).pipe(
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+          ),
+        );
+    const agent = yield* makeCodexAgentWithDependencies({
+      makeTransport: () =>
+        Effect.flatMap(
+          // The resolve failure reaches the caller as a spawn failure, which is
+          // what it is: the launch could not happen. Keeps the transport's
+          // error channel unchanged.
+          Effect.mapError(
+            executable,
+            (cause) => new CodexTransportError({ operation: "spawn", cause }),
+          ),
+          (executablePath) => makeCodexTransport({ ...options, executablePath }),
+        ),
+    });
+    return { ...agent, executable };
+  });

--- a/packages/server/src/harness/codex/agent.ts
+++ b/packages/server/src/harness/codex/agent.ts
@@ -125,7 +125,7 @@ export interface CodexAgent {
   /**
    * The absolute path this agent will spawn, resolved once and cached.
    *
-   * Exposed so the adapter's `checkAvailability` can answer off the *same*
+   * Exposed so the adapter's `availability` can answer off the *same*
    * resolve the transport launches, rather than performing a second, differently
    * scoped search. Two searches were what let "available" and "what actually
    * runs" disagree — see the note in `harness/executable.ts`.

--- a/packages/server/src/harness/codex/agent.ts
+++ b/packages/server/src/harness/codex/agent.ts
@@ -133,7 +133,7 @@ export interface CodexAgent {
   /**
    * The model catalog for the signed-in account, read straight from the
    * app-server. Follows the account and the installed codex version, so it can
-   * only be probed — never hardcoded.
+   * only be read from the app-server — never hardcoded.
    */
   readonly listModels: Effect.Effect<ReadonlyArray<Model>, CodexTransportFailure>;
   readonly session: {

--- a/packages/server/src/harness/codex/agent.ts
+++ b/packages/server/src/harness/codex/agent.ts
@@ -25,9 +25,8 @@ import {
   HarnessSessionNotFound,
   TurnAlreadyRunning,
 } from "../errors";
-import { resolveHarnessExecutable } from "../executable";
 import { drainQueue, streamFromQueueOne } from "../queue-stream";
-import { codexExecutableSpec } from "./executable";
+import { resolveCodexExecutable } from "./executable";
 import {
   approvalSourceOf,
   buildApprovalRequest,
@@ -866,9 +865,7 @@ export const makeCodexAgent = (
     const executable = options.executablePath
       ? Effect.succeed(options.executablePath)
       : yield* Effect.cached(
-          resolveHarnessExecutable(codexExecutableSpec).pipe(
-            Effect.provideService(FileSystem.FileSystem, fileSystem),
-          ),
+          resolveCodexExecutable().pipe(Effect.provideService(FileSystem.FileSystem, fileSystem)),
         );
     const agent = yield* makeCodexAgentWithDependencies({
       makeTransport: () =>

--- a/packages/server/src/harness/codex/executable.ts
+++ b/packages/server/src/harness/codex/executable.ts
@@ -1,0 +1,20 @@
+import type { HarnessExecutableSpec } from "../executable";
+
+/**
+ * Codex is the one harness vibest does not ship a copy of, so it has no
+ * bundled level — the user's own install is the only candidate, found on PATH
+ * or in one of the shared fallback directories.
+ *
+ * That fallback level is not incidental here: the common way to install codex
+ * is `bun install -g @openai/codex`, which lands it in `~/.bun/bin` — a
+ * directory present in an interactive shell's PATH and absent from a systemd
+ * unit's.
+ */
+export const codexExecutableSpec: HarnessExecutableSpec = {
+  harnessAgentId: "codex",
+  binaryName: "codex",
+  override: (env) => env["VIBEST_CODEX_EXECUTABLE"],
+  notFoundReason:
+    "Codex was not found. Install it from https://github.com/openai/codex, " +
+    "or set VIBEST_CODEX_EXECUTABLE to the path of the `codex` binary.",
+};

--- a/packages/server/src/harness/codex/executable.ts
+++ b/packages/server/src/harness/codex/executable.ts
@@ -1,20 +1,39 @@
-import type { HarnessExecutableSpec } from "../executable";
+import { Effect, type FileSystem } from "effect";
+
+import { ExecutableNotFound } from "../errors";
+import { searchInstallDirs, type ResolveExecutableDeps } from "../executable";
+
+const NOT_FOUND =
+  "Codex was not found. Install it from https://github.com/openai/codex, " +
+  "or set VIBEST_CODEX_EXECUTABLE to the path of the `codex` binary.";
 
 /**
- * Codex is the one harness vibest does not ship a copy of, so it has no
- * bundled level — the user's own install is the only candidate, found on PATH
- * or in one of the shared fallback directories.
+ * The `codex` binary to spawn.
  *
- * That fallback level is not incidental here: the common way to install codex
- * is `bun install -g @openai/codex`, which lands it in `~/.bun/bin` — a
- * directory present in an interactive shell's PATH and absent from a systemd
- * unit's.
+ * Codex is the one harness vibest does not ship a copy of, so its order is the
+ * shortest of the three: an explicit override, else the user's own install.
+ * An override wins unverified — naming a path is the user saying "this one".
+ *
+ * The fallback directories the search walks after PATH are not incidental
+ * here: the common way to install codex is `bun install -g @openai/codex`,
+ * which lands it in `~/.bun/bin` — a directory present in an interactive
+ * shell's PATH and absent from a systemd unit's.
  */
-export const codexExecutableSpec: HarnessExecutableSpec = {
-  harnessAgentId: "codex",
-  binaryName: "codex",
-  override: (env) => env["VIBEST_CODEX_EXECUTABLE"],
-  notFoundReason:
-    "Codex was not found. Install it from https://github.com/openai/codex, " +
-    "or set VIBEST_CODEX_EXECUTABLE to the path of the `codex` binary.",
-};
+export const resolveCodexExecutable = (
+  deps: ResolveExecutableDeps = {},
+): Effect.Effect<string, ExecutableNotFound, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const override = (deps.env ?? process.env)["VIBEST_CODEX_EXECUTABLE"];
+    if (override) return override;
+
+    const installed = yield* searchInstallDirs("codex", deps);
+    if (installed) return installed;
+
+    return yield* Effect.fail(
+      new ExecutableNotFound({
+        harnessAgentId: "codex",
+        executable: "codex",
+        reason: NOT_FOUND,
+      }),
+    );
+  });

--- a/packages/server/src/harness/errors.ts
+++ b/packages/server/src/harness/errors.ts
@@ -40,10 +40,19 @@ export class ExecutableNotFound extends Schema.TaggedErrorClass<ExecutableNotFou
   {
     harnessAgentId: HarnessAgentIdSchema,
     executable: Schema.String,
+    /**
+     * The harness's own remedy sentence (how to install it, which env var
+     * overrides it). Carried on the error rather than composed at each
+     * display site so the log line, the RPC message and the greyed-out
+     * harness's tooltip are all the same words.
+     */
+    reason: Schema.optionalKey(Schema.String),
   },
 ) {
   override get message() {
-    return `Executable '${this.executable}' for '${this.harnessAgentId}' was not found.`;
+    return (
+      this.reason ?? `Executable '${this.executable}' for '${this.harnessAgentId}' was not found.`
+    );
   }
 }
 

--- a/packages/server/src/harness/errors.ts
+++ b/packages/server/src/harness/errors.ts
@@ -237,15 +237,12 @@ export class PermissionModeUnsupported extends Schema.TaggedErrorClass<Permissio
   }
 }
 
-export class CapabilityProbeFailed extends Schema.TaggedErrorClass<CapabilityProbeFailed>()(
-  "CapabilityProbeFailed",
-  {
-    harnessAgentId: HarnessAgentIdSchema,
-    cause: Schema.Defect(),
-  },
-) {
+export class ModelListFailed extends Schema.TaggedErrorClass<ModelListFailed>()("ModelListFailed", {
+  harnessAgentId: HarnessAgentIdSchema,
+  cause: Schema.Defect(),
+}) {
   override get message() {
-    return `Failed to probe '${this.harnessAgentId}' capabilities: ${causeSummary(this.cause)}`;
+    return `Failed to read '${this.harnessAgentId}' models: ${causeSummary(this.cause)}`;
   }
 }
 

--- a/packages/server/src/harness/executable.ts
+++ b/packages/server/src/harness/executable.ts
@@ -1,24 +1,34 @@
+import os from "node:os";
 import path from "node:path";
 
+import type { HarnessAgentId } from "@vibest/contract";
 import { Effect, FileSystem } from "effect";
 
+import { ExecutableNotFound } from "./errors";
+
 /**
- * Locating the CLI a harness spawns. Claude Code has its own resolver (it
- * prefers the version-matched binary the SDK ships); the harnesses that just
- * exec a bare command off PATH — codex, pi — share this one.
+ * Locating the CLI a harness runs — one search, shared by all three.
  *
- * It exists for availability: `negotiate` has to answer "is this harness usable
- * right now" before it spends anything probing capabilities, and a missing
- * binary is the common case on a machine where the user only installed one
- * agent. A PATH lookup answers that cheaply; spawning to find out would make
- * the app's first paint wait on a process that was never going to start.
+ * It used to search PATH and nothing else, deliberately: the transports
+ * spawned a bare command name (`spawn("codex")`), the OS resolved that through
+ * PATH alone, so anything found elsewhere would have reported a harness
+ * available that then failed with an opaque ENOENT. That constraint is gone,
+ * and removing it is the point of this module: {@link resolveHarnessExecutable}
+ * returns an absolute path and **that path is what gets spawned**. The search
+ * and the launch can no longer disagree, because they are the same answer.
  *
- * It searches PATH and nothing else, deliberately. The transports spawn the
- * bare command name (`spawn("codex")`), which the OS resolves through PATH
- * alone — so any directory this looked in beyond PATH would make it report a
- * harness available that then fails to spawn, turning an actionable "not found
- * on PATH" into an opaque ENOENT at session-create time. Whatever fixes PATH
- * for the spawn (the desktop's login-shell environment) fixes it for both.
+ * Which makes the invariant to protect: *never widen this search without the
+ * result reaching spawn.* A caller that resolves here and then execs a bare
+ * name has reintroduced the exact bug this replaced — the harness reports
+ * available off one set of rules and launches off another.
+ *
+ * The old shape cost real users: a `codex` installed by bun (`~/.bun/bin`, not
+ * on a systemd unit's PATH) read as "not installed", while claude-code — whose
+ * resolver already searched past PATH *because* its result was passed to the
+ * SDK — found its own binary in that very directory.
+ *
+ * Four levels, first hit wins. What differs per harness is declared in a
+ * {@link HarnessExecutableSpec}; the walk itself never varies.
  */
 
 /**
@@ -31,9 +41,53 @@ const WINDOWS_EXTENSIONS = [".com", ".exe", ".bat", ".cmd"];
 /** PATH's separator — `node:path.delimiter` is fixed to the host platform. */
 export const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32" ? ";" : ":");
 
-export type FindExecutableDeps = {
+/**
+ * Where the native installers and common package managers put a CLI. Searched
+ * after PATH, so a PATH entry always wins; this level exists for the process
+ * whose PATH is not a login shell's — a systemd unit, a launchd GUI app, a
+ * non-interactive `ssh host "…"` — which is the normal case for a server
+ * deployment and the one where every one of these directories is missing.
+ */
+function fallbackInstallDirs(home: string): ReadonlyArray<string> {
+  return [
+    path.join(home, ".local", "bin"),
+    path.join(home, ".bun", "bin"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+  ];
+}
+
+/**
+ * What one harness declares about finding its CLI. Everything here is a
+ * difference that is real between harnesses; anything the same for all three
+ * belongs in {@link resolveHarnessExecutable} instead.
+ */
+export type HarnessExecutableSpec = {
+  readonly harnessAgentId: HarnessAgentId;
+  /** Bare name, no extension — Windows variants are derived by the resolver. */
+  readonly binaryName: string;
+  /**
+   * An operator's explicit answer, read straight from the environment. A
+   * function rather than a variable name because claude-code has a second,
+   * test-only variable gated on `VIBEST_E2E`.
+   */
+  readonly override: (env: NodeJS.ProcessEnv) => string | undefined;
+  /**
+   * The copy that ships as one of vibest's own dependencies, resolved through
+   * the module graph. Absent for a harness vibest does not bundle (codex).
+   * Best-effort by contract: a miss falls through to PATH rather than failing,
+   * because the same code runs from a source checkout and from a bundle whose
+   * module graph does not contain the harness.
+   */
+  readonly bundled?: (binary: string) => string | undefined;
+  /** Human-facing sentence for `checkAvailability`, naming how to fix it. */
+  readonly notFoundReason: string;
+};
+
+export type ResolveExecutableDeps = {
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
+  home?: string;
 };
 
 /**
@@ -58,37 +112,62 @@ export const isExecutableFile = (
     Effect.catch(() => Effect.succeed(false)),
   );
 
+/** The names a bare command can take on this platform. */
+const candidateNames = (binaryName: string, platform: NodeJS.Platform): ReadonlyArray<string> =>
+  platform !== "win32" || path.extname(binaryName)
+    ? [binaryName]
+    : WINDOWS_EXTENSIONS.map((extension) => `${binaryName}${extension}`);
+
 /**
- * The path a bare command name resolves to, or `undefined` when it is not
- * installed. An absolute `command` is taken as an explicit override and only
- * checked for executability.
+ * The absolute path to a harness's CLI, or {@link ExecutableNotFound}.
+ *
+ * The result is what the transport spawns — see the module note above; that is
+ * the whole reason levels 2 and 4 are allowed to exist.
  */
-export const findExecutable = (
-  command: string,
-  deps: FindExecutableDeps = {},
-): Effect.Effect<string | undefined, never, FileSystem.FileSystem> =>
+export const resolveHarnessExecutable = (
+  spec: HarnessExecutableSpec,
+  deps: ResolveExecutableDeps = {},
+): Effect.Effect<string, ExecutableNotFound, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const { env = process.env, platform = process.platform } = deps;
+    const { env = process.env, platform = process.platform, home = os.homedir() } = deps;
     const fs = yield* FileSystem.FileSystem;
     const isExecutable = (candidate: string) => isExecutableFile(fs, candidate, platform);
 
-    if (path.isAbsolute(command)) {
-      return (yield* isExecutable(command)) ? command : undefined;
+    // 1. An explicit override is taken at face value, unverified. Falling back
+    //    when it does not exist would be worse than failing: the operator
+    //    would be told the harness works while it silently runs a different
+    //    binary than the one they named.
+    const override = spec.override(env);
+    if (override) return override;
+
+    const names = candidateNames(spec.binaryName, platform);
+
+    // 2. vibest's own copy, when it has one.
+    for (const name of names) {
+      const bundled = spec.bundled?.(name);
+      if (bundled && (yield* isExecutable(bundled))) return bundled;
     }
 
-    const names =
-      platform !== "win32" || path.extname(command)
-        ? [command]
-        : WINDOWS_EXTENSIONS.map((extension) => `${command}${extension}`);
-
-    // First hit wins, and PATH order is the answer — so this walks candidates
-    // sequentially and stops, rather than stat'ing the whole search space.
-    for (const dir of (env["PATH"] ?? "").split(pathDelimiter(platform))) {
-      if (!dir) continue;
+    // 3 and 4. PATH first, then the install directories a stripped environment
+    //    would have dropped. One walk, so PATH order is honoured and a PATH hit
+    //    always beats a fallback.
+    const directories = [
+      ...(env["PATH"] ?? "").split(pathDelimiter(platform)),
+      ...fallbackInstallDirs(home),
+    ];
+    for (const directory of directories) {
+      if (!directory) continue;
       for (const name of names) {
-        const candidate = path.join(dir, name);
+        const candidate = path.join(directory, name);
         if (yield* isExecutable(candidate)) return candidate;
       }
     }
-    return undefined;
+
+    return yield* Effect.fail(
+      new ExecutableNotFound({
+        harnessAgentId: spec.harnessAgentId,
+        executable: spec.binaryName,
+        reason: spec.notFoundReason,
+      }),
+    );
   });

--- a/packages/server/src/harness/executable.ts
+++ b/packages/server/src/harness/executable.ts
@@ -1,34 +1,29 @@
 import os from "node:os";
 import path from "node:path";
 
-import type { HarnessAgentId } from "@vibest/contract";
 import { Effect, FileSystem } from "effect";
 
-import { ExecutableNotFound } from "./errors";
-
 /**
- * Locating the CLI a harness runs — one search, shared by all three.
+ * The mechanics of locating a CLI on disk. *Where to look, in what order* is
+ * each harness's own business — see `<agent>/executable.ts`; this file only
+ * supplies the two things all three would otherwise reimplement: "is this a
+ * runnable file" and "walk the install directories for this name".
  *
- * It used to search PATH and nothing else, deliberately: the transports
- * spawned a bare command name (`spawn("codex")`), the OS resolved that through
- * PATH alone, so anything found elsewhere would have reported a harness
- * available that then failed with an opaque ENOENT. That constraint is gone,
- * and removing it is the point of this module: {@link resolveHarnessExecutable}
- * returns an absolute path and **that path is what gets spawned**. The search
- * and the launch can no longer disagree, because they are the same answer.
+ * The whole point of resolving here rather than letting the OS do it: the
+ * result is an absolute path, and **that path is what gets spawned**. It used
+ * to be PATH-only, deliberately — the transports spawned a bare command name,
+ * the OS resolved that through PATH alone, so anything found elsewhere would
+ * have reported a harness available that then failed with an opaque ENOENT.
  *
- * Which makes the invariant to protect: *never widen this search without the
- * result reaching spawn.* A caller that resolves here and then execs a bare
- * name has reintroduced the exact bug this replaced — the harness reports
- * available off one set of rules and launches off another.
+ * So the invariant every caller inherits: *never widen the search without the
+ * result reaching spawn.* Resolve here and then exec a bare name and you have
+ * reintroduced the exact bug this replaced — availability answered off one set
+ * of rules, the launch off another.
  *
  * The old shape cost real users: a `codex` installed by bun (`~/.bun/bin`, not
  * on a systemd unit's PATH) read as "not installed", while claude-code — whose
  * resolver already searched past PATH *because* its result was passed to the
  * SDK — found its own binary in that very directory.
- *
- * Four levels, first hit wins. What differs per harness is declared in a
- * {@link HarnessExecutableSpec}; the walk itself never varies.
  */
 
 /**
@@ -43,8 +38,8 @@ export const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32
 
 /**
  * Where the native installers and common package managers put a CLI. Searched
- * after PATH, so a PATH entry always wins; this level exists for the process
- * whose PATH is not a login shell's — a systemd unit, a launchd GUI app, a
+ * after PATH, so a PATH entry always wins; this exists for the process whose
+ * PATH is not a login shell's — a systemd unit, a launchd GUI app, a
  * non-interactive `ssh host "…"` — which is the normal case for a server
  * deployment and the one where every one of these directories is missing.
  */
@@ -56,33 +51,6 @@ function fallbackInstallDirs(home: string): ReadonlyArray<string> {
     "/usr/local/bin",
   ];
 }
-
-/**
- * What one harness declares about finding its CLI. Everything here is a
- * difference that is real between harnesses; anything the same for all three
- * belongs in {@link resolveHarnessExecutable} instead.
- */
-export type HarnessExecutableSpec = {
-  readonly harnessAgentId: HarnessAgentId;
-  /** Bare name, no extension — Windows variants are derived by the resolver. */
-  readonly binaryName: string;
-  /**
-   * An operator's explicit answer, read straight from the environment. A
-   * function rather than a variable name because claude-code has a second,
-   * test-only variable gated on `VIBEST_E2E`.
-   */
-  readonly override: (env: NodeJS.ProcessEnv) => string | undefined;
-  /**
-   * The copy that ships as one of vibest's own dependencies, resolved through
-   * the module graph. Absent for a harness vibest does not bundle (codex).
-   * Best-effort by contract: a miss falls through to PATH rather than failing,
-   * because the same code runs from a source checkout and from a bundle whose
-   * module graph does not contain the harness.
-   */
-  readonly bundled?: (binary: string) => string | undefined;
-  /** Human-facing sentence for `availability`, naming how to fix it. */
-  readonly notFoundReason: string;
-};
 
 export type ResolveExecutableDeps = {
   env?: NodeJS.ProcessEnv;
@@ -112,62 +80,58 @@ export const isExecutableFile = (
     Effect.catch(() => Effect.succeed(false)),
   );
 
-/** The names a bare command can take on this platform. */
-const candidateNames = (binaryName: string, platform: NodeJS.Platform): ReadonlyArray<string> =>
+/**
+ * The names a bare command can take on this platform. Exported because a
+ * harness that nominates a file itself — a copy inside its own package — has to
+ * ask for the same set of names the search would have tried.
+ */
+export const candidateNames = (
+  binaryName: string,
+  platform: NodeJS.Platform,
+): ReadonlyArray<string> =>
   platform !== "win32" || path.extname(binaryName)
     ? [binaryName]
     : WINDOWS_EXTENSIONS.map((extension) => `${binaryName}${extension}`);
 
 /**
- * The absolute path to a harness's CLI, or {@link ExecutableNotFound}.
- *
- * The result is what the transport spawns — see the module note above; that is
- * the whole reason levels 2 and 4 are allowed to exist.
+ * A single candidate, checked. For the levels a harness knows how to name
+ * itself — an env override it wants verified, a copy inside its own package.
  */
-export const resolveHarnessExecutable = (
-  spec: HarnessExecutableSpec,
+export const executableAt = (
+  candidate: string,
   deps: ResolveExecutableDeps = {},
-): Effect.Effect<string, ExecutableNotFound, FileSystem.FileSystem> =>
+): Effect.Effect<string | undefined, never, FileSystem.FileSystem> =>
+  FileSystem.FileSystem.use((fs) =>
+    isExecutableFile(fs, candidate, deps.platform ?? process.platform),
+  ).pipe(Effect.map((runnable) => (runnable ? candidate : undefined)));
+
+/**
+ * Walk PATH, then the fallback install directories, for `binaryName`. One walk
+ * so PATH order is honoured and a PATH hit always beats a fallback; candidates
+ * are checked in sequence and the first runnable one wins, rather than stat'ing
+ * the whole search space.
+ *
+ * `undefined` means "not installed anywhere we look" — the caller decides
+ * whether that is the end of its search and what to say about it.
+ */
+export const searchInstallDirs = (
+  binaryName: string,
+  deps: ResolveExecutableDeps = {},
+): Effect.Effect<string | undefined, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const { env = process.env, platform = process.platform, home = os.homedir() } = deps;
     const fs = yield* FileSystem.FileSystem;
-    const isExecutable = (candidate: string) => isExecutableFile(fs, candidate, platform);
 
-    // 1. An explicit override is taken at face value, unverified. Falling back
-    //    when it does not exist would be worse than failing: the operator
-    //    would be told the harness works while it silently runs a different
-    //    binary than the one they named.
-    const override = spec.override(env);
-    if (override) return override;
-
-    const names = candidateNames(spec.binaryName, platform);
-
-    // 2. vibest's own copy, when it has one.
-    for (const name of names) {
-      const bundled = spec.bundled?.(name);
-      if (bundled && (yield* isExecutable(bundled))) return bundled;
-    }
-
-    // 3 and 4. PATH first, then the install directories a stripped environment
-    //    would have dropped. One walk, so PATH order is honoured and a PATH hit
-    //    always beats a fallback.
     const directories = [
       ...(env["PATH"] ?? "").split(pathDelimiter(platform)),
       ...fallbackInstallDirs(home),
     ];
     for (const directory of directories) {
       if (!directory) continue;
-      for (const name of names) {
+      for (const name of candidateNames(binaryName, platform)) {
         const candidate = path.join(directory, name);
-        if (yield* isExecutable(candidate)) return candidate;
+        if (yield* isExecutableFile(fs, candidate, platform)) return candidate;
       }
     }
-
-    return yield* Effect.fail(
-      new ExecutableNotFound({
-        harnessAgentId: spec.harnessAgentId,
-        executable: spec.binaryName,
-        reason: spec.notFoundReason,
-      }),
-    );
+    return undefined;
   });

--- a/packages/server/src/harness/executable.ts
+++ b/packages/server/src/harness/executable.ts
@@ -80,7 +80,7 @@ export type HarnessExecutableSpec = {
    * module graph does not contain the harness.
    */
   readonly bundled?: (binary: string) => string | undefined;
-  /** Human-facing sentence for `checkAvailability`, naming how to fix it. */
+  /** Human-facing sentence for `availability`, naming how to fix it. */
   readonly notFoundReason: string;
 };
 

--- a/packages/server/src/harness/index.ts
+++ b/packages/server/src/harness/index.ts
@@ -10,7 +10,7 @@ export * from "./adapter";
 export * from "./errors";
 export * from "./executable";
 export * from "./list";
-export * from "./probe";
+export * from "./models";
 export * from "./queue-stream";
 export * from "./registry";
 export * from "./session-io";

--- a/packages/server/src/harness/list.ts
+++ b/packages/server/src/harness/list.ts
@@ -15,7 +15,7 @@ import { HarnessAgentRegistry, type HarnessAgentRegistryShape } from "./registry
  * nothing memoizes it. Worth caching per process — see the note in
  * `claudeAvailability`.
  *
- * Anything that needs a CLI to answer belongs to {@link HarnessProbeService}
+ * Anything that needs a CLI to answer belongs to {@link HarnessModelsService}
  * instead. That split is about acquisition cost and failure mode only — it
  * says nothing about who owns the values' meaning (both endpoints can carry
  * normalized and opaque settings, see docs/design/harness-concept-ownership.md).

--- a/packages/server/src/harness/list.ts
+++ b/packages/server/src/harness/list.ts
@@ -13,7 +13,7 @@ import { HarnessAgentRegistry, type HarnessAgentRegistryShape } from "./registry
  * It is not free, though, and the client awaits it before first paint:
  * claude-code's check spawns `claude --version` (~45 ms) on every call, and
  * nothing memoizes it. Worth caching per process — see the note in
- * `checkClaudeAvailability`.
+ * `claudeAvailability`.
  *
  * Anything that needs a CLI to answer belongs to {@link HarnessProbeService}
  * instead. That split is about acquisition cost and failure mode only — it
@@ -47,7 +47,7 @@ export const makeHarnessList = (registry: HarnessAgentRegistryShape) => ({
                 ),
               ),
             );
-            const availability = yield* adapter.checkAvailability;
+            const availability = yield* adapter.availability;
             return {
               id: descriptor.id,
               name: descriptor.name,

--- a/packages/server/src/harness/models.ts
+++ b/packages/server/src/harness/models.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 
-import type { HarnessAgentId, HarnessProbeInput, HarnessProbeOutput } from "@vibest/contract";
+import type { HarnessAgentId, HarnessModelsInput, HarnessModelsOutput } from "@vibest/contract";
 import { Cache, Context, Data, Effect, Exit, FileSystem, Layer } from "effect";
 
 import type { AgentUnavailable, HarnessAgentNotFound } from "./errors";
-import { CapabilityProbeFailed } from "./errors";
+import { ModelListFailed } from "./errors";
 import { HarnessAgentRegistry, type HarnessAgentRegistryShape } from "./registry";
 
 /**
@@ -13,7 +13,7 @@ import { HarnessAgentRegistry, type HarnessAgentRegistryShape } from "./registry
  *
  * Today every harness carries exactly one built-in provider (its own model
  * catalogue, `providerId === harnessAgentId`); user-configured providers join
- * the same seam later by extending the key → probe resolution below. The cache
+ * the same seam later by extending the key → provider resolution below. The cache
  * key is therefore (providerId, cwd) — the unit that will stay correct when a
  * second kind of provider exists.
  *
@@ -33,7 +33,7 @@ import { HarnessAgentRegistry, type HarnessAgentRegistryShape } from "./registry
  * de-duplication window, not a claim about how long the answer stays true; the
  * client's `staleTime` is what decides freshness.
  */
-const PROBE_TTL = "60 seconds";
+const MODELS_TTL = "60 seconds";
 
 /**
  * Failures are deliberately given no lifetime at all. `Cache` stores the
@@ -44,11 +44,11 @@ const PROBE_TTL = "60 seconds";
 const FAILURE_TTL = 0;
 
 /**
- * Far above any real probe (measured: 0.7s / 3.6s). This is the "the CLI is
+ * Far above any real answer (measured: 0.7s / 3.6s). This is the "the CLI is
  * wedged" guard, not a latency budget — nothing is waiting on it to paint, so
  * there is no reason to cut a slow-but-working machine off.
  */
-const PROBE_TIMEOUT = "30 seconds";
+const LIST_TIMEOUT = "30 seconds";
 
 /**
  * Big enough that no real usage pattern evicts anything, small enough that it
@@ -57,43 +57,44 @@ const PROBE_TIMEOUT = "30 seconds";
 const CACHE_CAPACITY = 256;
 
 /** A `Data.Class` because structural equality is what makes it a cache key. */
-class ProbeKey extends Data.Class<{
+class ModelsKey extends Data.Class<{
   readonly providerId: HarnessAgentId;
   readonly cwd: string;
 }> {}
 
 /**
- * `AgentUnavailable` rides alongside `CapabilityProbeFailed` rather than being
+ * `AgentUnavailable` rides alongside `ModelListFailed` rather than being
  * folded into it: "this harness's CLI is not installed" is a settled fact the
- * client should render as a greyed-out harness, while a probe failure is a
- * transient, retryable degraded state. Collapsing the two would make an
- * uninstalled harness look like a server that keeps breaking.
+ * client should render as a greyed-out harness, while a failure to read the
+ * catalogue is a transient, retryable degraded state. Collapsing the two would
+ * make an uninstalled harness look like a server that keeps breaking.
  */
-export type HarnessProbeShape = {
-  readonly probe: (
-    input: HarnessProbeInput,
+export type HarnessModelsShape = {
+  readonly list: (
+    input: HarnessModelsInput,
   ) => Effect.Effect<
-    HarnessProbeOutput,
-    CapabilityProbeFailed | AgentUnavailable | HarnessAgentNotFound
+    HarnessModelsOutput,
+    ModelListFailed | AgentUnavailable | HarnessAgentNotFound
   >;
 };
 
-export class HarnessProbeService extends Context.Service<HarnessProbeService, HarnessProbeShape>()(
-  "HarnessProbeService",
-) {}
+export class HarnessModelsService extends Context.Service<
+  HarnessModelsService,
+  HarnessModelsShape
+>()("HarnessModelsService") {}
 
-export const makeHarnessProbe = (
+export const makeHarnessModels = (
   registry: HarnessAgentRegistryShape,
-): Effect.Effect<HarnessProbeShape, never, FileSystem.FileSystem> =>
+): Effect.Effect<HarnessModelsShape, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    // Bound once here so the service's `probe` stays `R`-free for its RPC
+    // Bound once here so the service's `list` stays `R`-free for its RPC
     // caller — the requirement comes from the registry's availability gate.
     const platform = yield* Effect.context<FileSystem.FileSystem>();
     // One built-in provider per harness for now, so resolving a providerId is
     // a registry lookup. Never collapse a failure into an empty answer here —
-    // the error channel is what keeps "probe failed" distinguishable from
+    // the error channel is what keeps "the read failed" distinguishable from
     // "this harness has no models".
-    const probeProvider = ({ providerId, cwd }: ProbeKey) =>
+    const loadProvider = ({ providerId, cwd }: ModelsKey) =>
       Effect.gen(function* () {
         // `require`, not `get`: asking a harness for its catalogue spawns its
         // CLI, so an absent binary has to stop the call here. Going in on an
@@ -101,48 +102,48 @@ export const makeHarnessProbe = (
         // executable vanished after the availability check gated on it"
         // defect — a check this path never performed.
         const adapter = yield* registry.require(providerId).pipe(Effect.provide(platform));
-        // No probe at all is an answer, not a failure: this harness has no
-        // model catalogue (pi), so the client renders no picker for it.
-        if (!adapter.probeModels) return { providers: [] } satisfies HarnessProbeOutput;
+        // No catalogue at all is an answer, not a failure: this harness has
+        // none to offer (pi), so the client renders no picker for it.
+        if (!adapter.listModels) return { providers: [] } satisfies HarnessModelsOutput;
 
-        const models = yield* adapter.probeModels(cwd).pipe(
+        const models = yield* adapter.listModels(cwd).pipe(
           Effect.timeoutOrElse({
-            duration: PROBE_TIMEOUT,
+            duration: LIST_TIMEOUT,
             orElse: () =>
               Effect.fail(
-                new CapabilityProbeFailed({
+                new ModelListFailed({
                   harnessAgentId: providerId,
-                  cause: new Error(`model probe timed out after ${PROBE_TIMEOUT}`),
+                  cause: new Error(`reading the model catalogue timed out after ${LIST_TIMEOUT}`),
                 }),
               ),
           }),
         );
         return {
           providers: [{ id: providerId, label: adapter.descriptor.name, models }],
-        } satisfies HarnessProbeOutput;
+        } satisfies HarnessModelsOutput;
       });
 
-    const cache = yield* Cache.makeWith(probeProvider, {
+    const cache = yield* Cache.makeWith(loadProvider, {
       capacity: CACHE_CAPACITY,
-      timeToLive: (exit) => (Exit.isSuccess(exit) ? PROBE_TTL : FAILURE_TTL),
+      timeToLive: (exit) => (Exit.isSuccess(exit) ? MODELS_TTL : FAILURE_TTL),
     });
 
     return {
       // Resolved on the way in, so `/w/app`, `/w/app/` and `/w/x/../app` are one
-      // entry rather than three probes of the same directory.
-      probe: ({ harnessAgentId, cwd }) =>
-        Cache.get(cache, new ProbeKey({ providerId: harnessAgentId, cwd: path.resolve(cwd) })),
+      // entry rather than three reads of the same directory.
+      list: ({ harnessAgentId, cwd }) =>
+        Cache.get(cache, new ModelsKey({ providerId: harnessAgentId, cwd: path.resolve(cwd) })),
     };
   });
 
-export const HarnessProbeLayer: Layer.Layer<
-  HarnessProbeService,
+export const HarnessModelsLayer: Layer.Layer<
+  HarnessModelsService,
   never,
   HarnessAgentRegistry | FileSystem.FileSystem
 > = Layer.effect(
-  HarnessProbeService,
+  HarnessModelsService,
   Effect.gen(function* () {
     const registry = yield* HarnessAgentRegistry;
-    return yield* makeHarnessProbe(registry);
+    return yield* makeHarnessModels(registry);
   }),
 );

--- a/packages/server/src/harness/pi/adapter.ts
+++ b/packages/server/src/harness/pi/adapter.ts
@@ -2,6 +2,7 @@ import { Effect, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 
 import type {
+  AvailabilityResult,
   HarnessAgentAdapter,
   HarnessAgentRuntime,
   SessionInfoResult,
@@ -16,7 +17,6 @@ import {
   TurnAlreadyRunning,
 } from "../errors";
 import type { SessionEnvelopeDraft, SessionEvent } from "../events/framework";
-import { findExecutable } from "../executable";
 import { streamFromQueueOne } from "../queue-stream";
 import type { PiAgent } from "./agent";
 import { entriesToUIMessages } from "./history";
@@ -229,19 +229,21 @@ const makeRuntime = (
     } satisfies HarnessAgentRuntime;
   });
 
-export const makePiAdapter = (
-  agent: PiAgent,
-  options: { readonly executablePath?: string } = {},
-): HarnessAgentAdapter => ({
+export const makePiAdapter = (agent: PiAgent): HarnessAgentAdapter => ({
   id: "pi",
   descriptor: { id: "pi", name: "Pi" },
   // Pi has neither a permission protocol nor a model catalogue — declaring
   // nothing (empty subset, no probe) is what makes the UI render no config
   // controls for it.
   permissionModes: [],
-  checkAvailability: findExecutable(options.executablePath ?? "pi").pipe(
-    Effect.map((found) =>
-      found ? { available: true } : { available: false, reason: "Pi was not found on PATH." },
+  // Answered off the agent's own cached resolve, so "available" and "what the
+  // transport spawns" cannot disagree — see `harness/executable.ts`.
+  // `suspend`, because building an adapter must stay a pure declaration that
+  // never touches its agent (`adapter-capabilities.test.ts` locks this).
+  checkAvailability: Effect.suspend(() => agent.executable).pipe(
+    Effect.as({ available: true } as AvailabilityResult),
+    Effect.catch((cause) =>
+      Effect.succeed({ available: false, reason: cause.message } as AvailabilityResult),
     ),
   ),
   open: (input) =>

--- a/packages/server/src/harness/pi/adapter.ts
+++ b/packages/server/src/harness/pi/adapter.ts
@@ -240,7 +240,7 @@ export const makePiAdapter = (agent: PiAgent): HarnessAgentAdapter => ({
   // transport spawns" cannot disagree — see `harness/executable.ts`.
   // `suspend`, because building an adapter must stay a pure declaration that
   // never touches its agent (`adapter-capabilities.test.ts` locks this).
-  checkAvailability: Effect.suspend(() => agent.executable).pipe(
+  availability: Effect.suspend(() => agent.executable).pipe(
     Effect.as({ available: true } as AvailabilityResult),
     Effect.catch((cause) =>
       Effect.succeed({ available: false, reason: cause.message } as AvailabilityResult),

--- a/packages/server/src/harness/pi/adapter.ts
+++ b/packages/server/src/harness/pi/adapter.ts
@@ -233,7 +233,7 @@ export const makePiAdapter = (agent: PiAgent): HarnessAgentAdapter => ({
   id: "pi",
   descriptor: { id: "pi", name: "Pi" },
   // Pi has neither a permission protocol nor a model catalogue — declaring
-  // nothing (empty subset, no probe) is what makes the UI render no config
+  // nothing (empty subset, no catalogue) is what makes the UI render no config
   // controls for it.
   permissionModes: [],
   // Answered off the agent's own cached resolve, so "available" and "what the

--- a/packages/server/src/harness/pi/agent.ts
+++ b/packages/server/src/harness/pi/agent.ts
@@ -1,5 +1,5 @@
 import type { AgentRequest, AgentResponse } from "@vibest/contract";
-import { Deferred, Effect, Exit, Queue, Ref, Scope, Stream } from "effect";
+import { Deferred, Effect, Exit, FileSystem, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 import type * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { v7 as uuid } from "uuid";
@@ -7,11 +7,14 @@ import { v7 as uuid } from "uuid";
 import {
   AgentOperationError,
   AgentRequestUnavailable,
+  type ExecutableNotFound,
   PiTransportError,
   HarnessSessionNotFound,
   TurnAlreadyRunning,
 } from "../errors";
+import { resolveHarnessExecutable } from "../executable";
 import { drainQueue, streamFromQueueOne } from "../queue-stream";
+import { piExecutableSpec } from "./executable";
 import type { RpcExtensionUIResponse, RpcSessionState, SessionEntries } from "./protocol";
 import { buildUiRequest, declineUiResponse, mapUiResponse } from "./request";
 import { createPiTransform } from "./transform";
@@ -83,6 +86,13 @@ export interface PiAgentDependencies<R> {
 }
 
 export interface PiAgent {
+  /**
+   * The absolute path this agent will spawn, resolved once and cached.
+   *
+   * Exposed so the adapter's `checkAvailability` answers off the *same* resolve
+   * the transport launches — see the note in `harness/executable.ts`.
+   */
+  readonly executable: Effect.Effect<string, ExecutableNotFound>;
   readonly session: {
     readonly create: (config: {
       readonly cwd: string;
@@ -129,7 +139,7 @@ export interface PiAgent {
 /** @internal */
 export const makePiAgentWithDependencies = <R>(
   dependencies: PiAgentDependencies<R>,
-): Effect.Effect<PiAgent, never, R | Scope.Scope> =>
+): Effect.Effect<Omit<PiAgent, "executable">, never, R | Scope.Scope> =>
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
     const buildContext = yield* Effect.context<R>();
@@ -578,18 +588,52 @@ export const makePiAgentWithDependencies = <R>(
         interrupt,
         abort,
       },
-    } satisfies PiAgent;
+    } satisfies Omit<PiAgent, "executable">;
   });
 
+/**
+ * An explicit `executablePath` wins outright (tests point it at a fake binary);
+ * otherwise the shared four-level search answers, once, for both the transport
+ * and the adapter's availability check.
+ */
 export const makePiAgent = (
   options: PiAgentOptions = {},
-): Effect.Effect<PiAgent, never, ChildProcessSpawner.ChildProcessSpawner | Scope.Scope> =>
-  makePiAgentWithDependencies({
-    makeTransport: (config) =>
-      makePiTransport({
-        ...(options.executablePath ? { executablePath: options.executablePath } : {}),
-        ...(options.args ? { args: options.args } : {}),
-        sessionId: config.sessionId,
-        ...(config.cwd ? { cwd: config.cwd } : {}),
-      }),
+): Effect.Effect<
+  PiAgent,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner | Scope.Scope | FileSystem.FileSystem
+> =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const executable = options.executablePath
+      ? Effect.succeed(options.executablePath)
+      : yield* Effect.cached(
+          resolveHarnessExecutable(piExecutableSpec).pipe(
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+          ),
+        );
+    const agent = yield* makePiAgentWithDependencies({
+      makeTransport: (config) =>
+        Effect.flatMap(
+          // A resolve miss reaches the caller as a spawn failure, which is what
+          // it is: the launch could not happen. The transport's error channel
+          // is unchanged.
+          Effect.mapError(
+            executable,
+            (cause) =>
+              new PiTransportError({
+                operation: "spawn",
+                cause,
+              }),
+          ),
+          (executablePath) =>
+            makePiTransport({
+              executablePath,
+              ...(options.args ? { args: options.args } : {}),
+              sessionId: config.sessionId,
+              ...(config.cwd ? { cwd: config.cwd } : {}),
+            }),
+        ),
+    });
+    return { ...agent, executable };
   });

--- a/packages/server/src/harness/pi/agent.ts
+++ b/packages/server/src/harness/pi/agent.ts
@@ -12,9 +12,8 @@ import {
   HarnessSessionNotFound,
   TurnAlreadyRunning,
 } from "../errors";
-import { resolveHarnessExecutable } from "../executable";
 import { drainQueue, streamFromQueueOne } from "../queue-stream";
-import { piExecutableSpec } from "./executable";
+import { resolvePiExecutable } from "./executable";
 import type { RpcExtensionUIResponse, RpcSessionState, SessionEntries } from "./protocol";
 import { buildUiRequest, declineUiResponse, mapUiResponse } from "./request";
 import { createPiTransform } from "./transform";
@@ -608,9 +607,7 @@ export const makePiAgent = (
     const executable = options.executablePath
       ? Effect.succeed(options.executablePath)
       : yield* Effect.cached(
-          resolveHarnessExecutable(piExecutableSpec).pipe(
-            Effect.provideService(FileSystem.FileSystem, fileSystem),
-          ),
+          resolvePiExecutable().pipe(Effect.provideService(FileSystem.FileSystem, fileSystem)),
         );
     const agent = yield* makePiAgentWithDependencies({
       makeTransport: (config) =>

--- a/packages/server/src/harness/pi/agent.ts
+++ b/packages/server/src/harness/pi/agent.ts
@@ -89,7 +89,7 @@ export interface PiAgent {
   /**
    * The absolute path this agent will spawn, resolved once and cached.
    *
-   * Exposed so the adapter's `checkAvailability` answers off the *same* resolve
+   * Exposed so the adapter's `availability` answers off the *same* resolve
    * the transport launches — see the note in `harness/executable.ts`.
    */
   readonly executable: Effect.Effect<string, ExecutableNotFound>;

--- a/packages/server/src/harness/pi/executable.ts
+++ b/packages/server/src/harness/pi/executable.ts
@@ -2,12 +2,24 @@ import fs from "node:fs";
 import module from "node:module";
 import path from "node:path";
 
-import type { HarnessExecutableSpec } from "../executable";
+import { Effect, type FileSystem } from "effect";
+
+import { ExecutableNotFound } from "../errors";
+import {
+  candidateNames,
+  executableAt,
+  searchInstallDirs,
+  type ResolveExecutableDeps,
+} from "../executable";
 
 const moduleRequire = module.createRequire(import.meta.url);
 
 /** The npm package `packages/server` depends on to ship a working pi. */
 const PI_PACKAGE = "@earendil-works/pi-coding-agent";
+
+const NOT_FOUND =
+  "Pi was not found. Install it from https://github.com/earendil-works/pi, " +
+  "or set VIBEST_PI_EXECUTABLE to the path of the `pi` binary.";
 
 /**
  * The pi that ships with vibest. Unlike codex, pi is one of our own
@@ -26,17 +38,15 @@ const PI_PACKAGE = "@earendil-works/pi-coding-agent";
  * Windows too. `resolve.paths` gives the `node_modules` chain without consulting
  * `exports`, which is the one thing here that stays a module-graph question.
  *
- * Best-effort, as the spec's contract says — but it resolves from both entry
- * points that matter, and that is not free: `packages/vibest` declares pi as a
- * dependency of its own so the bundled CLI's module graph reaches it, exactly
- * as it already does for the Claude SDK. Drop that declaration and this level
- * goes quiet in the shipped CLI while still passing every test from a source
- * checkout. The version there is pinned literally and must move with
- * `packages/server`'s.
+ * Only nominates — the caller verifies. It resolves from both entry points that
+ * matter, and that is not free: `packages/vibest` declares pi as a dependency of
+ * its own so the bundled CLI's module graph reaches it, exactly as it already
+ * does for the Claude SDK. Drop that declaration and this level goes quiet in
+ * the shipped CLI while still passing every test from a source checkout. The
+ * version there is pinned literally and must move with `packages/server`'s.
  */
 function bundledPi(binary: string): string | undefined {
   for (const nodeModules of moduleRequire.resolve.paths(PI_PACKAGE) ?? []) {
-    // Existence and runnability are the resolver's job — this only nominates.
     if (fs.existsSync(path.join(nodeModules, ...PI_PACKAGE.split("/")))) {
       return path.join(nodeModules, ".bin", binary);
     }
@@ -44,12 +54,39 @@ function bundledPi(binary: string): string | undefined {
   return undefined;
 }
 
-export const piExecutableSpec: HarnessExecutableSpec = {
-  harnessAgentId: "pi",
-  binaryName: "pi",
-  override: (env) => env["VIBEST_PI_EXECUTABLE"],
-  bundled: bundledPi,
-  notFoundReason:
-    "Pi was not found. Install it from https://github.com/earendil-works/pi, " +
-    "or set VIBEST_PI_EXECUTABLE to the path of the `pi` binary.",
+export type ResolvePiDeps = ResolveExecutableDeps & {
+  /** The copy shipped inside our own `node_modules`. Injectable for tests. */
+  bundled?: (binary: string) => string | undefined;
 };
+
+/**
+ * The `pi` binary to spawn: an explicit override (unverified — naming a path is
+ * the user saying "this one"), else our own bundled copy, else the machine's.
+ * Ours is preferred over the user's install because its version is the one this
+ * server's RPC vocabulary was written against.
+ */
+export const resolvePiExecutable = (
+  deps: ResolvePiDeps = {},
+): Effect.Effect<string, ExecutableNotFound, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const override = (deps.env ?? process.env)["VIBEST_PI_EXECUTABLE"];
+    if (override) return override;
+
+    for (const name of candidateNames("pi", deps.platform ?? process.platform)) {
+      const bundled = (deps.bundled ?? bundledPi)(name);
+      if (!bundled) continue;
+      const verified = yield* executableAt(bundled, deps);
+      if (verified) return verified;
+    }
+
+    const installed = yield* searchInstallDirs("pi", deps);
+    if (installed) return installed;
+
+    return yield* Effect.fail(
+      new ExecutableNotFound({
+        harnessAgentId: "pi",
+        executable: "pi",
+        reason: NOT_FOUND,
+      }),
+    );
+  });

--- a/packages/server/src/harness/pi/executable.ts
+++ b/packages/server/src/harness/pi/executable.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import module from "node:module";
+import path from "node:path";
+
+import type { HarnessExecutableSpec } from "../executable";
+
+const moduleRequire = module.createRequire(import.meta.url);
+
+/** The npm package `packages/server` depends on to ship a working pi. */
+const PI_PACKAGE = "@earendil-works/pi-coding-agent";
+
+/**
+ * The pi that ships with vibest. Unlike codex, pi is one of our own
+ * dependencies (`packages/server/package.json`), so a working copy is on disk
+ * next to the server whether or not the user ever installed pi themselves —
+ * and until now nothing looked there, so a machine carrying a perfectly good
+ * `node_modules/.bin/pi` was told pi was not installed.
+ *
+ * Found as the `node_modules/.bin` shim rather than through the module graph,
+ * for two reasons. `require.resolve` cannot see into this package at all — its
+ * `exports` map declares only `.` and `./rpc-entry`, both `import`-conditioned,
+ * so a CJS resolve of the entry *or* of `package.json` throws
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED`. And the manifest's `bin` points at a plain
+ * `dist/cli.js`, which carries no guarantee of an execute bit; the shim the
+ * package manager writes is the artifact that is guaranteed runnable, on
+ * Windows too. `resolve.paths` gives the `node_modules` chain without consulting
+ * `exports`, which is the one thing here that stays a module-graph question.
+ *
+ * Best-effort, as the spec's contract says — but it resolves from both entry
+ * points that matter, and that is not free: `packages/vibest` declares pi as a
+ * dependency of its own so the bundled CLI's module graph reaches it, exactly
+ * as it already does for the Claude SDK. Drop that declaration and this level
+ * goes quiet in the shipped CLI while still passing every test from a source
+ * checkout. The version there is pinned literally and must move with
+ * `packages/server`'s.
+ */
+function bundledPi(binary: string): string | undefined {
+  for (const nodeModules of moduleRequire.resolve.paths(PI_PACKAGE) ?? []) {
+    // Existence and runnability are the resolver's job — this only nominates.
+    if (fs.existsSync(path.join(nodeModules, ...PI_PACKAGE.split("/")))) {
+      return path.join(nodeModules, ".bin", binary);
+    }
+  }
+  return undefined;
+}
+
+export const piExecutableSpec: HarnessExecutableSpec = {
+  harnessAgentId: "pi",
+  binaryName: "pi",
+  override: (env) => env["VIBEST_PI_EXECUTABLE"],
+  bundled: bundledPi,
+  notFoundReason:
+    "Pi was not found. Install it from https://github.com/earendil-works/pi, " +
+    "or set VIBEST_PI_EXECUTABLE to the path of the `pi` binary.",
+};

--- a/packages/server/src/harness/probe.ts
+++ b/packages/server/src/harness/probe.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
 
 import type { HarnessAgentId, HarnessProbeInput, HarnessProbeOutput } from "@vibest/contract";
-import { Cache, Context, Data, Effect, Exit, Layer } from "effect";
+import { Cache, Context, Data, Effect, Exit, FileSystem, Layer } from "effect";
 
+import type { AgentUnavailable, HarnessAgentNotFound } from "./errors";
 import { CapabilityProbeFailed } from "./errors";
 import { HarnessAgentRegistry, type HarnessAgentRegistryShape } from "./registry";
 
@@ -61,10 +62,20 @@ class ProbeKey extends Data.Class<{
   readonly cwd: string;
 }> {}
 
+/**
+ * `AgentUnavailable` rides alongside `CapabilityProbeFailed` rather than being
+ * folded into it: "this harness's CLI is not installed" is a settled fact the
+ * client should render as a greyed-out harness, while a probe failure is a
+ * transient, retryable degraded state. Collapsing the two would make an
+ * uninstalled harness look like a server that keeps breaking.
+ */
 export type HarnessProbeShape = {
   readonly probe: (
     input: HarnessProbeInput,
-  ) => Effect.Effect<HarnessProbeOutput, CapabilityProbeFailed>;
+  ) => Effect.Effect<
+    HarnessProbeOutput,
+    CapabilityProbeFailed | AgentUnavailable | HarnessAgentNotFound
+  >;
 };
 
 export class HarnessProbeService extends Context.Service<HarnessProbeService, HarnessProbeShape>()(
@@ -73,21 +84,23 @@ export class HarnessProbeService extends Context.Service<HarnessProbeService, Ha
 
 export const makeHarnessProbe = (
   registry: HarnessAgentRegistryShape,
-): Effect.Effect<HarnessProbeShape> =>
+): Effect.Effect<HarnessProbeShape, never, FileSystem.FileSystem> =>
   Effect.gen(function* () {
+    // Bound once here so the service's `probe` stays `R`-free for its RPC
+    // caller — the requirement comes from the registry's availability gate.
+    const platform = yield* Effect.context<FileSystem.FileSystem>();
     // One built-in provider per harness for now, so resolving a providerId is
     // a registry lookup. Never collapse a failure into an empty answer here —
     // the error channel is what keeps "probe failed" distinguishable from
     // "this harness has no models".
     const probeProvider = ({ providerId, cwd }: ProbeKey) =>
       Effect.gen(function* () {
-        const adapter = yield* registry
-          .get(providerId)
-          .pipe(
-            Effect.mapError(
-              (cause) => new CapabilityProbeFailed({ harnessAgentId: providerId, cause }),
-            ),
-          );
+        // `require`, not `get`: asking a harness for its catalogue spawns its
+        // CLI, so an absent binary has to stop the call here. Going in on an
+        // unchecked adapter is what used to reach claude-code's "the
+        // executable vanished after the availability check gated on it"
+        // defect — a check this path never performed.
+        const adapter = yield* registry.require(providerId).pipe(Effect.provide(platform));
         // No probe at all is an answer, not a failure: this harness has no
         // model catalogue (pi), so the client renders no picker for it.
         if (!adapter.probeModels) return { providers: [] } satisfies HarnessProbeOutput;
@@ -122,11 +135,14 @@ export const makeHarnessProbe = (
     };
   });
 
-export const HarnessProbeLayer: Layer.Layer<HarnessProbeService, never, HarnessAgentRegistry> =
-  Layer.effect(
-    HarnessProbeService,
-    Effect.gen(function* () {
-      const registry = yield* HarnessAgentRegistry;
-      return yield* makeHarnessProbe(registry);
-    }),
-  );
+export const HarnessProbeLayer: Layer.Layer<
+  HarnessProbeService,
+  never,
+  HarnessAgentRegistry | FileSystem.FileSystem
+> = Layer.effect(
+  HarnessProbeService,
+  Effect.gen(function* () {
+    const registry = yield* HarnessAgentRegistry;
+    return yield* makeHarnessProbe(registry);
+  }),
+);

--- a/packages/server/src/harness/registry.ts
+++ b/packages/server/src/harness/registry.ts
@@ -1,14 +1,46 @@
 import type { HarnessAgentId } from "@vibest/contract";
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, FileSystem, Layer } from "effect";
 
 import type { AgentDescriptor, HarnessAgentAdapter } from "./adapter";
-import { HarnessAgentNotFound } from "./errors";
+import { AgentUnavailable, HarnessAgentNotFound } from "./errors";
 
 export type HarnessAgentRegistryShape = {
   readonly list: Effect.Effect<ReadonlyArray<AgentDescriptor>>;
+  /**
+   * The adapter as registered — available or not. For the two callers that
+   * must see an unusable harness: `harness.list` renders it greyed out with
+   * its reason, and permission-vocabulary validation reads declared values
+   * that cost no process. Everything that is about to make the harness *do*
+   * something uses {@link HarnessAgentRegistryShape.require} instead.
+   */
   readonly get: (
     harnessAgentId: HarnessAgentId,
   ) => Effect.Effect<HarnessAgentAdapter, HarnessAgentNotFound>;
+  /**
+   * The adapter, guaranteed usable.
+   *
+   * This is the availability gate, and it lives here so there is exactly one
+   * of it. It used to be the caller's homework — `session-manager` did it, the
+   * model-list path did not — and the miss was invisible: nothing in the type
+   * of `get` said an unchecked adapter was a mistake. A harness whose CLI was
+   * absent therefore answered `list` correctly (greyed out) while the
+   * model-list route walked straight into the adapter and died on the missing
+   * binary, taking the endpoint down every few seconds instead of degrading
+   * the one harness.
+   *
+   * Registered-but-unavailable and not-registered-at-all are one question to
+   * every caller here ("can I use this?"), so both errors come out of one
+   * call. The `FileSystem` requirement is the adapter's own
+   * `checkAvailability` showing through; consumers bind it while building
+   * their layer, as they already do.
+   */
+  readonly require: (
+    harnessAgentId: HarnessAgentId,
+  ) => Effect.Effect<
+    HarnessAgentAdapter,
+    HarnessAgentNotFound | AgentUnavailable,
+    FileSystem.FileSystem
+  >;
 };
 
 export class HarnessAgentRegistry extends Context.Service<
@@ -22,14 +54,35 @@ export const makeHarnessAgentRegistry = (
   const byId = new Map(adapters.map((adapter) => [adapter.id, adapter]));
   const descriptors = Array.from(byId.values(), (adapter) => adapter.descriptor);
 
+  const get = (
+    harnessAgentId: HarnessAgentId,
+  ): Effect.Effect<HarnessAgentAdapter, HarnessAgentNotFound> => {
+    const adapter = byId.get(harnessAgentId);
+    return adapter
+      ? Effect.succeed(adapter)
+      : Effect.fail(new HarnessAgentNotFound({ harnessAgentId }));
+  };
+
   return {
     list: Effect.succeed(descriptors),
-    get: (harnessAgentId) => {
-      const adapter = byId.get(harnessAgentId);
-      return adapter
-        ? Effect.succeed(adapter)
-        : Effect.fail(new HarnessAgentNotFound({ harnessAgentId }));
-    },
+    get,
+    require: (harnessAgentId) =>
+      get(harnessAgentId).pipe(
+        Effect.flatMap((adapter) =>
+          adapter.checkAvailability.pipe(
+            Effect.flatMap((availability) =>
+              availability.available
+                ? Effect.succeed(adapter)
+                : Effect.fail(
+                    new AgentUnavailable({
+                      harnessAgentId,
+                      reason: availability.reason ?? "Unavailable",
+                    }),
+                  ),
+            ),
+          ),
+        ),
+      ),
   };
 };
 

--- a/packages/server/src/harness/registry.ts
+++ b/packages/server/src/harness/registry.ts
@@ -31,7 +31,7 @@ export type HarnessAgentRegistryShape = {
    * Registered-but-unavailable and not-registered-at-all are one question to
    * every caller here ("can I use this?"), so both errors come out of one
    * call. The `FileSystem` requirement is the adapter's own
-   * `checkAvailability` showing through; consumers bind it while building
+   * `availability` showing through; consumers bind it while building
    * their layer, as they already do.
    */
   readonly require: (
@@ -69,7 +69,7 @@ export const makeHarnessAgentRegistry = (
     require: (harnessAgentId) =>
       get(harnessAgentId).pipe(
         Effect.flatMap((adapter) =>
-          adapter.checkAvailability.pipe(
+          adapter.availability.pipe(
             Effect.flatMap((availability) =>
               availability.available
                 ? Effect.succeed(adapter)

--- a/packages/server/src/harness/session-manager.ts
+++ b/packages/server/src/harness/session-manager.ts
@@ -12,7 +12,6 @@ import type { CreateSessionInput, HarnessAgentRuntime } from "./adapter";
 import {
   AgentOpenError,
   type AgentOperationError,
-  AgentUnavailable,
   type CreateSessionError,
   HarnessSessionNotFound,
   type ResumeSessionError,
@@ -213,24 +212,13 @@ export const makeHarnessAgentSessionManager = (
         }),
       );
 
+    // The gate itself lives in the registry (one of it, for every caller); all
+    // this adds is the platform the manager already holds, so the shape it
+    // exposes stays `R`-free.
     const checkAvailable = (harnessAgentId: HarnessAgentId) =>
-      registry.get(harnessAgentId).pipe(
-        Effect.tap((adapter) =>
-          adapter.checkAvailability.pipe(
-            Effect.flatMap((availability) =>
-              availability.available
-                ? Effect.void
-                : Effect.fail(
-                    new AgentUnavailable({
-                      harnessAgentId,
-                      reason: availability.reason ?? "Unavailable",
-                    }),
-                  ),
-            ),
-            Effect.provideService(FileSystem.FileSystem, fileSystem),
-          ),
-        ),
-      );
+      registry
+        .require(harnessAgentId)
+        .pipe(Effect.provideService(FileSystem.FileSystem, fileSystem));
 
     const acquireOpen = (
       harnessAgentId: HarnessAgentId,

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -290,8 +290,14 @@ export const makeHarnessAgentSessionService = (deps: {
   readonly bus: EventBusShape;
   /** Mints a session id; RNG failure is a defect, so the effect never fails. */
   readonly newSessionId: Effect.Effect<string>;
+  /**
+   * Bound here so the service's own shape stays `R`-free. Only the registry's
+   * availability gate needs it — the same trade `HarnessListLayer` and the
+   * session manager already make.
+   */
+  readonly platform: Context.Context<FileSystem.FileSystem>;
 }): HarnessAgentSessionServiceShape => {
-  const { manager, registry, repo, bus, newSessionId } = deps;
+  const { manager, registry, repo, bus, newSessionId, platform } = deps;
 
   // The permission mode is our closed vocabulary, so membership in the
   // harness's declared subset is checked here — the boundary between the
@@ -331,7 +337,8 @@ export const makeHarnessAgentSessionService = (deps: {
     ReadonlyArray<UIMessage>,
     ResumeSessionError | CapabilityUnsupported | SessionClosed | AgentOperationError
   > =>
-    registry.get(ref.harnessAgentId).pipe(
+    registry.require(ref.harnessAgentId).pipe(
+      Effect.provide(platform),
       Effect.flatMap((adapter) => {
         const cold = adapter.getMessages;
         if (cold) return cold(harnessSessionId, cwd);
@@ -697,11 +704,13 @@ export const HarnessAgentSessionServiceLayer: Layer.Layer<
     const paths = yield* Paths;
     const crypto = yield* Crypto.Crypto;
     const repo = yield* makeHarnessAgentSessionRepository(paths.sessionsDir);
+    const platform = yield* Effect.context<FileSystem.FileSystem>();
     return makeHarnessAgentSessionService({
       manager,
       registry,
       repo,
       bus,
+      platform,
       // A platform RNG that cannot produce a uuid is a defect, not a domain
       // failure — keep it out of the service's error channel. Tag-specific so
       // a future recoverable error on this channel stays typed instead of dying.

--- a/packages/server/src/harness/session.ts
+++ b/packages/server/src/harness/session.ts
@@ -98,7 +98,7 @@ type AcquireDecision =
 // The two channels fail differently on purpose (harness-concept-ownership §3.3):
 // `permissionMode` was validated at the RPC boundary, so failing to apply it is
 // a real fault and the acquisition fails with it. `model`/`reasoningEffort` come
-// from probed lists that go stale (an old URL, a re-mapped alias), so they are
+// from fetched lists that go stale (an old URL, a re-mapped alias), so they are
 // best-effort: a miss is logged and the session runs on the harness default
 // rather than turning "the list was a bit old" into "the session cannot start".
 const seedConfig = (

--- a/packages/server/src/rpc/context.ts
+++ b/packages/server/src/rpc/context.ts
@@ -7,7 +7,7 @@ import type {
   HarnessAgentRegistry,
   HarnessAgentSessionService,
   HarnessListService,
-  HarnessProbeService,
+  HarnessModelsService,
 } from "../harness";
 import type { ProjectService } from "../project";
 
@@ -18,7 +18,7 @@ export type RpcContext = WithEffectContext<
   | HarnessAgentRegistry
   | HarnessAgentSessionService
   | HarnessListService
-  | HarnessProbeService
+  | HarnessModelsService
   | ProjectService
   | FileSystemService
 >;

--- a/packages/server/src/rpc/harness.ts
+++ b/packages/server/src/rpc/harness.ts
@@ -1,6 +1,7 @@
 import "@orpc/experimental-effect/extensions/effect";
 import { implement } from "@orpc/server";
 import { harnessContract } from "@vibest/contract/harness";
+import { Effect } from "effect";
 
 import { HarnessListService, HarnessProbeService } from "../harness";
 import type { RpcContext } from "./context";
@@ -19,9 +20,23 @@ export const harnessRouter = orpc.router({
   // de-duplication and the timeout all live in the service — this route is just
   // the wire. A failed probe fails the call; collapsing it into an empty result
   // would cache "no models" over what is actually "login expired".
-  probe: orpc.probe.effect(function* ({ input }) {
+  // A failed probe fails the call; collapsing it into an empty result would
+  // cache "no models" over what is actually "login expired". The two failures
+  // map apart on purpose: an uninstalled harness is UNSUPPORTED (settled — the
+  // client greys it out, as `list` already told it to), a broken probe is
+  // INTERNAL (retryable). Left unmapped, both surfaced as an unhandled
+  // internal error and this endpoint became the loudest symptom of a harness
+  // that simply was not installed.
+  probe: orpc.probe.effect(function* ({ input, errors }) {
     const probe = yield* HarnessProbeService;
-    return yield* probe.probe(input);
+    return yield* probe.probe(input).pipe(
+      Effect.catchTags({
+        HarnessAgentNotFound: (e) => Effect.fail(errors.UNSUPPORTED({ message: e.message })),
+        AgentUnavailable: (e) =>
+          Effect.fail(errors.UNSUPPORTED({ message: `${e.harnessAgentId}: ${e.reason}` })),
+        CapabilityProbeFailed: (e) => Effect.fail(errors.INTERNAL({ message: e.message })),
+      }),
+    );
   }),
 });
 

--- a/packages/server/src/rpc/harness.ts
+++ b/packages/server/src/rpc/harness.ts
@@ -3,7 +3,7 @@ import { implement } from "@orpc/server";
 import { harnessContract } from "@vibest/contract/harness";
 import { Effect } from "effect";
 
-import { HarnessListService, HarnessProbeService } from "../harness";
+import { HarnessListService, HarnessModelsService } from "../harness";
 import type { RpcContext } from "./context";
 
 const orpc = implement(harnessContract).$context<RpcContext>();
@@ -16,25 +16,23 @@ export const harnessRouter = orpc.router({
     const list = yield* HarnessListService;
     return yield* list.list;
   }),
-  // Probed data, per directory: costs a CLI spawn, so caching, in-flight
+  // Fetched data, per directory: costs a CLI spawn, so caching, in-flight
   // de-duplication and the timeout all live in the service — this route is just
-  // the wire. A failed probe fails the call; collapsing it into an empty result
-  // would cache "no models" over what is actually "login expired".
-  // A failed probe fails the call; collapsing it into an empty result would
-  // cache "no models" over what is actually "login expired". The two failures
-  // map apart on purpose: an uninstalled harness is UNSUPPORTED (settled — the
-  // client greys it out, as `list` already told it to), a broken probe is
-  // INTERNAL (retryable). Left unmapped, both surfaced as an unhandled
-  // internal error and this endpoint became the loudest symptom of a harness
-  // that simply was not installed.
-  probe: orpc.probe.effect(function* ({ input, errors }) {
-    const probe = yield* HarnessProbeService;
-    return yield* probe.probe(input).pipe(
+  // the wire. A failed read fails the call; collapsing it into an empty result
+  // would cache "no models" over what is actually "login expired". The two
+  // failures map apart on purpose: an uninstalled harness is UNSUPPORTED
+  // (settled — the client greys it out, as `list` already told it to), a CLI
+  // that broke while answering is INTERNAL (retryable). Left unmapped, both
+  // surfaced as an unhandled internal error and this endpoint became the
+  // loudest symptom of a harness that simply was not installed.
+  models: orpc.models.effect(function* ({ input, errors }) {
+    const models = yield* HarnessModelsService;
+    return yield* models.list(input).pipe(
       Effect.catchTags({
         HarnessAgentNotFound: (e) => Effect.fail(errors.UNSUPPORTED({ message: e.message })),
         AgentUnavailable: (e) =>
           Effect.fail(errors.UNSUPPORTED({ message: `${e.harnessAgentId}: ${e.reason}` })),
-        CapabilityProbeFailed: (e) => Effect.fail(errors.INTERNAL({ message: e.message })),
+        ModelListFailed: (e) => Effect.fail(errors.INTERNAL({ message: e.message })),
       }),
     );
   }),

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -44,12 +44,16 @@ export const ClaudeCodeLayer: Layer.Layer<ClaudeCode> = Layer.effect(
   makeClaudeCodeAgent(),
 ).pipe(Layer.provide(PlatformLayer));
 
+// `PlatformLayer` on top of the process layer: resolving the executable reads
+// the filesystem, and `NodeProcessLayer` has already consumed its own copy.
 export const CodexLayer: Layer.Layer<Codex> = Layer.effect(Codex, makeCodexAgent()).pipe(
   Layer.provide(NodeProcessLayer),
+  Layer.provide(PlatformLayer),
 );
 
 export const PiLayer: Layer.Layer<Pi> = Layer.effect(Pi, makePiAgent()).pipe(
   Layer.provide(NodeProcessLayer),
+  Layer.provide(PlatformLayer),
 );
 
 const ProvidersLayer = Layer.mergeAll(ClaudeCodeLayer, CodexLayer, PiLayer);
@@ -103,7 +107,12 @@ const HarnessListProvided = HarnessListLayer.pipe(
   Layer.provide(RegistryLayer),
   Layer.provide(PlatformLayer),
 );
-const HarnessProbeProvided = HarnessProbeLayer.pipe(Layer.provide(RegistryLayer));
+const HarnessProbeProvided = HarnessProbeLayer.pipe(
+  Layer.provide(RegistryLayer),
+  // The availability gate reads the filesystem, so this route needs the
+  // platform now — it did not before, which is exactly how it slipped past it.
+  Layer.provide(PlatformLayer),
+);
 
 // The session stack: the manager owns all live state (instances + projections,
 // publishing wire events onto the bus); the outward façade on top does the

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -14,7 +14,7 @@ import {
   HarnessAgentSessionManagerLayer,
   HarnessAgentSessionServiceLayer,
   HarnessListLayer,
-  HarnessProbeLayer,
+  HarnessModelsLayer,
   makeHarnessAgentRegistry,
 } from "../harness";
 import {
@@ -101,13 +101,13 @@ const RegistryLayer = Layer.effect(
 ).pipe(Layer.provide(ProvidersLayer), Layer.provide(PlatformLayer));
 
 // Both harness routes read the same registry instance. It matters most for the
-// probe: one cache, shared by every connecting client, so N tabs on the same
-// directory still cost one CLI spawn.
+// model catalogue: one cache, shared by every connecting client, so N tabs on
+// the same directory still cost one CLI spawn.
 const HarnessListProvided = HarnessListLayer.pipe(
   Layer.provide(RegistryLayer),
   Layer.provide(PlatformLayer),
 );
-const HarnessProbeProvided = HarnessProbeLayer.pipe(
+const HarnessModelsProvided = HarnessModelsLayer.pipe(
   Layer.provide(RegistryLayer),
   // The availability gate reads the filesystem, so this route needs the
   // platform now — it did not before, which is exactly how it slipped past it.
@@ -149,7 +149,7 @@ export const AgentRuntimeLayer = Layer.mergeAll(
   ProjectServiceProvided,
   RegistryLayer,
   HarnessListProvided,
-  HarnessProbeProvided,
+  HarnessModelsProvided,
   FileSystemServiceLayer.pipe(Layer.provide(PlatformLayer)),
   PlatformLayer,
   // For the HTTP request app: `HttpStaticServer` needs it to turn a file into a

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -81,9 +81,9 @@ const ProvidersLayer = Layer.mergeAll(ClaudeCodeLayer, CodexLayer, PiLayer);
 export const cacheAvailability = (
   adapter: HarnessAgentAdapter,
 ): Effect.Effect<HarnessAgentAdapter, never, FileSystem.FileSystem> =>
-  Effect.map(Effect.cached(adapter.checkAvailability), (cachedCheck) => ({
+  Effect.map(Effect.cached(adapter.availability), (cachedCheck) => ({
     ...adapter,
-    checkAvailability: Effect.uninterruptible(cachedCheck),
+    availability: Effect.uninterruptible(cachedCheck),
   }));
 
 const RegistryLayer = Layer.effect(

--- a/packages/server/test/harness/adapter-capabilities.test.ts
+++ b/packages/server/test/harness/adapter-capabilities.test.ts
@@ -31,16 +31,16 @@ it("pi declares an empty permission subset and no default", () => {
   expect(adapter.defaultPermissionMode).toBeUndefined();
 });
 
-it("only the harnesses with a model catalogue declare a probe", () => {
-  expect(makeClaudeCodeAdapter(stub<ClaudeCodeAgent>()).probeModels).toBeDefined();
-  expect(makeCodexAdapter(stub<CodexAgent>()).probeModels).toBeDefined();
+it("only the harnesses with a model catalogue declare a list", () => {
+  expect(makeClaudeCodeAdapter(stub<ClaudeCodeAgent>()).listModels).toBeDefined();
+  expect(makeCodexAdapter(stub<CodexAgent>()).listModels).toBeDefined();
   // Absent, not empty: pi has no model switch, so the client renders no picker.
-  expect(makePiAdapter(stub<PiAgent>()).probeModels).toBeUndefined();
+  expect(makePiAdapter(stub<PiAgent>()).listModels).toBeUndefined();
 });
 
 it("declaring an adapter never touches its agent", () => {
   // Construction has to stay a pure declaration — the stubs above would throw
-  // on any property access if a probe were built eagerly rather than per call.
+  // on any property access if a lookup were built eagerly rather than per call.
   expect(() => makeClaudeCodeAdapter(stub<ClaudeCodeAgent>())).not.toThrow();
   expect(() => makeCodexAdapter(stub<CodexAgent>())).not.toThrow();
 });

--- a/packages/server/test/harness/claude-code/executable.test.ts
+++ b/packages/server/test/harness/claude-code/executable.test.ts
@@ -7,7 +7,7 @@ import { describe, expect } from "vitest";
 import {
   type AvailabilityDeps,
   type AvailabilityResult,
-  checkClaudeAvailability,
+  claudeAvailability,
   type ResolveDeps,
   resolveClaudeExecutable,
 } from "../../../src/harness/claude-code/executable";
@@ -108,7 +108,7 @@ describe("resolveClaudeExecutable", () => {
   });
 });
 
-describe("checkClaudeAvailability (version floor)", () => {
+describe("claudeAvailability (version floor)", () => {
   /** A resolvable executable plus injectable version reader / floor. */
   function availDeps(overrides: AvailabilityDeps = {}): AvailabilityDeps {
     return {
@@ -121,9 +121,7 @@ describe("checkClaudeAvailability (version floor)", () => {
 
   /** The check reads the platform only through the resolver; a bare fake will do. */
   const check = (overrides: AvailabilityDeps = {}, ...installed: ReadonlyArray<string>) =>
-    checkClaudeAvailability(availDeps(overrides)).pipe(
-      Effect.provide(fakeExecutables(...installed)),
-    );
+    claudeAvailability(availDeps(overrides)).pipe(Effect.provide(fakeExecutables(...installed)));
 
   /** Unconditional reason extractor so assertions never sit behind an `if`. */
   const reasonOf = (result: AvailabilityResult): string => (result.available ? "" : result.reason);

--- a/packages/server/test/harness/codex/executable.test.ts
+++ b/packages/server/test/harness/codex/executable.test.ts
@@ -1,0 +1,40 @@
+import { Effect } from "effect";
+import { expect, it } from "vitest";
+
+import { resolveCodexExecutable } from "../../../src/harness/codex/executable";
+import { fakeExecutables } from "../../fake-file-system";
+
+const resolve = (env: NodeJS.ProcessEnv, ...installed: ReadonlyArray<string>) =>
+  resolveCodexExecutable({ env, platform: "darwin", home: "/home/din" }).pipe(
+    Effect.provide(fakeExecutables(...installed)),
+  );
+
+it("takes an explicit override ahead of an install, without verifying it", () => {
+  // Unverified on purpose: falling back would tell the operator the harness
+  // works while silently running a different binary than the one they named.
+  const resolved = Effect.runSync(
+    resolve({ VIBEST_CODEX_EXECUTABLE: "/custom/codex", PATH: "/bin" }, "/bin/codex"),
+  );
+
+  expect(resolved).toBe("/custom/codex");
+});
+
+// Codex is the one harness vibest ships no copy of, so the user's own install
+// is the whole of its search — including the `bun install -g` directory a
+// systemd unit's PATH never carries.
+it("finds the user's install, PATH or not", () => {
+  const onPath = Effect.runSync(resolve({ PATH: "/usr/bin" }, "/usr/bin/codex"));
+  const offPath = Effect.runSync(resolve({ PATH: "/usr/bin" }, "/home/din/.bun/bin/codex"));
+
+  expect(onPath).toBe("/usr/bin/codex");
+  expect(offPath).toBe("/home/din/.bun/bin/codex");
+});
+
+it("fails with its own remedy when nothing is installed", () => {
+  // The reason travels on the error so the log line, the RPC message and the
+  // greyed-out harness's tooltip are all the same words.
+  const error = Effect.runSync(Effect.flip(resolve({ PATH: "/usr/bin:/bin" })));
+
+  expect(error._tag).toBe("ExecutableNotFound");
+  expect(error.message).toMatch(/Codex was not found.*VIBEST_CODEX_EXECUTABLE/s);
+});

--- a/packages/server/test/harness/executable.test.ts
+++ b/packages/server/test/harness/executable.test.ts
@@ -1,70 +1,147 @@
 import { Effect } from "effect";
 import { expect, it } from "vitest";
 
-import { findExecutable, type FindExecutableDeps } from "../../src/harness/executable";
+import {
+  type HarnessExecutableSpec,
+  type ResolveExecutableDeps,
+  resolveHarnessExecutable,
+} from "../../src/harness/executable";
 import { fakeExecutables, fakeStats, fileInfo } from "../fake-file-system";
 
-// The whole point of this resolver is to answer the same question the OS will
-// answer when a transport calls `spawn("codex")`. Every test here is about that
-// agreement: anything it finds that spawn wouldn't turns a clear "not found on
-// PATH" into an opaque ENOENT once the user picks the harness.
-const resolve = (
-  command: string,
-  deps: FindExecutableDeps,
-  ...installed: ReadonlyArray<string>
-): string | undefined =>
-  Effect.runSync(findExecutable(command, deps).pipe(Effect.provide(fakeExecutables(...installed))));
+// This resolver's result is what the transport spawns — that is the property
+// every test here is really about. It is also what changed: the search used to
+// be PATH-only *because* spawn re-resolved a bare name and would have
+// disagreed with anything found elsewhere. Now the two are the same answer, so
+// the search is allowed to look where a stripped environment's PATH cannot.
+const spec = (over: Partial<HarnessExecutableSpec> = {}): HarnessExecutableSpec => ({
+  harnessAgentId: "codex",
+  binaryName: "codex",
+  override: () => undefined,
+  notFoundReason: "Codex was not found. Install it, or set VIBEST_CODEX_EXECUTABLE.",
+  ...over,
+});
 
-it("resolves a bare command against PATH, in PATH order", () => {
-  const resolved = resolve(
-    "codex",
-    { env: { PATH: "/first:/second" }, platform: "darwin" },
-    "/first/codex",
-    "/second/codex",
+const resolve = (
+  overrides: Partial<HarnessExecutableSpec>,
+  deps: ResolveExecutableDeps,
+  ...installed: ReadonlyArray<string>
+) =>
+  resolveHarnessExecutable(spec(overrides), { home: "/home/din", ...deps }).pipe(
+    Effect.provide(fakeExecutables(...installed)),
+  );
+
+it("resolves against PATH, in PATH order", () => {
+  const resolved = Effect.runSync(
+    resolve(
+      {},
+      { env: { PATH: "/first:/second" }, platform: "darwin" },
+      "/first/codex",
+      "/second/codex",
+    ),
   );
 
   expect(resolved).toBe("/first/codex");
 });
 
-it("does not look outside PATH, because spawn will not either", () => {
-  const resolved = resolve(
-    "codex",
-    { env: { PATH: "/usr/bin" }, platform: "darwin" },
-    // Installed, but somewhere this process's PATH does not mention.
-    "/Users/someone/.local/bin/codex",
+it("takes an explicit override ahead of everything, without verifying it", () => {
+  // Unverified on purpose: falling back would tell the operator the harness
+  // works while silently running a different binary than the one they named.
+  const resolved = Effect.runSync(
+    resolve(
+      { override: (env) => env["VIBEST_CODEX_EXECUTABLE"] },
+      { env: { VIBEST_CODEX_EXECUTABLE: "/custom/codex", PATH: "/bin" }, platform: "darwin" },
+      "/bin/codex",
+    ),
   );
 
-  expect(resolved).toBeUndefined();
+  expect(resolved).toBe("/custom/codex");
 });
 
-it("takes an absolute command as an override and only checks it is runnable", () => {
-  const deps = { env: { PATH: "" }, platform: "darwin" as const };
+it("prefers vibest's own bundled copy over one on PATH", () => {
+  const resolved = Effect.runSync(
+    resolve(
+      { bundled: () => "/app/node_modules/.bin/codex" },
+      { env: { PATH: "/bin" }, platform: "darwin" },
+      "/app/node_modules/.bin/codex",
+      "/bin/codex",
+    ),
+  );
 
-  expect(resolve("/opt/codex", deps, "/opt/codex")).toBe("/opt/codex");
-  expect(resolve("/opt/missing", deps, "/opt/codex")).toBeUndefined();
+  expect(resolved).toBe("/app/node_modules/.bin/codex");
+});
+
+it("falls through a bundled copy that is not really on disk", () => {
+  // The bundled level is best-effort by contract: it resolves in a source
+  // checkout and misses in a bundle whose module graph lacks the harness.
+  const resolved = Effect.runSync(
+    resolve(
+      { bundled: () => "/app/node_modules/.bin/codex" },
+      { env: { PATH: "/bin" }, platform: "darwin" },
+      "/bin/codex",
+    ),
+  );
+
+  expect(resolved).toBe("/bin/codex");
+});
+
+// The regression this whole change exists for: a systemd unit / launchd app /
+// non-interactive ssh gets a PATH that never saw a login shell, and every
+// bun-, npm- or native-installer-managed CLI lives outside it.
+it("finds a CLI installed outside a stripped PATH", () => {
+  const resolved = Effect.runSync(
+    resolve({}, { env: { PATH: "/usr/bin:/bin" }, platform: "darwin" }, "/home/din/.bun/bin/codex"),
+  );
+
+  expect(resolved).toBe("/home/din/.bun/bin/codex");
+});
+
+it("still lets PATH win over an install directory", () => {
+  const resolved = Effect.runSync(
+    resolve(
+      {},
+      { env: { PATH: "/usr/bin" }, platform: "darwin" },
+      "/usr/bin/codex",
+      "/home/din/.bun/bin/codex",
+    ),
+  );
+
+  expect(resolved).toBe("/usr/bin/codex");
 });
 
 // Paths stay posix-shaped because `node:path` follows the host running the
 // test, not the `platform` we pass in; only the extension probing is under
 // test here, and that is the part `platform` actually drives.
 it("finds the .cmd shim npm installs on Windows, not just .exe", () => {
-  const resolved = resolve("codex", { env: { PATH: "/bin" }, platform: "win32" }, "/bin/codex.cmd");
+  const resolved = Effect.runSync(
+    resolve({}, { env: { PATH: "/bin" }, platform: "win32" }, "/bin/codex.cmd"),
+  );
 
   expect(resolved).toBe("/bin/codex.cmd");
 });
 
-it("reports a missing command as undefined rather than guessing a path", () => {
-  expect(resolve("pi", { env: { PATH: "/usr/bin:/bin" }, platform: "darwin" })).toBeUndefined();
+it("fails with the harness's own remedy when nothing is installed", () => {
+  // The reason travels on the error so the log line, the RPC message and the
+  // greyed-out harness's tooltip are all the same words.
+  const error = Effect.runSync(
+    Effect.flip(resolve({}, { env: { PATH: "/usr/bin:/bin" }, platform: "darwin" })),
+  );
+
+  expect(error._tag).toBe("ExecutableNotFound");
+  expect(error.message).toMatch(/Codex was not found.*VIBEST_CODEX_EXECUTABLE/s);
 });
 
 // A directory carries the same execute bits a binary does, and `spawn` cannot
 // run one — so the mode check alone would report a false hit.
 it("ignores a directory that shares the command's name", () => {
-  const resolved = Effect.runSync(
-    findExecutable("codex", { env: { PATH: "/bin" }, platform: "darwin" }).pipe(
-      Effect.provide(fakeStats({ "/bin/codex": fileInfo("Directory", 0o755) })),
+  const error = Effect.runSync(
+    Effect.flip(
+      resolveHarnessExecutable(spec(), {
+        env: { PATH: "/bin" },
+        platform: "darwin",
+        home: "/home/din",
+      }).pipe(Effect.provide(fakeStats({ "/bin/codex": fileInfo("Directory", 0o755) }))),
     ),
   );
 
-  expect(resolved).toBeUndefined();
+  expect(error._tag).toBe("ExecutableNotFound");
 });

--- a/packages/server/test/harness/executable.test.ts
+++ b/packages/server/test/harness/executable.test.ts
@@ -1,39 +1,26 @@
 import { Effect } from "effect";
 import { expect, it } from "vitest";
 
-import {
-  type HarnessExecutableSpec,
-  type ResolveExecutableDeps,
-  resolveHarnessExecutable,
-} from "../../src/harness/executable";
+import { executableAt, searchInstallDirs } from "../../src/harness/executable";
 import { fakeExecutables, fakeStats, fileInfo } from "../fake-file-system";
 
-// This resolver's result is what the transport spawns — that is the property
-// every test here is really about. It is also what changed: the search used to
-// be PATH-only *because* spawn re-resolved a bare name and would have
-// disagreed with anything found elsewhere. Now the two are the same answer, so
-// the search is allowed to look where a stripped environment's PATH cannot.
-const spec = (over: Partial<HarnessExecutableSpec> = {}): HarnessExecutableSpec => ({
-  harnessAgentId: "codex",
-  binaryName: "codex",
-  override: () => undefined,
-  notFoundReason: "Codex was not found. Install it, or set VIBEST_CODEX_EXECUTABLE.",
-  ...over,
-});
-
-const resolve = (
-  overrides: Partial<HarnessExecutableSpec>,
-  deps: ResolveExecutableDeps,
+// The search primitive every harness's own resolver ends with. Its result is
+// what the transport spawns — that is the property these tests are really
+// about. It is also what changed: the search used to be PATH-only *because*
+// spawn re-resolved a bare name and would have disagreed with anything found
+// elsewhere. Now the two are the same answer, so the search is allowed to look
+// where a stripped environment's PATH cannot.
+const search = (
+  deps: Parameters<typeof searchInstallDirs>[1],
   ...installed: ReadonlyArray<string>
 ) =>
-  resolveHarnessExecutable(spec(overrides), { home: "/home/din", ...deps }).pipe(
+  searchInstallDirs("codex", { home: "/home/din", ...deps }).pipe(
     Effect.provide(fakeExecutables(...installed)),
   );
 
 it("resolves against PATH, in PATH order", () => {
   const resolved = Effect.runSync(
-    resolve(
-      {},
+    search(
       { env: { PATH: "/first:/second" }, platform: "darwin" },
       "/first/codex",
       "/second/codex",
@@ -43,53 +30,12 @@ it("resolves against PATH, in PATH order", () => {
   expect(resolved).toBe("/first/codex");
 });
 
-it("takes an explicit override ahead of everything, without verifying it", () => {
-  // Unverified on purpose: falling back would tell the operator the harness
-  // works while silently running a different binary than the one they named.
-  const resolved = Effect.runSync(
-    resolve(
-      { override: (env) => env["VIBEST_CODEX_EXECUTABLE"] },
-      { env: { VIBEST_CODEX_EXECUTABLE: "/custom/codex", PATH: "/bin" }, platform: "darwin" },
-      "/bin/codex",
-    ),
-  );
-
-  expect(resolved).toBe("/custom/codex");
-});
-
-it("prefers vibest's own bundled copy over one on PATH", () => {
-  const resolved = Effect.runSync(
-    resolve(
-      { bundled: () => "/app/node_modules/.bin/codex" },
-      { env: { PATH: "/bin" }, platform: "darwin" },
-      "/app/node_modules/.bin/codex",
-      "/bin/codex",
-    ),
-  );
-
-  expect(resolved).toBe("/app/node_modules/.bin/codex");
-});
-
-it("falls through a bundled copy that is not really on disk", () => {
-  // The bundled level is best-effort by contract: it resolves in a source
-  // checkout and misses in a bundle whose module graph lacks the harness.
-  const resolved = Effect.runSync(
-    resolve(
-      { bundled: () => "/app/node_modules/.bin/codex" },
-      { env: { PATH: "/bin" }, platform: "darwin" },
-      "/bin/codex",
-    ),
-  );
-
-  expect(resolved).toBe("/bin/codex");
-});
-
 // The regression this whole change exists for: a systemd unit / launchd app /
 // non-interactive ssh gets a PATH that never saw a login shell, and every
 // bun-, npm- or native-installer-managed CLI lives outside it.
 it("finds a CLI installed outside a stripped PATH", () => {
   const resolved = Effect.runSync(
-    resolve({}, { env: { PATH: "/usr/bin:/bin" }, platform: "darwin" }, "/home/din/.bun/bin/codex"),
+    search({ env: { PATH: "/usr/bin:/bin" }, platform: "darwin" }, "/home/din/.bun/bin/codex"),
   );
 
   expect(resolved).toBe("/home/din/.bun/bin/codex");
@@ -97,8 +43,7 @@ it("finds a CLI installed outside a stripped PATH", () => {
 
 it("still lets PATH win over an install directory", () => {
   const resolved = Effect.runSync(
-    resolve(
-      {},
+    search(
       { env: { PATH: "/usr/bin" }, platform: "darwin" },
       "/usr/bin/codex",
       "/home/din/.bun/bin/codex",
@@ -113,35 +58,47 @@ it("still lets PATH win over an install directory", () => {
 // test here, and that is the part `platform` actually drives.
 it("finds the .cmd shim npm installs on Windows, not just .exe", () => {
   const resolved = Effect.runSync(
-    resolve({}, { env: { PATH: "/bin" }, platform: "win32" }, "/bin/codex.cmd"),
+    search({ env: { PATH: "/bin" }, platform: "win32" }, "/bin/codex.cmd"),
   );
 
   expect(resolved).toBe("/bin/codex.cmd");
 });
 
-it("fails with the harness's own remedy when nothing is installed", () => {
-  // The reason travels on the error so the log line, the RPC message and the
-  // greyed-out harness's tooltip are all the same words.
-  const error = Effect.runSync(
-    Effect.flip(resolve({}, { env: { PATH: "/usr/bin:/bin" }, platform: "darwin" })),
-  );
+// `undefined`, not a failure: what to say about "nowhere on this machine" is
+// the calling harness's own wording, and some of them have levels left to try.
+it("reports nothing found rather than failing", () => {
+  const resolved = Effect.runSync(search({ env: { PATH: "/usr/bin:/bin" }, platform: "darwin" }));
 
-  expect(error._tag).toBe("ExecutableNotFound");
-  expect(error.message).toMatch(/Codex was not found.*VIBEST_CODEX_EXECUTABLE/s);
+  expect(resolved).toBeUndefined();
 });
 
 // A directory carries the same execute bits a binary does, and `spawn` cannot
 // run one — so the mode check alone would report a false hit.
 it("ignores a directory that shares the command's name", () => {
-  const error = Effect.runSync(
-    Effect.flip(
-      resolveHarnessExecutable(spec(), {
-        env: { PATH: "/bin" },
-        platform: "darwin",
-        home: "/home/din",
-      }).pipe(Effect.provide(fakeStats({ "/bin/codex": fileInfo("Directory", 0o755) }))),
+  const resolved = Effect.runSync(
+    searchInstallDirs("codex", {
+      env: { PATH: "/bin" },
+      platform: "darwin",
+      home: "/home/din",
+    }).pipe(Effect.provide(fakeStats({ "/bin/codex": fileInfo("Directory", 0o755) }))),
+  );
+
+  expect(resolved).toBeUndefined();
+});
+
+it("verifies a single nominated candidate", () => {
+  // The level a harness nominates itself — a copy inside its own package.
+  const present = Effect.runSync(
+    executableAt("/app/node_modules/.bin/pi", { platform: "darwin" }).pipe(
+      Effect.provide(fakeExecutables("/app/node_modules/.bin/pi")),
+    ),
+  );
+  const absent = Effect.runSync(
+    executableAt("/app/node_modules/.bin/pi", { platform: "darwin" }).pipe(
+      Effect.provide(fakeExecutables()),
     ),
   );
 
-  expect(error._tag).toBe("ExecutableNotFound");
+  expect(present).toBe("/app/node_modules/.bin/pi");
+  expect(absent).toBeUndefined();
 });

--- a/packages/server/test/harness/list.test.ts
+++ b/packages/server/test/harness/list.test.ts
@@ -97,6 +97,7 @@ it.effect("a registry get that misses a listed id dies with the id in the defect
     const broken: HarnessAgentRegistryShape = {
       list: Effect.succeed([{ id: "claude-code", name: "claude-code" }]),
       get: (harnessAgentId) => Effect.fail(new HarnessAgentNotFound({ harnessAgentId })),
+      require: (harnessAgentId) => Effect.fail(new HarnessAgentNotFound({ harnessAgentId })),
     };
 
     const exit = yield* makeHarnessList(broken).list.pipe(

--- a/packages/server/test/harness/list.test.ts
+++ b/packages/server/test/harness/list.test.ts
@@ -26,9 +26,9 @@ const adapter = (over: {
   ),
   permissionModes: ["ask"],
   defaultPermissionMode: "ask",
-  // Listing must never reach for one of these: declaring a model probe
+  // Listing must never reach for one of these: declaring a model catalogue
   // changes nothing about what this call returns.
-  probeModels: () => Effect.die("list must not probe models"),
+  listModels: () => Effect.die("list must not read the model catalogue"),
   open: () => Effect.die("list must not open a session"),
   resume: () => Effect.die("list must not resume a session"),
   getSessionInfo: () => Effect.succeed({ _tag: "unsupported" as const }),

--- a/packages/server/test/harness/list.test.ts
+++ b/packages/server/test/harness/list.test.ts
@@ -19,7 +19,7 @@ const adapter = (over: {
 }): HarnessAgentAdapter => ({
   id: over.id,
   descriptor: { id: over.id, name: over.id },
-  checkAvailability: Effect.succeed(
+  availability: Effect.succeed(
     over.available === false
       ? { available: false, ...(over.reason ? { reason: over.reason } : {}) }
       : { available: true },

--- a/packages/server/test/harness/models.test.ts
+++ b/packages/server/test/harness/models.test.ts
@@ -4,40 +4,40 @@ import { it } from "@effect/vitest";
 import { Cause, Effect, Exit, Ref } from "effect";
 
 import type { HarnessAgentAdapter } from "../../src/harness/adapter";
-import { AgentUnavailable, CapabilityProbeFailed } from "../../src/harness/errors";
-import { makeHarnessProbe } from "../../src/harness/probe";
+import { AgentUnavailable, ModelListFailed } from "../../src/harness/errors";
+import { makeHarnessModels } from "../../src/harness/models";
 import { makeHarnessAgentRegistry } from "../../src/harness/registry";
 import { NodePlatformLayer } from "../platform";
 
 const adapter = (over: {
   id: HarnessAgentAdapter["id"];
-  probeModels?: HarnessAgentAdapter["probeModels"];
+  listModels?: HarnessAgentAdapter["listModels"];
 }): HarnessAgentAdapter => ({
   id: over.id,
   descriptor: { id: over.id, name: over.id },
   availability: Effect.succeed({ available: true }),
   permissionModes: [],
-  ...(over.probeModels ? { probeModels: over.probeModels } : {}),
-  open: () => Effect.die("probe must not open a session"),
-  resume: () => Effect.die("probe must not resume a session"),
+  ...(over.listModels ? { listModels: over.listModels } : {}),
+  open: () => Effect.die("reading models must not open a session"),
+  resume: () => Effect.die("reading models must not resume a session"),
   getSessionInfo: () => Effect.succeed({ _tag: "unsupported" as const }),
 });
 
-/** Records every cwd it is probed with, and yields so callers can actually race. */
-const recordingProbe = (seen: Ref.Ref<ReadonlyArray<string>>) => (cwd: string) =>
+/** Records every cwd it is asked about, and yields so callers can actually race. */
+const recordingList = (seen: Ref.Ref<ReadonlyArray<string>>) => (cwd: string) =>
   Ref.update(seen, (current) => [...current, cwd]).pipe(
     Effect.andThen(Effect.yieldNow),
     Effect.as([{ id: "sonnet", label: "Sonnet" }]),
   );
 
-it.effect("probes the directory it was asked about, grouped under the built-in provider", () =>
+it.effect("answers for the directory it was asked about, grouped under the built-in provider", () =>
   Effect.gen(function* () {
     const seen = yield* Ref.make<ReadonlyArray<string>>([]);
-    const probe = yield* makeHarnessProbe(
-      makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: recordingProbe(seen) })]),
+    const models = yield* makeHarnessModels(
+      makeHarnessAgentRegistry([adapter({ id: "claude-code", listModels: recordingList(seen) })]),
     ).pipe(Effect.provide(NodePlatformLayer));
 
-    const result = yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
+    const result = yield* models.list({ harnessAgentId: "claude-code", cwd: "/work/app" });
 
     assert.deepEqual(yield* Ref.get(seen), ["/work/app"]);
     // Models never leave their provider: the built-in provider carries the
@@ -47,15 +47,15 @@ it.effect("probes the directory it was asked about, grouped under the built-in p
   }),
 );
 
-it.effect("gives concurrent callers one probe, not one each", () =>
+it.effect("gives concurrent callers one CLI spawn, not one each", () =>
   Effect.gen(function* () {
     const seen = yield* Ref.make<ReadonlyArray<string>>([]);
-    const probe = yield* makeHarnessProbe(
-      makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: recordingProbe(seen) })]),
+    const models = yield* makeHarnessModels(
+      makeHarnessAgentRegistry([adapter({ id: "claude-code", listModels: recordingList(seen) })]),
     ).pipe(Effect.provide(NodePlatformLayer));
-    const ask = probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
+    const ask = models.list({ harnessAgentId: "claude-code", cwd: "/work/app" });
 
-    // Two tabs on the same directory, arriving before the first probe settles.
+    // Two tabs on the same directory, arriving before the first answer settles.
     const [first, second] = yield* Effect.all([ask, ask], { concurrency: "unbounded" });
 
     assert.equal((yield* Ref.get(seen)).length, 1);
@@ -64,22 +64,22 @@ it.effect("gives concurrent callers one probe, not one each", () =>
   }),
 );
 
-it.effect("treats two directories as two probes, and does not serialise them", () =>
+it.effect("treats two directories as two questions, and does not serialise them", () =>
   Effect.gen(function* () {
     const seen = yield* Ref.make<ReadonlyArray<string>>([]);
-    const probe = yield* makeHarnessProbe(
-      makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: recordingProbe(seen) })]),
+    const models = yield* makeHarnessModels(
+      makeHarnessAgentRegistry([adapter({ id: "claude-code", listModels: recordingList(seen) })]),
     ).pipe(Effect.provide(NodePlatformLayer));
 
     yield* Effect.all(
       [
-        probe.probe({ harnessAgentId: "claude-code", cwd: "/work/a" }),
-        probe.probe({ harnessAgentId: "claude-code", cwd: "/work/b" }),
+        models.list({ harnessAgentId: "claude-code", cwd: "/work/a" }),
+        models.list({ harnessAgentId: "claude-code", cwd: "/work/b" }),
       ],
       { concurrency: "unbounded" },
     );
 
-    // Both ran; if the registration lock covered the probes, the second would
+    // Both ran; if the registration lock covered the lookups, the second would
     // have queued behind the first rather than interleaving.
     assert.deepEqual(Array.from(yield* Ref.get(seen)).toSorted(), ["/work/a", "/work/b"]);
   }),
@@ -88,13 +88,13 @@ it.effect("treats two directories as two probes, and does not serialise them", (
 it.effect("normalises the directory, so one answer serves its aliases", () =>
   Effect.gen(function* () {
     const seen = yield* Ref.make<ReadonlyArray<string>>([]);
-    const probe = yield* makeHarnessProbe(
-      makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: recordingProbe(seen) })]),
+    const models = yield* makeHarnessModels(
+      makeHarnessAgentRegistry([adapter({ id: "claude-code", listModels: recordingList(seen) })]),
     ).pipe(Effect.provide(NodePlatformLayer));
 
-    yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
-    yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app/" });
-    yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/nested/../app" });
+    yield* models.list({ harnessAgentId: "claude-code", cwd: "/work/app" });
+    yield* models.list({ harnessAgentId: "claude-code", cwd: "/work/app/" });
+    yield* models.list({ harnessAgentId: "claude-code", cwd: "/work/nested/../app" });
 
     assert.equal((yield* Ref.get(seen)).length, 1);
   }),
@@ -109,15 +109,13 @@ it.effect("caches a success but retries a failure", () =>
         Effect.flatMap((n) =>
           n > 1
             ? Effect.succeed([{ id: "sonnet" }])
-            : Effect.fail(
-                new CapabilityProbeFailed({ harnessAgentId: "claude-code", cause: "boom" }),
-              ),
+            : Effect.fail(new ModelListFailed({ harnessAgentId: "claude-code", cause: "boom" })),
         ),
       );
-    const probe = yield* makeHarnessProbe(
-      makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: flaky })]),
+    const models = yield* makeHarnessModels(
+      makeHarnessAgentRegistry([adapter({ id: "claude-code", listModels: flaky })]),
     ).pipe(Effect.provide(NodePlatformLayer));
-    const ask = probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
+    const ask = models.list({ harnessAgentId: "claude-code", cwd: "/work/app" });
 
     // A cached failure would pin "no models" for the whole TTL, so the user
     // would have to wait it out after logging back in.
@@ -131,15 +129,15 @@ it.effect("caches a success but retries a failure", () =>
   }),
 );
 
-it.effect("answers an empty provider list for a harness that has no probe", () =>
+it.effect("answers an empty provider list for a harness with no catalogue", () =>
   Effect.gen(function* () {
-    const probe = yield* makeHarnessProbe(makeHarnessAgentRegistry([adapter({ id: "pi" })])).pipe(
+    const models = yield* makeHarnessModels(makeHarnessAgentRegistry([adapter({ id: "pi" })])).pipe(
       Effect.provide(NodePlatformLayer),
     );
 
     // Not a failure: pi genuinely has no models, and the client renders no
     // picker rather than an error.
-    assert.deepEqual(yield* probe.probe({ harnessAgentId: "pi", cwd: "/work/app" }), {
+    assert.deepEqual(yield* models.list({ harnessAgentId: "pi", cwd: "/work/app" }), {
       providers: [],
     });
   }),
@@ -156,22 +154,22 @@ it.effect("never asks an unavailable harness for its catalogue", () =>
     const uninstalled: HarnessAgentAdapter = {
       ...adapter({
         id: "claude-code",
-        probeModels: () => Ref.set(asked, true).pipe(Effect.as([])),
+        listModels: () => Ref.set(asked, true).pipe(Effect.as([])),
       }),
       availability: Effect.succeed({ available: false, reason: "not on PATH" }),
     };
 
-    const probe = yield* makeHarnessProbe(makeHarnessAgentRegistry([uninstalled])).pipe(
+    const models = yield* makeHarnessModels(makeHarnessAgentRegistry([uninstalled])).pipe(
       Effect.provide(NodePlatformLayer),
     );
 
-    const exit = yield* probe
-      .probe({ harnessAgentId: "claude-code", cwd: "/work/app" })
+    const exit = yield* models
+      .list({ harnessAgentId: "claude-code", cwd: "/work/app" })
       .pipe(Effect.exit);
 
     assert.equal(yield* Ref.get(asked), false);
-    // A typed failure, not a defect: the route maps it to UNSUPPORTED, which
-    // is what keeps "not installed" distinct from "the probe broke".
+    // A typed failure, not a defect: the route maps it to UNSUPPORTED, which is
+    // what keeps "not installed" distinct from "the CLI broke while answering".
     assert.equal(Exit.isFailure(exit) && Cause.hasFails(exit.cause), true);
     assert.equal(Exit.isFailure(exit) && Cause.hasDies(exit.cause), false);
     const error = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;

--- a/packages/server/test/harness/pi/executable.test.ts
+++ b/packages/server/test/harness/pi/executable.test.ts
@@ -1,0 +1,72 @@
+import { Effect } from "effect";
+import { expect, it } from "vitest";
+
+import { resolvePiExecutable, type ResolvePiDeps } from "../../../src/harness/pi/executable";
+import { fakeExecutables } from "../../fake-file-system";
+
+/** No copy in our own node_modules and nothing installed, unless a test says so. */
+const resolve = (overrides: ResolvePiDeps, ...installed: ReadonlyArray<string>) =>
+  resolvePiExecutable({
+    env: {},
+    platform: "darwin",
+    home: "/home/din",
+    bundled: () => undefined,
+    ...overrides,
+  }).pipe(Effect.provide(fakeExecutables(...installed)));
+
+it("takes an explicit override ahead of everything, without verifying it", () => {
+  // Unverified on purpose: falling back would tell the operator the harness
+  // works while silently running a different binary than the one they named.
+  const resolved = Effect.runSync(
+    resolve(
+      {
+        env: { VIBEST_PI_EXECUTABLE: "/custom/pi", PATH: "/bin" },
+        bundled: () => "/app/node_modules/.bin/pi",
+      },
+      "/app/node_modules/.bin/pi",
+      "/bin/pi",
+    ),
+  );
+
+  expect(resolved).toBe("/custom/pi");
+});
+
+// pi is one of our own dependencies, so a working copy sits next to the server
+// whether or not the user ever installed pi — and its version is the one this
+// server's RPC vocabulary was written against.
+it("prefers vibest's own bundled copy over one on PATH", () => {
+  const resolved = Effect.runSync(
+    resolve(
+      { env: { PATH: "/bin" }, bundled: () => "/app/node_modules/.bin/pi" },
+      "/app/node_modules/.bin/pi",
+      "/bin/pi",
+    ),
+  );
+
+  expect(resolved).toBe("/app/node_modules/.bin/pi");
+});
+
+it("falls through a bundled copy that is not really on disk", () => {
+  // Nominating is best-effort: it resolves in a source checkout and misses in
+  // a bundle whose module graph never reached pi.
+  const resolved = Effect.runSync(
+    resolve({ env: { PATH: "/bin" }, bundled: () => "/app/node_modules/.bin/pi" }, "/bin/pi"),
+  );
+
+  expect(resolved).toBe("/bin/pi");
+});
+
+it("finds a user install outside a stripped PATH", () => {
+  const resolved = Effect.runSync(
+    resolve({ env: { PATH: "/usr/bin:/bin" } }, "/home/din/.local/bin/pi"),
+  );
+
+  expect(resolved).toBe("/home/din/.local/bin/pi");
+});
+
+it("fails with its own remedy when nothing is installed", () => {
+  const error = Effect.runSync(Effect.flip(resolve({ env: { PATH: "/usr/bin:/bin" } })));
+
+  expect(error._tag).toBe("ExecutableNotFound");
+  expect(error.message).toMatch(/Pi was not found.*VIBEST_PI_EXECUTABLE/s);
+});

--- a/packages/server/test/harness/probe.test.ts
+++ b/packages/server/test/harness/probe.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 
 import { it } from "@effect/vitest";
-import { Effect, Ref } from "effect";
+import { Cause, Effect, Exit, Ref } from "effect";
 
 import type { HarnessAgentAdapter } from "../../src/harness/adapter";
-import { CapabilityProbeFailed } from "../../src/harness/errors";
+import { AgentUnavailable, CapabilityProbeFailed } from "../../src/harness/errors";
 import { makeHarnessProbe } from "../../src/harness/probe";
 import { makeHarnessAgentRegistry } from "../../src/harness/registry";
+import { NodePlatformLayer } from "../platform";
 
 const adapter = (over: {
   id: HarnessAgentAdapter["id"];
@@ -34,7 +35,7 @@ it.effect("probes the directory it was asked about, grouped under the built-in p
     const seen = yield* Ref.make<ReadonlyArray<string>>([]);
     const probe = yield* makeHarnessProbe(
       makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: recordingProbe(seen) })]),
-    );
+    ).pipe(Effect.provide(NodePlatformLayer));
 
     const result = yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
 
@@ -51,7 +52,7 @@ it.effect("gives concurrent callers one probe, not one each", () =>
     const seen = yield* Ref.make<ReadonlyArray<string>>([]);
     const probe = yield* makeHarnessProbe(
       makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: recordingProbe(seen) })]),
-    );
+    ).pipe(Effect.provide(NodePlatformLayer));
     const ask = probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
 
     // Two tabs on the same directory, arriving before the first probe settles.
@@ -68,7 +69,7 @@ it.effect("treats two directories as two probes, and does not serialise them", (
     const seen = yield* Ref.make<ReadonlyArray<string>>([]);
     const probe = yield* makeHarnessProbe(
       makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: recordingProbe(seen) })]),
-    );
+    ).pipe(Effect.provide(NodePlatformLayer));
 
     yield* Effect.all(
       [
@@ -89,7 +90,7 @@ it.effect("normalises the directory, so one answer serves its aliases", () =>
     const seen = yield* Ref.make<ReadonlyArray<string>>([]);
     const probe = yield* makeHarnessProbe(
       makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: recordingProbe(seen) })]),
-    );
+    ).pipe(Effect.provide(NodePlatformLayer));
 
     yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
     yield* probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app/" });
@@ -115,7 +116,7 @@ it.effect("caches a success but retries a failure", () =>
       );
     const probe = yield* makeHarnessProbe(
       makeHarnessAgentRegistry([adapter({ id: "claude-code", probeModels: flaky })]),
-    );
+    ).pipe(Effect.provide(NodePlatformLayer));
     const ask = probe.probe({ harnessAgentId: "claude-code", cwd: "/work/app" });
 
     // A cached failure would pin "no models" for the whole TTL, so the user
@@ -132,12 +133,48 @@ it.effect("caches a success but retries a failure", () =>
 
 it.effect("answers an empty provider list for a harness that has no probe", () =>
   Effect.gen(function* () {
-    const probe = yield* makeHarnessProbe(makeHarnessAgentRegistry([adapter({ id: "pi" })]));
+    const probe = yield* makeHarnessProbe(makeHarnessAgentRegistry([adapter({ id: "pi" })])).pipe(
+      Effect.provide(NodePlatformLayer),
+    );
 
     // Not a failure: pi genuinely has no models, and the client renders no
     // picker rather than an error.
     assert.deepEqual(yield* probe.probe({ harnessAgentId: "pi", cwd: "/work/app" }), {
       providers: [],
     });
+  }),
+);
+
+it.effect("never asks an unavailable harness for its catalogue", () =>
+  Effect.gen(function* () {
+    // The bug this gate exists for: with the CLI absent, `list` correctly
+    // reported the harness greyed out while this path walked into the adapter
+    // anyway and hit its missing binary — which claude-code answers with a
+    // defect, not a failure, taking the whole endpoint down every few seconds
+    // instead of degrading the one harness.
+    const asked = yield* Ref.make(false);
+    const uninstalled: HarnessAgentAdapter = {
+      ...adapter({
+        id: "claude-code",
+        probeModels: () => Ref.set(asked, true).pipe(Effect.as([])),
+      }),
+      checkAvailability: Effect.succeed({ available: false, reason: "not on PATH" }),
+    };
+
+    const probe = yield* makeHarnessProbe(makeHarnessAgentRegistry([uninstalled])).pipe(
+      Effect.provide(NodePlatformLayer),
+    );
+
+    const exit = yield* probe
+      .probe({ harnessAgentId: "claude-code", cwd: "/work/app" })
+      .pipe(Effect.exit);
+
+    assert.equal(yield* Ref.get(asked), false);
+    // A typed failure, not a defect: the route maps it to UNSUPPORTED, which
+    // is what keeps "not installed" distinct from "the probe broke".
+    assert.equal(Exit.isFailure(exit) && Cause.hasFails(exit.cause), true);
+    assert.equal(Exit.isFailure(exit) && Cause.hasDies(exit.cause), false);
+    const error = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;
+    assert.ok(error instanceof AgentUnavailable && error.reason === "not on PATH");
   }),
 );

--- a/packages/server/test/harness/probe.test.ts
+++ b/packages/server/test/harness/probe.test.ts
@@ -15,7 +15,7 @@ const adapter = (over: {
 }): HarnessAgentAdapter => ({
   id: over.id,
   descriptor: { id: over.id, name: over.id },
-  checkAvailability: Effect.succeed({ available: true }),
+  availability: Effect.succeed({ available: true }),
   permissionModes: [],
   ...(over.probeModels ? { probeModels: over.probeModels } : {}),
   open: () => Effect.die("probe must not open a session"),
@@ -158,7 +158,7 @@ it.effect("never asks an unavailable harness for its catalogue", () =>
         id: "claude-code",
         probeModels: () => Ref.set(asked, true).pipe(Effect.as([])),
       }),
-      checkAvailability: Effect.succeed({ available: false, reason: "not on PATH" }),
+      availability: Effect.succeed({ available: false, reason: "not on PATH" }),
     };
 
     const probe = yield* makeHarnessProbe(makeHarnessAgentRegistry([uninstalled])).pipe(

--- a/packages/server/test/harness/registry.test.ts
+++ b/packages/server/test/harness/registry.test.ts
@@ -9,7 +9,7 @@ import { makeHarnessAgentRegistry } from "../../src/harness/registry";
 const claude = {
   id: "claude-code",
   descriptor: { id: "claude-code", name: "Claude Code" },
-  checkAvailability: Effect.succeed({ available: true }),
+  availability: Effect.succeed({ available: true }),
   permissionModes: [],
   getSessionInfo: () => Effect.succeed({ _tag: "unsupported" as const }),
   open: () => Effect.die("not used"),

--- a/packages/server/test/harness/session-manager.test.ts
+++ b/packages/server/test/harness/session-manager.test.ts
@@ -108,7 +108,7 @@ const makeFixture = Effect.gen(function* () {
   const adapter = {
     id: "claude-code",
     descriptor: { id: "claude-code", name: "Claude Code" },
-    checkAvailability: Effect.succeed({ available: true }),
+    availability: Effect.succeed({ available: true }),
     permissionModes: [],
     open: () => makeRuntime("created-session"),
     resume: ({ sessionId }) =>

--- a/packages/server/test/harness/session-manager.test.ts
+++ b/packages/server/test/harness/session-manager.test.ts
@@ -138,7 +138,7 @@ const makeFixture = Effect.gen(function* () {
 
 type Fixture = Effect.Success<typeof makeFixture>;
 
-/** Liveness probe: `get` succeeds while a session has a runtime, fails once torn down. */
+/** Liveness check: `get` succeeds while a session has a runtime, fails once torn down. */
 const isActive = (fixture: Fixture, ref: SessionRef) =>
   fixture.manager.get(ref).pipe(Effect.exit, Effect.map(Exit.isSuccess));
 

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -166,6 +166,7 @@ describe("HarnessAgentSessionService", () => {
                 repo,
                 bus,
                 newSessionId: crypto.randomUUIDv4.pipe(Effect.orDie),
+                platform: yield* Effect.context<FileSystem.FileSystem>(),
               });
               return { service, repo, bus, spy, restart: build };
             });

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -129,7 +129,7 @@ describe("HarnessAgentSessionService", () => {
           const adapter = {
             id: "claude-code",
             descriptor: { id: "claude-code", name: "Claude Code" },
-            checkAvailability: Effect.sync(() =>
+            availability: Effect.sync(() =>
               opts.unavailable !== undefined
                 ? { available: false, reason: opts.unavailable }
                 : { available: true },

--- a/packages/server/test/rpc-harness.test.ts
+++ b/packages/server/test/rpc-harness.test.ts
@@ -20,7 +20,7 @@ const fakeAdapter = (over: {
 }): HarnessAgentAdapter => ({
   id: over.id,
   descriptor: { id: over.id, name: over.name },
-  checkAvailability: Effect.succeed(
+  availability: Effect.succeed(
     over.reason
       ? { available: over.available, reason: over.reason }
       : { available: over.available },

--- a/packages/server/test/rpc-harness.ts
+++ b/packages/server/test/rpc-harness.ts
@@ -9,7 +9,7 @@ import {
   HarnessAgentSessionManagerLayer,
   HarnessAgentSessionServiceLayer,
   HarnessListLayer,
-  HarnessProbeLayer,
+  HarnessModelsLayer,
   makeHarnessAgentRegistry,
   type HarnessAgentAdapter,
 } from "../src/harness";
@@ -49,7 +49,7 @@ export async function makeRpcTestHarness(
     Layer.provide(registryLayer),
     Layer.provide(NodePlatformLayer),
   );
-  const probeLayer = HarnessProbeLayer.pipe(
+  const modelsLayer = HarnessModelsLayer.pipe(
     Layer.provide(registryLayer),
     Layer.provide(NodePlatformLayer),
   );
@@ -61,7 +61,7 @@ export async function makeRpcTestHarness(
       projectLayer,
       registryLayer,
       listLayer,
-      probeLayer,
+      modelsLayer,
       FileSystemServiceLayer.pipe(Layer.provide(NodePlatformLayer)),
       NodePlatformLayer,
     ),

--- a/packages/server/test/rpc-harness.ts
+++ b/packages/server/test/rpc-harness.ts
@@ -49,7 +49,10 @@ export async function makeRpcTestHarness(
     Layer.provide(registryLayer),
     Layer.provide(NodePlatformLayer),
   );
-  const probeLayer = HarnessProbeLayer.pipe(Layer.provide(registryLayer));
+  const probeLayer = HarnessProbeLayer.pipe(
+    Layer.provide(registryLayer),
+    Layer.provide(NodePlatformLayer),
+  );
   const projectLayer = ProjectModuleLayer.pipe(Layer.provide(paths));
   const runtime = ManagedRuntime.make(
     Layer.mergeAll(

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -59,7 +59,7 @@ async function setup() {
   // Paths plus the platform services the repositories' JSON store runs on.
   const pathsLayer = Layer.provideMerge(layerPaths(home), NodeServices.layer);
 
-  // Handed to the agent alone: the adapter's checkAvailability now answers off
+  // Handed to the agent alone: the adapter's availability now answers off
   // the agent's own resolve, so `session.create`'s gate sees this fake without
   // the path being passed twice.
   const executablePath = makeFake();

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -59,9 +59,9 @@ async function setup() {
   // Paths plus the platform services the repositories' JSON store runs on.
   const pathsLayer = Layer.provideMerge(layerPaths(home), NodeServices.layer);
 
-  // The fake path goes to the adapter too: `session.create` gates on
-  // checkAvailability, which is a PATH lookup — without the override the test
-  // silently depends on a real codex install.
+  // Handed to the agent alone: the adapter's checkAvailability now answers off
+  // the agent's own resolve, so `session.create`'s gate sees this fake without
+  // the path being passed twice.
   const executablePath = makeFake();
   const codexLayer = Layer.effect(Codex, makeCodexAgent({ executablePath })).pipe(
     Layer.provide(NodeServices.layer),
@@ -70,7 +70,7 @@ async function setup() {
     HarnessAgentRegistry,
     Effect.gen(function* () {
       const codex = yield* Codex;
-      return makeHarnessAgentRegistry([makeCodexAdapter(codex, { executablePath })]);
+      return makeHarnessAgentRegistry([makeCodexAdapter(codex)]);
     }),
   ).pipe(Layer.provide(codexLayer));
 
@@ -100,7 +100,7 @@ async function setup() {
     projectServiceLayer,
     registryLayer,
     HarnessListLayer.pipe(Layer.provide(registryLayer), Layer.provide(NodeServices.layer)),
-    HarnessProbeLayer.pipe(Layer.provide(registryLayer)),
+    HarnessProbeLayer.pipe(Layer.provide(registryLayer), Layer.provide(NodeServices.layer)),
     FileSystemServiceLayer.pipe(Layer.provide(NodeServices.layer)),
     NodeServices.layer,
   );

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -15,7 +15,7 @@ import {
   HarnessAgentSessionManagerLayer,
   HarnessAgentSessionServiceLayer,
   HarnessListLayer,
-  HarnessProbeLayer,
+  HarnessModelsLayer,
   makeHarnessAgentRegistry,
 } from "../src/harness";
 import { makeCodexAdapter, makeCodexAgent } from "../src/harness/codex";
@@ -100,7 +100,7 @@ async function setup() {
     projectServiceLayer,
     registryLayer,
     HarnessListLayer.pipe(Layer.provide(registryLayer), Layer.provide(NodeServices.layer)),
-    HarnessProbeLayer.pipe(Layer.provide(registryLayer), Layer.provide(NodeServices.layer)),
+    HarnessModelsLayer.pipe(Layer.provide(registryLayer), Layer.provide(NodeServices.layer)),
     FileSystemServiceLayer.pipe(Layer.provide(NodeServices.layer)),
     NodeServices.layer,
   );

--- a/packages/server/test/rpc/cache-availability.test.ts
+++ b/packages/server/test/rpc/cache-availability.test.ts
@@ -14,7 +14,7 @@ const unusedAdapter = {
   open: () => Effect.die("unused"),
   resume: () => Effect.die("unused"),
   getSessionInfo: () => Effect.die("unused"),
-} satisfies Omit<HarnessAgentAdapter, "checkAvailability">;
+} satisfies Omit<HarnessAgentAdapter, "availability">;
 
 describe("cacheAvailability", () => {
   layer(NodeFileSystem.layer)((it) => {
@@ -29,7 +29,7 @@ describe("cacheAvailability", () => {
         let runs = 0;
         const adapter: HarnessAgentAdapter = {
           ...unusedAdapter,
-          checkAvailability: Effect.suspend(() => {
+          availability: Effect.suspend(() => {
             runs += 1;
             return Deferred.succeed(started, undefined).pipe(
               Effect.andThen(Deferred.await(gate)),
@@ -39,7 +39,7 @@ describe("cacheAvailability", () => {
         };
         const cached = yield* cacheAvailability(adapter);
 
-        const caller = yield* Effect.forkChild(cached.checkAvailability);
+        const caller = yield* Effect.forkChild(cached.availability);
         yield* Deferred.await(started);
         // Interrupt while the check is in flight; the guard makes the fiber
         // ride out the interruption, so awaiting it needs the gate open.
@@ -47,7 +47,7 @@ describe("cacheAvailability", () => {
         yield* Deferred.succeed(gate, undefined);
         yield* Fiber.await(interruptor);
 
-        const result = yield* cached.checkAvailability;
+        const result = yield* cached.availability;
         assert.deepEqual(result, { available: true });
         // The healthy exit came from the cache, not a rerun.
         assert.equal(runs, 1);

--- a/packages/vibest/package.json
+++ b/packages/vibest/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "catalog:",
+    "@earendil-works/pi-coding-agent": "0.80.7",
     "@effect/platform-node": "catalog:",
     "@orpc/contract": "catalog:orpc",
     "@orpc/server": "catalog:orpc",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,6 +633,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 'catalog:'
         version: 0.3.220(@anthropic-ai/sdk@0.111.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.80.7
+        version: 0.80.7(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.21.1)(zod@4.4.3)
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.11.1(supports-color@10.2.2))


### PR DESCRIPTION
On a server deployment all three harnesses reported "not installed" while their binaries sat on disk. Three separate causes, one shape: **the search for a harness's CLI was neither shared nor trusted.**

The report came from a real box — a systemd unit with `PATH` pinned to the system default. `codex` was in `~/.bun/bin`, `pi` was in our own `node_modules/.bin`, and a version-matched `claude` was in the SDK's platform package. None were found. The model-list endpoint then crashed every 2–4 seconds, which is why it read as "completely broken" rather than "one harness greyed out".

## 1. Gate the model-list path

Availability was the caller's homework. `harness.list` and `session.create` did it; the model-list path did not — and nothing in `registry.get`'s type said an unchecked adapter was a mistake.

So an uninstalled harness answered `list` *correctly* (greyed out, with a reason) while that route walked into the adapter and hit claude-code's

```
invariant: the claude executable vanished after the availability check gated on it
```

That invariant was **false from the day it was written**: this path never passed the gate it named. Being a `die` and not a failure, `CapabilityProbeFailed`'s error channel could not catch it, and the route had **no `catchTags` at all** — so it surfaced as an unhandled internal error, on repeat.

- `registry.require()` is now the single gate — "is it registered" and "is its CLI installed" are one question to every caller who is about to *use* a harness. `get()` stays for the two who must see unusable harnesses: `list`, and permission-vocabulary validation.
- `readHistory`'s cold-read path had the same hole; it goes through the gate too.
- The defect becomes a typed failure. Both call sites already carried `ClaudeSdkError`, so this changed no outward type.
- The route now maps not-installed to `UNSUPPORTED` (settled — the client greys it out) and a broken probe to `INTERNAL` (retryable).

`HarnessProbeLayer` now requires `FileSystem`. It did not before — which is *structurally* why it could skip the gate: that path had no capacity to check.

## 2. Search once, and spawn what was found

`checkAvailability` resolved a path and threw it away. The transport then spawned a bare name and let the OS resolve it *again*, under different rules.

That disagreement is what forced the search to be PATH-only ("anything found elsewhere would report available and then ENOENT" — the old comment was right, given the shape). claude-code was the exception that proves it: its resolver already searched `~/.bun/bin` and friends **because** its result was handed to the SDK. Same machine, same directory, one harness found its binary and the other didn't.

Now: agents hold one cached resolve, transports spawn that absolute path, and adapters answer availability off the same effect. "Available" and "what runs" are physically the same answer, so the search is free to look where a login shell's `PATH` points and a systemd unit's does not.

The old `findExecutable` became dead code and is deleted. Its test asserting `does not look outside PATH, because spawn will not either` is rewritten — that constraint is what this PR removes, deliberately. The replacement invariant is documented at the top of `executable.ts`: **never widen this search without the result reaching spawn.**

## 3. Look inside our own dependencies

- **claude-code**: the two-hop SDK resolution existed for exactly this and **never once fired**. The platform package is an optionalDependency *of the SDK*, so under pnpm's strict layout it is invisible from the harness module — `require.resolve` threw `MODULE_NOT_FOUND` in every checkout and every install silently fell through to PATH. Resolving the SDK's entry first, then asking *from there*, puts it back in view.
- **pi**: ships as our own dependency and nothing looked there at all. Found via the `node_modules/.bin` shim — pi's `exports` are `import`-only so CJS resolve throws `ERR_PACKAGE_PATH_NOT_EXPORTED`, and its `bin` points at a `dist/cli.js` with no guaranteed execute bit.

`packages/vibest` now declares pi as its own dependency, as it already does for the Claude SDK: without it this level resolves in a source checkout and goes **silently quiet in the shipped CLI**, passing every test either way. Two literal pins, one version — noted in `.agents/rules/toolchain.md`.

## Verification

Built CLI, `PATH` stripped to the system default (the failing unit's exact value):

```
claude-code  AVAILABLE   probe OK, 5 models
codex        AVAILABLE   probe OK, 16 models
pi           AVAILABLE   probe OK, 0 providers   (no model catalogue by design)
```

Before this change, all three reported not-installed under that PATH. Each is found at a different level — claude-code in-package, codex via a fallback directory, pi via its shim.

`pnpm check` 10/10; workspace tests 590 passed. New regression tests: an unavailable harness is **never** asked for its catalogue (asserting `probeModels` is not called, and that the failure is typed, not a defect); plus the four search levels, precedence between them, and the stripped-PATH case.

## Notes for review

- No ADR: `docs/adr/` records cross-module architectural decisions, and this is a module-internal one. The reversed constraint, why it existed, and what replaces it are written into `executable.ts`'s header instead.
- `VIBEST_CODEX_EXECUTABLE` / `VIBEST_PI_EXECUTABLE` now exist, matching claude-code's escape hatch. Neither had one.
- `pnpm-lock.yaml` moves because of the `packages/vibest` dependency above.