### PR TITLE
fix(app): sit the sidebar scrollbar on the seam with the main inset

### DIFF
--- a/apps/app/src/components/layout/app-sidebar.tsx
+++ b/apps/app/src/components/layout/app-sidebar.tsx
@@ -21,7 +21,19 @@ export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
   const { os } = usePlatform();
 
   return (
-    <Sidebar variant="inset" collapsible="offcanvas" className="md:p-1.5">
+    <Sidebar
+      variant="inset"
+      collapsible="offcanvas"
+      /*
+       * Two nudges that put the scrollbar on the seam with the inset. The
+       * scrollbar's own `m-1` sat it 4px inside the sidebar card, so it read as
+       * floating over the list rather than marking its edge — drop the inline
+       * margin, keep the block one. `pe-0` then closes the gutter this side of
+       * the inset (which already carries `ms-0`), so the panel runs right up to
+       * the main card instead of leaving a 6px strip between them.
+       */
+      className="md:p-1.5 md:pe-0 [&_[data-slot=scroll-area-scrollbar][data-orientation=vertical]]:mx-0"
+    >
       {/*
        * Reserves the traffic-light / pinned-toggle row (see __root.tsx). On
        * macOS the row belongs to the native traffic lights; everywhere else it

--- a/apps/app/src/components/layout/app-sidebar.tsx
+++ b/apps/app/src/components/layout/app-sidebar.tsx
@@ -24,14 +24,8 @@ export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
     <Sidebar
       variant="inset"
       collapsible="offcanvas"
-      /*
-       * Two nudges that put the scrollbar on the seam with the inset. The
-       * scrollbar's own `m-1` sat it 4px inside the sidebar card, so it read as
-       * floating over the list rather than marking its edge — drop the inline
-       * margin, keep the block one. `pe-0` then closes the gutter this side of
-       * the inset (which already carries `ms-0`), so the panel runs right up to
-       * the main card instead of leaving a 6px strip between them.
-       */
+      // `pe-0` closes the gutter to the inset (which already has `ms-0`), and
+      // `mx-0` undoes the scrollbar's own `m-1`, so both land on one seam.
       className="md:p-1.5 md:pe-0 [&_[data-slot=scroll-area-scrollbar][data-orientation=vertical]]:mx-0"
     >
       {/*


### PR DESCRIPTION
The sidebar's vertical scrollbar sat 10px away from the main inset — far enough
that it read as floating over the session list instead of marking its edge.

Two separate gaps were in play:

| source | value |
| --- | --- |
| `ScrollBar`'s own `m-1` (`packages/ui/src/components/scroll-area.tsx`) | 4px |
| the sidebar card's `md:p-1.5` gutter to the inset | 6px |

`packages/ui/src/components/*` is registry-vendored and gets discarded on the
next `--overwrite` refresh, so the scrollbar margin is overridden from the app
side rather than edited in place.

## Change

```
md:p-1.5 md:pe-0 [&_[data-slot=scroll-area-scrollbar][data-orientation=vertical]]:mx-0
```

- `mx-0` on the vertical scrollbar drops the inline margin (the block one
  stays), parking it on the sidebar card's right edge.
- `md:pe-0` closes the gutter on that side. `SidebarInset` already carries
  `ms-0`, so those 6px were entirely the sidebar's padding; the panel now runs
  up to the main card.

Measured in the browser afterwards: scrollbar right edge / sidebar panel right
edge / inset left edge all land on 256.

## Checks

- Collapsed state is unaffected — `__root.tsx`'s
  `peer-data-[state=collapsed]:ms-1.5` still gives the main card its 6px left
  margin (measured `mainLeft = 6` after toggling).
- The seam looks clean: under `variant="inset"` the sidebar panel has no radius
  or border of its own, so the white `rounded-xl` main card simply floats on the
  grey panel — no colliding corners.
- oxlint (`--deny-warnings`), oxfmt, `turbo run typecheck --filter=@vibest/app`.
