### PR TITLE
fix(app): drop a Chat from the manager once its session closes

### DIFF
--- a/apps/app/src/features/chat/runtime/chat-manager.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-manager.test.ts
@@ -1,0 +1,92 @@
+import type { PermissionMode, ReasoningEffort, SessionRef } from "@vibest/contract";
+import { describe, expect, it } from "vitest";
+
+import type { AgentResponse } from "./agent-requests";
+import { ChatManager } from "./chat-manager";
+import type { ChatSessionTransport, ChatTransportEvent } from "./chat-transport-port";
+
+const refFor = (sessionId: string): SessionRef => ({
+  projectId: "project-1",
+  harnessAgentId: "claude-code",
+  sessionId,
+});
+
+class FakeTransport implements ChatSessionTransport {
+  onEvent: ((event: ChatTransportEvent) => void) | null = null;
+  disposed = 0;
+
+  subscribe(onEvent: (event: ChatTransportEvent) => void): () => void {
+    this.onEvent = onEvent;
+    return () => {
+      this.disposed += 1;
+    };
+  }
+  prompt = async () => ({ turnId: "turn-receipt" });
+  getMessages = async () => null;
+  respondToAgentRequest = async (_requestId: string, _response: AgentResponse) => {};
+  setModel = async (_providerId: string, _modelId: string) => {};
+  setReasoningEffort = async (_effort: ReasoningEffort) => {};
+  setPermissionMode = async (_mode: PermissionMode) => {};
+}
+
+const makeManager = () => {
+  const transports: FakeTransport[] = [];
+  const manager = new ChatManager(() => {
+    const transport = new FakeTransport();
+    transports.push(transport);
+    return transport;
+  });
+  return { manager, transports };
+};
+
+describe("ChatManager", () => {
+  it("hands out one Chat per session across calls", () => {
+    const { manager, transports } = makeManager();
+    const first = manager.chatFor(refFor("session-1"));
+    expect(manager.chatFor(refFor("session-1"))).toBe(first);
+    expect(manager.chatFor(refFor("session-2"))).not.toBe(first);
+    expect(transports).toHaveLength(2);
+  });
+
+  it("evicts and unsubscribes a Chat once the session closes", () => {
+    const { manager, transports } = makeManager();
+    const chat = manager.chatFor(refFor("session-1"));
+    const transport = transports[0];
+
+    transport?.onEvent?.({ type: "closed", reason: "session_closed" });
+
+    expect(transport?.disposed).toBe(1);
+    // The evicted instance keeps its terminal state for whoever is still
+    // rendering it — eviction only stops it being handed out again.
+    expect(chat.store.getState().error?.message).toBe("Session closed");
+  });
+
+  it("builds a fresh Chat when a closed session is opened again", () => {
+    const { manager, transports } = makeManager();
+    const closed = manager.chatFor(refFor("session-1"));
+    transports[0]?.onEvent?.({ type: "closed", reason: "session_closed" });
+
+    // What a restore looks like from here: the terminated instance is gone,
+    // so the session gets a new Chat on its own new subscription rather than
+    // the permanently-terminated one.
+    const reopened = manager.chatFor(refFor("session-1"));
+    expect(reopened).not.toBe(closed);
+    expect(transports).toHaveLength(2);
+    expect(reopened.store.getState().error).toBeUndefined();
+  });
+
+  it("evicts once even if the stream closes twice", () => {
+    const { manager, transports } = makeManager();
+    manager.chatFor(refFor("session-1"));
+    const first = transports[0];
+    first?.onEvent?.({ type: "closed", reason: "session_closed" });
+    const reopened = manager.chatFor(refFor("session-1"));
+
+    // A late duplicate from the dead subscription must not take the
+    // replacement down with it.
+    first?.onEvent?.({ type: "closed", reason: "session_deleted" });
+
+    expect(manager.chatFor(refFor("session-1"))).toBe(reopened);
+    expect(transports[1]?.disposed).toBe(0);
+  });
+});

--- a/apps/app/src/features/chat/runtime/chat-manager.ts
+++ b/apps/app/src/features/chat/runtime/chat-manager.ts
@@ -11,9 +11,10 @@ export interface ChatManagerApi {
 
 // Owns the live Chat instances keyed by the session's uuid. Sessions survive
 // route switches: chatFor() is get-or-create, and nothing disposes a Chat on
-// navigation — its store keeps the transcript for the next mount. Each Chat
-// gets its own transport, minted from the injected factory and bound to its
-// SessionRef; the manager knows nothing about oRPC or the wire client.
+// navigation — its store keeps the transcript for the next mount. The one
+// exception is eviction below. Each Chat gets its own transport, minted from
+// the injected factory and bound to its SessionRef; the manager knows nothing
+// about oRPC or the wire client.
 // Constructed once when the shared App mounts, not at module scope: a
 // module-level `new` cannot see the host connection the entry supplied.
 export class ChatManager implements ChatManagerApi {
@@ -31,8 +32,27 @@ export class ChatManager implements ChatManagerApi {
     const chat = new Chat({
       sessionRef,
       transport: this.createTransport(sessionRef),
+      onTerminated: () => this.#evict(sessionRef.sessionId),
     });
     this.#chats.set(sessionRef.sessionId, chat);
     return chat;
+  }
+
+  // The server declared the stream over (archived, deleted — the Chat doesn't
+  // distinguish, and neither does this). Drop the cache entry and release the
+  // subscription; the store itself is left alone, because whoever is rendering
+  // this session right now still holds the instance and needs its terminal
+  // error on screen. That view keeps working, the transcript is collected once
+  // it unmounts, and a session restored later gets a Chat built from scratch —
+  // which is also what un-sticks `#terminated`, a flag nothing ever clears.
+  //
+  // Safe to look the entry up rather than compare identities: `closed` reaches
+  // a Chat only from inside the subscription's async loop, so the `set` below
+  // has always run by the time this fires.
+  #evict(sessionId: string): void {
+    const chat = this.#chats.get(sessionId);
+    if (!chat) return;
+    this.#chats.delete(sessionId);
+    chat.dispose();
   }
 }

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -64,9 +64,9 @@ class FakeTransport implements ChatSessionTransport {
   setPermissionMode = async (_mode: PermissionMode) => {};
 }
 
-const makeChat = () => {
+const makeChat = (options?: { onTerminated?: () => void }) => {
   const transport = new FakeTransport();
-  const chat = new Chat({ sessionRef: ref, transport });
+  const chat = new Chat({ sessionRef: ref, transport, onTerminated: options?.onTerminated });
   const emit = (event: ChatTransportEvent) => transport.onEvent?.(event);
   const attach = async (snapshot: Partial<SessionRuntimeSnapshot>) => {
     emit({
@@ -790,6 +790,18 @@ describe("Chat lifecycle", () => {
     emit({ type: "closed", reason: "session_closed" });
     expect(chat.store.getState().status).toBe("error");
     expect(chat.store.getState().error?.message).toBe("Session closed");
+  });
+
+  it("hands the owner a one-shot termination signal", async () => {
+    let terminations = 0;
+    const { emit, attach } = makeChat({ onTerminated: () => (terminations += 1) });
+    await attach({});
+
+    emit({ type: "closed", reason: "session_closed" });
+    // A duplicate from the same dead stream is still one termination: the
+    // owner has already released this Chat by then.
+    emit({ type: "closed", reason: "session_deleted" });
+    expect(terminations).toBe(1);
   });
 
   it("dispose tears down the subscription and folds", async () => {

--- a/apps/app/src/features/chat/runtime/chat.ts
+++ b/apps/app/src/features/chat/runtime/chat.ts
@@ -20,6 +20,13 @@ import { sanitizeTail } from "./sanitize-tail";
 export interface ChatInit {
   sessionRef: SessionRef;
   transport: ChatSessionTransport;
+  /**
+   * Fired once, when the server declares this session's stream over for good
+   * (closed or deleted). The owner's cue to stop caching this Chat — the
+   * instance stays usable for whoever is currently rendering it, showing the
+   * terminal error, and is simply never handed out again.
+   */
+  onTerminated?: () => void;
 }
 
 // Runtime phase → AI-SDK chat status. "submitted" is a sender-local optimistic
@@ -75,6 +82,7 @@ export class Chat {
   readonly store: StoreApi<ChatStoreState>;
   readonly #state: ChatState;
   readonly #transport: ChatSessionTransport;
+  readonly #onTerminated: (() => void) | undefined;
   readonly #unsubscribe: () => void;
   readonly #turnFolds = new Map<string, TurnFold>();
   // Turns whose live rendering was abandoned (buffer truncated, replay gap):
@@ -106,11 +114,12 @@ export class Chat {
   // over it.
   #terminated = false;
 
-  constructor({ sessionRef, transport }: ChatInit) {
+  constructor({ sessionRef, transport, onTerminated }: ChatInit) {
     this.harnessAgentId = sessionRef.harnessAgentId;
     this.#state = new ChatState();
     this.store = this.#state.store;
     this.#transport = transport;
+    this.#onTerminated = onTerminated;
     this.#unsubscribe = transport.subscribe((event) => {
       if (event.type === "attached") this.#hydrate(event.snapshot);
       else if (event.type === "closed") this.#terminate(event.reason);
@@ -210,6 +219,10 @@ export class Chat {
   // so the runtime is gone and prompting or answering could only fail. Enter
   // the same terminal shape a crash does, with the reason on the error.
   #terminate(reason: "session_closed" | "session_deleted"): void {
+    // A second `closed` would re-enter with the same terminal shape, but
+    // `onTerminated` is a one-shot handover — its owner may already have let
+    // this instance go.
+    if (this.#terminated) return;
     this.#terminated = true;
     for (const fold of this.#turnFolds.values()) fold.close();
     this.#turnFolds.clear();
@@ -222,6 +235,7 @@ export class Chat {
       reason === "session_deleted" ? "Session deleted" : "Session closed",
     );
     this.#setStatus("error");
+    this.#onTerminated?.();
   }
 
   // ---------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Archiving (or deleting) a session ends its stream server-side — `session-service.ts` publishes `closeSession(ref, "session_closed")` — and the renderer's `Chat` folds that into its terminal state. But `ChatManager` kept caching the instance:

- the subscription and the whole transcript stayed reachable for the life of the tab
- reopening the session handed back the same permanently-terminated `Chat`: red **"Session closed"**, dead composer
- `#terminated` is never reset, so nothing un-stuck it

## Fix

`Chat` already knows the exact moment — `#terminate()`. It now reports it through a one-shot `onTerminated` callback, and `ChatManager` evicts on that: drop the map entry, `dispose()` the subscription.

Using `#terminate` as the seam means one exit covers archive, delete, and any terminal reason the server adds later, in **every** client rather than only the tab that drove the change. Wiring this into `SessionActionsMenu.onSuccess` would have needed one line per action and missed other tabs; wiring it into `useSessionListSync` would have crossed the "features never import each other" boundary and introduced a second source of truth beside the `closed` event the Chat already receives.

The store is deliberately **not** cleared. Whoever is rendering the session still holds the instance and needs its terminal error on screen; eviction only stops the `Chat` being handed out again, and the transcript is collected when that view unmounts. A session reopened later gets a `Chat` built from scratch — which is also what un-sticks `#terminated`.

## Verification

Unit — 5 new tests (`chat-manager.test.ts` + one in `chat.test.ts`): one instance per session, eviction + unsubscribe on `closed`, a fresh instance on reopen, and one-shot semantics so a duplicate `closed` from the dead stream can't take the replacement down.

Runtime — drove the app against an isolated `VIBEST_HOME`, archiving a session from the route that was viewing it and navigating back in-app:

- **without the fix** — the stale instance rendered, "Session closed" in red, composer broken
- **with the fix** — full transcript, working composer, no error

`pnpm turbo run test typecheck --filter=@vibest/app` green; `lint:check` clean.