### PR TITLE
feat(app): add a registry-driven content panel beside the chat

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,3 +59,29 @@ _Avoid_: widget, element
 **Coss registry**:
 The upstream shadcn-style component registry at `coss.com/ui` (the `@coss` namespace in `components.json`). It is the source of truth for base components. It is a rolling "latest" — items carry no version or date, so "the latest version" means whatever the registry serves now.
 _Avoid_: coss/ui (repo shorthand)
+
+## Content Panel
+
+The column beside the chat, in `apps/app/src/components/layout/content-panel/`.
+_Avoid_: right panel, right sidebar, aux panel — "right" is a position, and the
+left one is already the **sidebar**.
+
+**ContentPanel**:
+The host: one app-wide instance (`apps/app/src/content-panel.ts`) owning the registry, the per-session tab lists, and every live panel instance. Its zustand store holds only what the UI re-renders on _and_ what survives a reload — everything else lives on the instances. Knows no panel type.
+_Avoid_: panel manager, panel store
+
+**Panel type**:
+The string a definition registers under (`terminal`, `file`, …). Registration is open: `HarnessAgentIdSchema`-style whitelists have no counterpart here, and an unregistered type in persisted state is skipped, not dropped.
+_Avoid_: panel kind, panel variant
+
+**PanelDefinition**:
+What `definePanel` / `definePanelFamily` produce — the type, how to label it, how to parse its persisted payload, optionally how to build its instance, and its view. A **singleton** has no `key` (one panel, id = type); a **family** has one (id = `type:key(payload)`), and that is the _only_ thing that differs between them.
+_Avoid_: PanelSpec, panel config, panel registration
+
+**PanelHandle / PanelInstance**:
+The handle is what every panel gets: id, sessionId, live `payload`, and `activate` / `close` / `setPayload` / `reopen`. A definition's `create` returns _extra_ members, which the host prototype-links onto the handle to make the **instance**. Instance state is live and unpersisted (a scrollback, a spinner); it outlives navigation and dies on `close`, never on unmount. Materialized lazily — the tab strip draws a restored tab without one, so reopening ten tabs spawns nothing until each is rendered.
+_Avoid_: panel object, panel controller
+
+**Tab strip**:
+The host's row of open panels — the only place a tab is drawn. A panel that wants several of something opens several panels rather than growing tabs of its own.
+_Avoid_: inner tabs, sub-tabs, splits

--- a/apps/app/src/components/layout/content-panel/core/content-panel.test.ts
+++ b/apps/app/src/components/layout/content-panel/core/content-panel.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+
+import { ContentPanel } from "./content-panel";
+import { definePanel, definePanelFamily, type PanelHandle } from "./panel";
+
+const diff = definePanel({ type: "diff", label: "Diff", view: null });
+
+const file = definePanelFamily({
+  type: "file",
+  key: (payload: { path: string }) => payload.path,
+  label: (payload) => payload.path,
+  parse: (raw) =>
+    typeof raw === "object" && raw !== null && typeof (raw as { path?: unknown }).path === "string"
+      ? { path: (raw as { path: string }).path }
+      : null,
+  view: null,
+});
+
+const S = "session-1";
+
+const snapshotOf = (host: ContentPanel<null>, sessionId: string | null = S) =>
+  host.snapshot(host.store.getState(), sessionId);
+
+const withPanels = (...definitions: Parameters<ContentPanel<null>["register"]>[0][]) => {
+  const host = new ContentPanel<null>();
+  for (const definition of definitions) host.register(definition);
+  return host;
+};
+
+/** A read-only `Storage` standing in for a reload with these panels persisted. */
+const storageHolding = (bySessionId: unknown): Storage => {
+  const value = JSON.stringify({ state: { bySessionId }, version: 1 });
+  return {
+    length: 1,
+    getItem: (key) => (key === "vibest:content-panel" ? value : null),
+    setItem: () => {},
+    removeItem: () => {},
+    clear: () => {},
+    key: () => null,
+  };
+};
+
+describe("ContentPanel", () => {
+  it("opens a singleton and docks the panel", () => {
+    const host = withPanels(diff);
+    host.open(S, diff);
+
+    const snapshot = snapshotOf(host);
+    expect(snapshot.presentation).toBe("docked");
+    expect(snapshot.panels.map((panel) => panel.id)).toEqual(["diff"]);
+    expect(snapshot.active?.id).toBe("diff");
+  });
+
+  it("reopening a singleton lands on the same panel", () => {
+    const host = withPanels(diff);
+    const first = host.open(S, diff);
+    const second = host.open(S, diff);
+
+    expect(second).toBe(first);
+    expect(snapshotOf(host).panels).toHaveLength(1);
+  });
+
+  it("gives a family one panel per key", () => {
+    const host = withPanels(file);
+    host.open(S, file, { path: "a.ts" });
+    host.open(S, file, { path: "b.ts" });
+
+    expect(snapshotOf(host).panels.map((panel) => panel.id)).toEqual(["file:a.ts", "file:b.ts"]);
+  });
+
+  it("reopening a family member reuses its instance and tells it so", () => {
+    const reopened: unknown[] = [];
+    const tracked = definePanelFamily({
+      type: "tracked",
+      key: (payload: { path: string; line?: number }) => payload.path,
+      label: (payload) => payload.path,
+      create: () => ({ reopen: (payload: unknown) => void reopened.push(payload) }),
+      view: null,
+    });
+    const host = withPanels(tracked);
+
+    const first = host.open(S, tracked, { path: "a.ts" });
+    const second = host.open(S, tracked, { path: "a.ts", line: 12 });
+
+    expect(second).toBe(first);
+    expect(reopened).toEqual([{ path: "a.ts", line: 12 }]);
+    // The payload is written before `reopen` fires, so the handle already sees it.
+    expect(first.payload).toEqual({ path: "a.ts", line: 12 });
+  });
+
+  it("closing the active panel lands on its neighbour", () => {
+    const host = withPanels(file);
+    host.open(S, file, { path: "a.ts" });
+    host.open(S, file, { path: "b.ts" });
+    host.open(S, file, { path: "c.ts" });
+    host.activate(S, "file:b.ts");
+
+    host.close(S, "file:b.ts");
+
+    expect(snapshotOf(host).active?.id).toBe("file:c.ts");
+  });
+
+  it("closing the last panel hides the container", () => {
+    const host = withPanels(diff);
+    host.open(S, diff);
+
+    host.close(S, "diff");
+
+    const snapshot = snapshotOf(host);
+    expect(snapshot.presentation).toBe("hidden");
+    expect(snapshot.active).toBeNull();
+  });
+
+  it("closing disposes the instance", () => {
+    let disposed = 0;
+    const disposable = definePanel({
+      type: "disposable",
+      label: "Disposable",
+      create: () => ({ dispose: () => void disposed++ }),
+      view: null,
+    });
+    const host = withPanels(disposable);
+    host.open(S, disposable);
+
+    host.close(S, "disposable");
+
+    expect(disposed).toBe(1);
+  });
+
+  it("toggling visibility keeps the panels and their instances", () => {
+    const host = withPanels(diff);
+    const instance = host.open(S, diff);
+
+    host.toggleVisibility(S);
+    expect(snapshotOf(host).presentation).toBe("hidden");
+
+    host.toggleVisibility(S);
+    expect(snapshotOf(host).presentation).toBe("docked");
+    expect(snapshotOf(host).panels).toHaveLength(1);
+    expect(host.instanceFor(S, "diff")).toBe(instance);
+  });
+
+  it("opens a fresh member by type, and shrugs at an unknown one", () => {
+    let next = 0;
+    const numbered = definePanelFamily({
+      type: "numbered",
+      key: (payload: { n: number }) => String(payload.n),
+      label: (payload) => `#${payload.n}`,
+      title: "Numbered",
+      newPayload: () => ({ n: ++next }),
+      view: null,
+    });
+    const host = withPanels(numbered);
+
+    host.openNew(S, "numbered");
+    host.openNew(S, "numbered");
+    expect(snapshotOf(host).panels.map((panel) => panel.id)).toEqual(["numbered:1", "numbered:2"]);
+
+    // A keyboard map or link handler can name a panel that is not registered
+    // here; that is a no-op, not a throw.
+    host.openNew(S, "nope");
+    expect(snapshotOf(host).panels).toHaveLength(2);
+  });
+
+  it("names a menu entry without ever calling a family's label", () => {
+    const host = withPanels(diff, file);
+
+    // `file` is a family with no `newPayload`, so it can only be opened from
+    // elsewhere; `diff`'s title came from its constant label, and nothing had to
+    // call `label(undefined)` to find it.
+    expect(snapshotOf(host).openable.map((entry) => entry.title)).toEqual(["Diff"]);
+  });
+
+  it("registers a batch in one registry bump", () => {
+    const host = new ContentPanel<null>();
+    const before = host.store.getState().registryVersion;
+
+    const retract = host.registerAll([diff, file]);
+    expect(host.store.getState().registryVersion).toBe(before + 1);
+    host.open(S, diff);
+    expect(snapshotOf(host).panels).toHaveLength(1);
+
+    retract();
+    expect(host.store.getState().registryVersion).toBe(before + 2);
+    expect(snapshotOf(host).panels).toHaveLength(0);
+  });
+
+  it("keeps an unregistered panel's record and resolves it once it registers", () => {
+    const host = new ContentPanel<null>();
+    host.register(file);
+    host.open(S, file, { path: "a.ts" });
+
+    const unregister = host.register(diff);
+    host.open(S, diff);
+    expect(snapshotOf(host).panels).toHaveLength(2);
+
+    // A panel going away — code split not loaded, capability withdrawn — must
+    // not delete what the user had open.
+    unregister();
+    expect(snapshotOf(host).panels.map((panel) => panel.id)).toEqual(["file:a.ts"]);
+
+    host.register(diff);
+    expect(snapshotOf(host).panels.map((panel) => panel.id)).toEqual(["file:a.ts", "diff"]);
+  });
+
+  it("hides a panel whose stored payload no longer parses", () => {
+    const host = withPanels(file);
+    host.open(S, file, { path: "a.ts" });
+    // Simulate a payload shape that has moved on since it was written.
+    (host.instanceFor(S, "file:a.ts") as PanelHandle<unknown>).setPayload({ oldPath: "a.ts" });
+
+    expect(snapshotOf(host).panels).toHaveLength(0);
+  });
+
+  it("keeps each derived collection identical until its own inputs change", () => {
+    const host = withPanels(diff, file);
+    host.open(S, diff);
+    host.open(S, file, { path: "a.ts" });
+    const { panels, openable } = snapshotOf(host);
+
+    expect(snapshotOf(host).panels).toBe(panels);
+    expect(snapshotOf(host).openable).toBe(openable);
+
+    // A tab click and a resize replace the session object but not its records.
+    // If the strip were rebuilt here, every click would re-render the subtree.
+    host.activate(S, "diff");
+    host.setPresentation(S, "maximized");
+    expect(snapshotOf(host).panels).toBe(panels);
+    expect(snapshotOf(host).openable).toBe(openable);
+
+    // Opening one does change the records — but not the registry, so the menu
+    // is left alone.
+    host.open(S, file, { path: "b.ts" });
+    expect(snapshotOf(host).panels).not.toBe(panels);
+    expect(snapshotOf(host).openable).toBe(openable);
+
+    host.register(definePanel({ type: "other", label: "Other", view: null }));
+    expect(snapshotOf(host).openable).not.toBe(openable);
+  });
+
+  it("materializes a restored panel's instance only when it is read", () => {
+    let created = 0;
+    const counted = definePanelFamily({
+      type: "counted",
+      key: (payload: { n: number }) => String(payload.n),
+      label: (payload) => `#${payload.n}`,
+      create: () => ({ ordinal: ++created }),
+      view: null,
+    });
+    const host = new ContentPanel<null>({
+      storage: storageHolding({
+        [S]: {
+          presentation: "docked",
+          activeId: "counted:1",
+          panels: [
+            { id: "counted:1", type: "counted", payload: { n: 1 } },
+            { id: "counted:2", type: "counted", payload: { n: 2 } },
+          ],
+        },
+      }),
+    });
+    host.register(counted);
+
+    const snapshot = snapshotOf(host);
+    // Both tabs are drawn, and neither panel exists yet: a reload with ten tabs
+    // open must not spawn ten of whatever they own.
+    expect(snapshot.panels.map((panel) => panel.label)).toEqual(["#1", "#2"]);
+    expect(created).toBe(0);
+
+    expect(snapshot.active?.instance).toBeDefined();
+    expect(created).toBe(1);
+  });
+
+  it("scopes panels per session", () => {
+    const host = withPanels(diff);
+    host.open(S, diff);
+    host.open("session-2", diff);
+    host.close("session-2", "diff");
+
+    expect(snapshotOf(host).panels).toHaveLength(1);
+    expect(snapshotOf(host, "session-2").panels).toHaveLength(0);
+  });
+
+  it("forget drops a session and disposes its instances", () => {
+    let disposed = 0;
+    const disposable = definePanel({
+      type: "disposable",
+      label: "Disposable",
+      create: () => ({ dispose: () => void disposed++ }),
+      view: null,
+    });
+    const host = withPanels(disposable);
+    host.open(S, disposable);
+
+    host.forget(S);
+
+    expect(disposed).toBe(1);
+    expect(snapshotOf(host).panels).toHaveLength(0);
+    expect(host.instanceFor(S, "disposable")).toBeUndefined();
+  });
+
+  it("no session means no panels", () => {
+    const host = withPanels(diff);
+    host.open(S, diff);
+
+    expect(snapshotOf(host, null).panels).toHaveLength(0);
+  });
+
+  it("a duplicate registration's unregister does not retract the one that replaced it", () => {
+    const host = new ContentPanel<null>();
+    const retractFirst = host.register(diff);
+    host.register(diff);
+
+    retractFirst();
+
+    host.open(S, diff);
+    expect(snapshotOf(host).panels).toHaveLength(1);
+  });
+});

--- a/apps/app/src/components/layout/content-panel/core/content-panel.ts
+++ b/apps/app/src/components/layout/content-panel/core/content-panel.ts
@@ -1,0 +1,440 @@
+import { createJSONStorage, persist } from "zustand/middleware";
+import { createStore, type StoreApi } from "zustand/vanilla";
+
+import {
+  type AnyPanelDefinition,
+  type PanelDefinition,
+  type PanelHandle,
+  type PanelInstance,
+  panelId,
+  type PayloadArgs,
+} from "./panel";
+
+export type PanelPresentation = "hidden" | "docked" | "maximized";
+
+/** What survives a reload: enough to rebuild the tab strip, and nothing else. */
+interface PanelRecord {
+  readonly id: string;
+  readonly type: string;
+  readonly payload: unknown;
+}
+
+interface SessionPanels {
+  readonly presentation: PanelPresentation;
+  readonly activeId: string | null;
+  readonly panels: readonly PanelRecord[];
+}
+
+/**
+ * Only what the UI must re-render on — which here is also exactly what is
+ * worth persisting. Everything else a panel owns lives on its instance, so a
+ * panel loading its content never re-renders the tab strip.
+ */
+export interface ContentPanelState {
+  readonly bySessionId: Readonly<Record<string, SessionPanels>>;
+  /**
+   * Definitions live in the host's Map: they carry components, they are not UI
+   * state. This counter is the only part of the registry the UI reacts to, and
+   * it is what makes a late-registering panel's tab appear.
+   */
+  readonly registryVersion: number;
+}
+
+type PersistedState = Pick<ContentPanelState, "bySessionId">;
+
+export interface OpenPanel<View> {
+  readonly id: string;
+  readonly label: string;
+  readonly view: View;
+  /**
+   * Lazy on purpose: reading it is what materializes the panel, and only the
+   * one being rendered ever does. Restoring ten tabs must not spawn ten of
+   * whatever they own. A getter, so nobody may spread this object.
+   */
+  readonly instance: PanelHandle<unknown>;
+}
+
+/** A registered panel a "+" menu can offer. Registry-derived, so session-free. */
+export interface OpenablePanel<View> {
+  readonly type: string;
+  readonly title: string;
+  readonly view: View;
+}
+
+export interface PanelSnapshot<View> {
+  readonly presentation: PanelPresentation;
+  /**
+   * Resolved panels only. A record whose type is not registered *yet*, or
+   * whose payload no longer parses, stays in storage but never surfaces — so a
+   * code-split or conditionally registered panel restores itself when it
+   * arrives instead of having been dropped at hydration.
+   */
+  readonly panels: readonly OpenPanel<View>[];
+  readonly active: OpenPanel<View> | null;
+  readonly openable: readonly OpenablePanel<View>[];
+}
+
+export interface ContentPanelOptions {
+  /** Omit to keep everything in memory — the default in tests. */
+  readonly storage?: Storage;
+}
+
+const EMPTY_SESSION: SessionPanels = { presentation: "hidden", activeId: null, panels: [] };
+/** Shared so an empty strip is `Object.is`-stable without costing a cache entry. */
+const NO_PANELS: readonly never[] = [];
+
+// NUL occurs in neither half, so the two never collide and `forget` can match a
+// session by prefix. A panel id may well contain a space; a separator may not.
+const instanceKey = (sessionId: string, id: string): string => `${sessionId}\0${id}`;
+
+/**
+ * The global instance: it owns the registry, the live panel instances, and a
+ * small zustand store for the reactive slice. Mirrors `ChatManager` — instances
+ * are cached and outlive navigation, and nothing here is torn down by a route
+ * change.
+ */
+export class ContentPanel<View = unknown> {
+  readonly store: StoreApi<ContentPanelState>;
+
+  readonly #definitions = new Map<string, AnyPanelDefinition<View>>();
+  /** Identifies *which* registration a given unregister belongs to; see `#put`. */
+  readonly #tokens = new Map<string, symbol>();
+  readonly #instances = new Map<string, PanelHandle<unknown>>();
+  /**
+   * The two derivations `snapshot` must keep reference-stable, cached against
+   * exactly what each depends on. Splitting them is what makes a tab click —
+   * which replaces the session object but not its `panels` array — free.
+   */
+  readonly #tabs = new Map<
+    string,
+    { records: readonly PanelRecord[]; registryVersion: number; panels: readonly OpenPanel<View>[] }
+  >();
+  #openable: { registryVersion: number; entries: readonly OpenablePanel<View>[] } | null = null;
+
+  constructor(options: ContentPanelOptions = {}) {
+    const initial: ContentPanelState = { bySessionId: {}, registryVersion: 0 };
+    const { storage } = options;
+    this.store = storage
+      ? createStore<ContentPanelState>()(
+          persist<ContentPanelState, [], [], PersistedState>(() => initial, {
+            name: "vibest:content-panel",
+            version: 1,
+            storage: createJSONStorage(() => storage),
+            partialize: (state) => ({ bySessionId: state.bySessionId }),
+          }),
+        )
+      : createStore<ContentPanelState>(() => initial);
+  }
+
+  register(definition: AnyPanelDefinition<View>): () => void {
+    const retract = this.#put(definition);
+    this.#bumpRegistry();
+    return () => {
+      retract();
+      this.#bumpRegistry();
+    };
+  }
+
+  /**
+   * A batch, in one bump. Registering four panels one at a time would discard
+   * every derived tab list four times before the first paint.
+   */
+  registerAll(definitions: readonly AnyPanelDefinition<View>[]): () => void {
+    const retractions = definitions.map((definition) => this.#put(definition));
+    this.#bumpRegistry();
+    return () => {
+      for (const retract of retractions) retract();
+      this.#bumpRegistry();
+    };
+  }
+
+  /**
+   * Idempotent: an id already open is activated and handed the new payload
+   * (then told via `reopen`) rather than duplicated. Returns the live instance.
+   */
+  open<Type extends string, Payload, Extra extends object>(
+    sessionId: string,
+    definition: PanelDefinition<Type, Payload, Extra, View>,
+    ...payloadArgs: PayloadArgs<Payload>
+  ): PanelInstance<Payload, Extra> {
+    return this.#openWith(
+      sessionId,
+      definition as AnyPanelDefinition<View>,
+      payloadArgs[0],
+    ) as PanelInstance<Payload, Extra>;
+  }
+
+  /**
+   * Open a fresh member of a registered type — what a "+" menu entry does. By
+   * type rather than by definition so `openable` stays plain data, shareable
+   * across sessions instead of one bound closure per session per definition.
+   */
+  openNew(sessionId: string, type: string): void {
+    const definition = this.#definitions.get(type);
+    if (!definition) return;
+    this.#openWith(sessionId, definition, definition.newPayload?.());
+  }
+
+  activate(sessionId: string, id: string): void {
+    const session = this.#sessionOf(sessionId);
+    if (!session.panels.some((panel) => panel.id === id)) return;
+    this.#writeSession(sessionId, {
+      ...session,
+      presentation: session.presentation === "hidden" ? "docked" : session.presentation,
+      activeId: id,
+    });
+  }
+
+  /**
+   * The low-level door. `instance.close()` comes through here, and it is also
+   * how an unresolved record left over from a retired panel type gets purged.
+   */
+  close(sessionId: string, id: string): void {
+    const session = this.#sessionOf(sessionId);
+    const index = session.panels.findIndex((panel) => panel.id === id);
+    if (index < 0) return;
+    this.#disposeInstance(sessionId, id);
+    const panels = session.panels.filter((panel) => panel.id !== id);
+    // Closing the active tab lands on its neighbour, the way an editor does.
+    const fallback = panels[Math.min(index, panels.length - 1)] ?? null;
+    this.#writeSession(sessionId, {
+      presentation: panels.length === 0 ? "hidden" : session.presentation,
+      activeId: session.activeId === id ? (fallback?.id ?? null) : session.activeId,
+      panels,
+    });
+  }
+
+  setPresentation(sessionId: string, presentation: PanelPresentation): void {
+    const session = this.#sessionOf(sessionId);
+    if (session.presentation === presentation) return;
+    this.#writeSession(sessionId, { ...session, presentation });
+  }
+
+  /** Hidden → docked, anything else → hidden. */
+  toggleVisibility(sessionId: string): void {
+    const { presentation } = this.#sessionOf(sessionId);
+    this.setPresentation(sessionId, presentation === "hidden" ? "docked" : "hidden");
+  }
+
+  /**
+   * Drops a session's panels and disposes their instances — for a deleted
+   * session. No caller yet: nothing in the app hard-deletes a session, and
+   * archiving is reversible, so forgetting there would lose a user's tabs.
+   */
+  forget(sessionId: string): void {
+    const prefix = `${sessionId}\0`;
+    for (const [key, instance] of this.#instances) {
+      if (!key.startsWith(prefix)) continue;
+      instance.dispose?.();
+      this.#instances.delete(key);
+    }
+    this.#tabs.delete(sessionId);
+    this.store.setState((state) => {
+      if (!(sessionId in state.bySessionId)) return state;
+      const { [sessionId]: _removed, ...rest } = state.bySessionId;
+      return { bySessionId: rest };
+    });
+  }
+
+  /** The test seam: asserts on instance lifetime without going through a render. */
+  instanceFor(sessionId: string, id: string): PanelHandle<unknown> | undefined {
+    return this.#instances.get(instanceKey(sessionId, id));
+  }
+
+  /**
+   * Derives the render-ready view. The two collection-valued fields come from
+   * caches keyed on their own inputs, so an unchanged input returns the
+   * identical array — which is what lets `useStore` decide, by `Object.is`, not
+   * to re-render. Select fields off this; the wrapper itself is cheap and fresh.
+   */
+  snapshot(state: ContentPanelState, sessionId: string | null): PanelSnapshot<View> {
+    const openable = this.#openableFor(state.registryVersion);
+    if (sessionId === null) {
+      return { presentation: "hidden", panels: NO_PANELS, active: null, openable };
+    }
+    const session = state.bySessionId[sessionId] ?? EMPTY_SESSION;
+    const panels = this.#tabsFor(sessionId, session.panels, state.registryVersion);
+    return {
+      presentation: session.presentation,
+      panels,
+      active: panels.find((panel) => panel.id === session.activeId) ?? null,
+      openable,
+    };
+  }
+
+  #tabsFor(
+    sessionId: string,
+    records: readonly PanelRecord[],
+    registryVersion: number,
+  ): readonly OpenPanel<View>[] {
+    // Sessions merely visited never reach the cache, so it stays the size of
+    // what the user actually opened.
+    if (records.length === 0) return NO_PANELS;
+    const cached = this.#tabs.get(sessionId);
+    if (cached && cached.records === records && cached.registryVersion === registryVersion) {
+      return cached.panels;
+    }
+    const panels: OpenPanel<View>[] = [];
+    for (const record of records) {
+      const definition = this.#definitions.get(record.type);
+      if (!definition) continue;
+      const payload = definition.parse ? definition.parse(record.payload) : record.payload;
+      if (payload === null) continue;
+      // Arrow, so `this` is the host without aliasing it into the literal.
+      const materialize = () => this.#ensureInstance(sessionId, record.id, definition);
+      panels.push({
+        id: record.id,
+        label: definition.label(payload),
+        view: definition.view,
+        get instance(): PanelHandle<unknown> {
+          return materialize();
+        },
+      });
+    }
+    this.#tabs.set(sessionId, { records, registryVersion, panels });
+    return panels;
+  }
+
+  #openableFor(registryVersion: number): readonly OpenablePanel<View>[] {
+    if (this.#openable?.registryVersion === registryVersion) return this.#openable.entries;
+    const entries: OpenablePanel<View>[] = [];
+    for (const definition of this.#definitions.values()) {
+      // A family with no `newPayload` can only be opened from elsewhere.
+      if (definition.key && !definition.newPayload) continue;
+      // Never `label(undefined)`: a family's label reads its payload, so the
+      // fallback would throw. `definePanel` fills `title` in for singletons.
+      entries.push({
+        type: definition.type,
+        title: definition.title ?? definition.type,
+        view: definition.view,
+      });
+    }
+    this.#openable = { registryVersion, entries };
+    return entries;
+  }
+
+  /**
+   * The payload-erased body of `open`. Split out because the public signature's
+   * variadic payload can't be forwarded once `Payload` is `any`: the tuple
+   * conditional collapses to a union and the spread stops type-checking.
+   */
+  #openWith(
+    sessionId: string,
+    definition: AnyPanelDefinition<View>,
+    payload: unknown,
+  ): PanelHandle<unknown> {
+    const id = panelId(definition, payload);
+    const session = this.#sessionOf(sessionId);
+    const isOpen = session.panels.some((panel) => panel.id === id);
+    this.#writeSession(sessionId, {
+      presentation: session.presentation === "hidden" ? "docked" : session.presentation,
+      activeId: id,
+      panels: isOpen
+        ? session.panels.map((panel) => (panel.id === id ? { ...panel, payload } : panel))
+        : [...session.panels, { id, type: definition.type, payload }],
+    });
+    const instance = this.#ensureInstance(sessionId, id, definition);
+    // The payload is written first, so `reopen` sees it on the handle too.
+    if (isOpen) instance.reopen(payload);
+    return instance;
+  }
+
+  #put(definition: AnyPanelDefinition<View>): () => void {
+    const token = Symbol(definition.type);
+    if (import.meta.env.DEV && this.#definitions.has(definition.type)) {
+      console.warn(
+        `[content-panel] panel type "${definition.type}" registered twice; the later one wins.`,
+      );
+    }
+    this.#definitions.set(definition.type, definition);
+    this.#tokens.set(definition.type, token);
+    return () => {
+      // StrictMode remounts as register → unregister → register. Retract only
+      // our own registration, never the one that has already replaced it.
+      if (this.#tokens.get(definition.type) !== token) return;
+      this.#definitions.delete(definition.type);
+      this.#tokens.delete(definition.type);
+    };
+  }
+
+  #bumpRegistry(): void {
+    this.store.setState((state) => ({ registryVersion: state.registryVersion + 1 }));
+  }
+
+  #sessionOf(sessionId: string): SessionPanels {
+    return this.store.getState().bySessionId[sessionId] ?? EMPTY_SESSION;
+  }
+
+  #writeSession(sessionId: string, session: SessionPanels): void {
+    this.store.setState((state) => ({
+      bySessionId: { ...state.bySessionId, [sessionId]: session },
+    }));
+  }
+
+  #setPayload(sessionId: string, id: string, next: unknown): void {
+    const session = this.#sessionOf(sessionId);
+    this.#writeSession(sessionId, {
+      ...session,
+      panels: session.panels.map((panel) =>
+        panel.id === id
+          ? {
+              ...panel,
+              // A payload that is itself callable can't be set functionally;
+              // no panel has one, and the updater form is worth more.
+              payload:
+                typeof next === "function"
+                  ? (next as (p: unknown) => unknown)(panel.payload)
+                  : next,
+            }
+          : panel,
+      ),
+    });
+  }
+
+  #disposeInstance(sessionId: string, id: string): void {
+    const key = instanceKey(sessionId, id);
+    this.#instances.get(key)?.dispose?.();
+    this.#instances.delete(key);
+  }
+
+  /**
+   * Get-or-create, like `ChatManager.chatFor`. Reached through `OpenPanel`'s
+   * lazy `instance`, so a panel restored from storage gets its instance the
+   * moment it is rendered — and not before.
+   */
+  #ensureInstance(
+    sessionId: string,
+    id: string,
+    definition: AnyPanelDefinition<View>,
+  ): PanelHandle<unknown> {
+    const key = instanceKey(sessionId, id);
+    const existing = this.#instances.get(key);
+    if (existing) return existing;
+    const handle = this.#createHandle(sessionId, id);
+    // Prototype-linked, not spread: `payload` is an accessor on the handle, and
+    // copying it would freeze the value it had the moment the panel opened.
+    const instance: PanelHandle<unknown> = definition.create
+      ? Object.assign(Object.create(handle) as PanelHandle<unknown>, definition.create(handle))
+      : handle;
+    this.#instances.set(key, instance);
+    return instance;
+  }
+
+  #createHandle(sessionId: string, id: string): PanelHandle<unknown> {
+    // Arrows throughout: they close over `this` lexically, so the getter below
+    // can reach the host without aliasing it.
+    const payloadOf = (): unknown =>
+      this.#sessionOf(sessionId).panels.find((panel) => panel.id === id)?.payload;
+    return {
+      id,
+      sessionId,
+      get payload(): unknown {
+        return payloadOf();
+      },
+      activate: () => this.activate(sessionId, id),
+      close: () => this.close(sessionId, id),
+      setPayload: (next) => this.#setPayload(sessionId, id, next),
+      reopen: () => {},
+    };
+  }
+}

--- a/apps/app/src/components/layout/content-panel/core/panel.ts
+++ b/apps/app/src/components/layout/content-panel/core/panel.ts
@@ -1,0 +1,150 @@
+/**
+ * The panel vocabulary. Zero React on purpose: everything here is data or a
+ * pure function, so the workspace model in `content-panel.ts` can be driven
+ * from a plain synchronous test with no renderer.
+ */
+
+/**
+ * What a panel gets when it is opened: its identity plus the operations every
+ * panel needs. Instances are cached by the host and survive navigation, so
+ * `payload` is a getter that reads through to the store rather than a value
+ * captured at construction — a held handle never goes stale. It is a snapshot
+ * read, not a subscription; a panel that must re-render when its own payload
+ * changes selects it through `usePanelSnapshot`.
+ *
+ * A panel needing more than this (its own store, a subscription, a disposer)
+ * supplies `create`, which returns only the *extra* members; the host links
+ * them onto the handle. Deliberately not "return the whole instance": the
+ * obvious way to write that is `{ ...handle, extra }`, and spreading flattens
+ * the `payload` getter into a stale snapshot without a word.
+ */
+export interface PanelHandle<Payload> {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly payload: Payload;
+  activate(): void;
+  close(): void;
+  setPayload(next: Payload | ((current: Payload) => Payload)): void;
+  /**
+   * Called when an already-open panel is opened again; the new payload has
+   * already been written by then. The default handle does nothing — override
+   * in `create` to reveal a line, steal focus, or refetch.
+   */
+  reopen(payload: Payload): void;
+  /** Called once, when the panel is really closed. The default handle has none. */
+  dispose?(): void;
+}
+
+/** What a definition's `create` adds on top of the handle. */
+export type PanelInstance<Payload, Extra> = PanelHandle<Payload> & Extra;
+
+export interface PanelDefinition<
+  Type extends string,
+  Payload,
+  Extra extends object = object,
+  View = unknown,
+> {
+  readonly type: Type;
+  /**
+   * Present = a family: one panel per distinct key, id is `${type}:${key}`.
+   * Absent = a singleton: the id *is* the type, so opening it twice lands on
+   * the same panel. Nothing else in the system branches on singleton-vs-family
+   * — it is only this id function, which is why adding either costs the same.
+   */
+  readonly key?: (payload: Payload) => string;
+  /** Per-instance, so a family's tab reads "foo.ts" rather than "File". */
+  readonly label: (payload: Payload) => string;
+  /**
+   * The panel's own name, for menus. A family needs it because `label` speaks
+   * for one member; a singleton falls back to its constant label.
+   */
+  readonly title?: string;
+  /**
+   * How to mint a fresh member. Its presence is what puts the panel in the "+"
+   * menu — a family that can only be opened from elsewhere (a file needs a
+   * path) simply omits it. Singletons are offerable without one.
+   */
+  readonly newPayload?: () => Payload;
+  /**
+   * Validates a payload read back from storage. Returning null keeps the
+   * record but leaves the panel unresolved, so a payload shape can evolve by
+   * editing this one function instead of a global migration.
+   */
+  readonly parse?: (raw: unknown) => Payload | null;
+  /**
+   * The extra members this panel's instance carries — its own store, a
+   * disposer, an overriding `reopen`. The host links the result onto the
+   * handle, so `handle` is here only to be captured, never to be copied.
+   */
+  readonly create?: (handle: PanelHandle<Payload>) => Extra;
+  /** The host never reads this; the React layer narrows it to `PanelView`. */
+  readonly view: View;
+}
+
+/**
+ * The erased form the registry stores. `any` in the payload slot is
+ * load-bearing: `key`/`create` consume a payload (contravariant) while `parse`
+ * produces one (covariant), so no single concrete type — not `unknown`, not
+ * `never` — accepts every definition.
+ */
+// oxlint-disable-next-line typescript/no-explicit-any
+export type AnyPanelDefinition<View = unknown> = PanelDefinition<string, any, any, View>;
+
+/** Empty for a singleton, one required argument for a family. */
+export type PayloadArgs<Payload> = [Payload] extends [void] ? [] : [payload: Payload];
+
+/**
+ * Everything a family takes except `key` — whose absence is the whole
+ * difference — and with `label` a constant, since one panel needs only one.
+ * `Payload` still defaults to `void` but is no longer forced to it: a singleton
+ * that grows a payload later must not have to become a family with a fake
+ * `key`, because that would change its persisted id.
+ */
+export type SingletonPanelInput<Type extends string, Payload, Extra extends object, View> = Omit<
+  PanelDefinition<Type, Payload, Extra, View>,
+  "key" | "label" | "title"
+> & {
+  readonly label: string;
+};
+
+/** A singleton: no `key`, so the id *is* the type and opening it twice is once. */
+export function definePanel<
+  const Type extends string,
+  View,
+  Extra extends object = object,
+  Payload = void,
+>(
+  definition: SingletonPanelInput<Type, Payload, Extra, View>,
+): PanelDefinition<Type, Payload, Extra, View> {
+  // `title` too, so the "+" menu never has to invent a name for it.
+  return { ...definition, label: () => definition.label, title: definition.label };
+}
+
+/** A family: `key` is what makes it one, and is the only required extra. */
+export function definePanelFamily<
+  const Type extends string,
+  Payload,
+  View,
+  Extra extends object = object,
+>(
+  definition: PanelDefinition<Type, Payload, Extra, View> & {
+    readonly key: (payload: Payload) => string;
+  },
+): PanelDefinition<Type, Payload, Extra, View> {
+  return definition;
+}
+
+/**
+ * The half of every `parse` that is the same everywhere: narrow a value read
+ * back from storage to something whose fields can be checked.
+ */
+export const asRecord = (raw: unknown): Record<string, unknown> | null =>
+  typeof raw === "object" && raw !== null ? (raw as Record<string, unknown>) : null;
+
+/** Singleton and family collapse to this one line. */
+export function panelId<Payload>(
+  definition: Pick<PanelDefinition<string, Payload>, "type" | "key">,
+  payload: Payload,
+): string {
+  return definition.key ? `${definition.type}:${definition.key(payload)}` : definition.type;
+}

--- a/apps/app/src/components/layout/content-panel/panels/README.md
+++ b/apps/app/src/components/layout/content-panel/panels/README.md
@@ -1,0 +1,24 @@
+# Placeholder panels
+
+Mock content, real wiring. These exist to exercise the four shapes a panel can
+take, so the host is proven against all of them before anything real is built:
+
+|            | arity                 | `create` | what it demonstrates                                  |
+| ---------- | --------------------- | -------- | ----------------------------------------------------- |
+| `diff`     | singleton             | —        | the thin default handle; opening twice is one panel   |
+| `file`     | family (`key: path`)  | —        | one tab per key, opened with a payload from elsewhere |
+| `browser`  | family (`key: tabId`) | ✓        | an instance with its own store (url, loading)         |
+| `terminal` | family (`key: id`)    | ✓        | an instance whose store holds live, unpersisted state |
+
+There is one tab strip and it belongs to the host. A panel that wants "several
+of a thing" — two shells, two files — opens several panels, so the strip stays
+the only place a tab is drawn.
+
+Before filling one in, check `packages/ui`: the browser panel's chrome already
+exists there, unused, as `ai-elements/web-preview` — swap `onUrlChange` for the
+payload and delete the hand-rolled bar rather than growing it.
+
+Each of these belongs in its own `features/<name>/` directory once it has a
+real implementation — a panel is owned by the feature it renders, not by the
+layout. They sit here only because there is no feature behind them yet, which
+also makes this whole directory deletable in one go.

--- a/apps/app/src/components/layout/content-panel/panels/browser-panel.tsx
+++ b/apps/app/src/components/layout/content-panel/panels/browser-panel.tsx
@@ -1,0 +1,103 @@
+import { Button } from "@vibest/ui/components/button";
+import { Input } from "@vibest/ui/components/input";
+import { GlobeIcon, RotateCwIcon } from "lucide-react";
+import { useState } from "react";
+import { useStore } from "zustand";
+import { createStore, type StoreApi } from "zustand/vanilla";
+
+import { asRecord, type PanelInstance } from "../core/panel";
+import { definePanelFamily } from "../react/view";
+
+interface BrowserPayload {
+  readonly tabId: string;
+  /** Persisted so a reload lands back where the tab was. */
+  readonly url: string;
+}
+
+interface BrowserState {
+  readonly loading: boolean;
+  readonly title: string;
+}
+
+/**
+ * What this instance adds on top of the handle. Loading and title are
+ * per-instance and worthless across a reload, so they live in the instance's
+ * own store rather than the host's — a tab finishing its load re-renders
+ * itself and nothing else.
+ */
+interface BrowserExtra {
+  readonly store: StoreApi<BrowserState>;
+  navigate(url: string): void;
+}
+
+type BrowserInstance = PanelInstance<BrowserPayload, BrowserExtra>;
+
+let nextTab = 0;
+
+export const browserPanel = definePanelFamily({
+  type: "browser",
+  key: (payload: BrowserPayload) => payload.tabId,
+  label: (payload) => hostOf(payload.url),
+  title: "Browser",
+  newPayload: () => ({ tabId: `tab-${++nextTab}`, url: "http://localhost:5173" }),
+  parse: (raw) => {
+    const { tabId, url } = asRecord(raw) ?? {};
+    return typeof tabId === "string" && typeof url === "string" ? { tabId, url } : null;
+  },
+  create: (handle) => {
+    const store = createStore<BrowserState>(() => ({
+      loading: false,
+      title: hostOf(handle.payload.url),
+    }));
+    const navigate = (url: string) => {
+      // The URL is persisted state, so it goes to the host; the spinner is not,
+      // so it stays here.
+      handle.setPayload((current) => ({ ...current, url }));
+      store.setState({ loading: true });
+      setTimeout(() => store.setState({ loading: false, title: hostOf(url) }), 400);
+    };
+    return { store, navigate };
+  },
+  view: {
+    icon: GlobeIcon,
+    render: (instance) => <BrowserPanelView instance={instance} />,
+  },
+});
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host || "Browser";
+  } catch {
+    return "Browser";
+  }
+}
+
+function BrowserPanelView({ instance }: { instance: BrowserInstance }) {
+  const { loading, title } = useStore(instance.store);
+  const [draft, setDraft] = useState(instance.payload.url);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <form
+        className="flex shrink-0 items-center gap-1 border-b p-1.5"
+        onSubmit={(event) => {
+          event.preventDefault();
+          instance.navigate(draft);
+        }}
+      >
+        <Input
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          className="h-7 text-xs"
+          aria-label="Address"
+        />
+        <Button type="submit" variant="ghost" size="icon-xs" aria-label="Reload">
+          <RotateCwIcon className={loading ? "size-3.5 animate-spin" : "size-3.5"} />
+        </Button>
+      </form>
+      <div className="bg-muted/30 text-muted-foreground flex min-h-0 flex-1 items-center justify-center text-xs">
+        {loading ? "Loading…" : `Rendered ${title}`}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/layout/content-panel/panels/diff-panel.tsx
+++ b/apps/app/src/components/layout/content-panel/panels/diff-panel.tsx
@@ -1,0 +1,70 @@
+import { FileDiffIcon } from "lucide-react";
+
+import { definePanel } from "../react/view";
+
+// Placeholder content — see ./README.md.
+const MOCK_FILES = [
+  { path: "packages/server/src/harness/session.ts", added: 24, removed: 6 },
+  { path: "apps/app/src/features/chat/chat.tsx", added: 8, removed: 8 },
+  { path: "packages/contract/src/domain.ts", added: 3, removed: 0 },
+];
+
+const MOCK_HUNK = [
+  { sign: " ", text: "  const session = yield* manager.sessionFor(ref)" },
+  { sign: "-", text: "  return session.snapshot()" },
+  { sign: "+", text: "  const snapshot = session.snapshot()" },
+  { sign: "+", text: "  yield* bus.publish(sessionUpdated(ref, snapshot))" },
+  { sign: "+", text: "  return snapshot" },
+  { sign: " ", text: "}" },
+];
+
+/**
+ * A singleton with no `create`: the default handle is everything it needs. The
+ * whole definition is data plus one render function.
+ */
+export const diffPanel = definePanel({
+  type: "diff",
+  label: "Diff",
+  view: {
+    icon: FileDiffIcon,
+    render: () => <DiffPanelView />,
+  },
+});
+
+function DiffPanelView() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <ul className="shrink-0 border-b py-1">
+        {MOCK_FILES.map((file) => (
+          <li
+            key={file.path}
+            className="hover:bg-accent/60 flex items-center gap-2 px-3 py-1 text-xs"
+          >
+            <span className="text-muted-foreground truncate">{file.path}</span>
+            <span className="ms-auto shrink-0 font-mono text-[11px]">
+              <span className="text-emerald-600 dark:text-emerald-400">+{file.added}</span>{" "}
+              <span className="text-rose-600 dark:text-rose-400">−{file.removed}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+      <pre className="min-h-0 flex-1 overflow-auto p-3 font-mono text-xs leading-relaxed">
+        {MOCK_HUNK.map((line, index) => (
+          <div
+            key={index}
+            className={
+              line.sign === "+"
+                ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                : line.sign === "-"
+                  ? "bg-rose-500/10 text-rose-700 dark:text-rose-300"
+                  : "text-muted-foreground"
+            }
+          >
+            {line.sign}
+            {line.text}
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}

--- a/apps/app/src/components/layout/content-panel/panels/file-panel.tsx
+++ b/apps/app/src/components/layout/content-panel/panels/file-panel.tsx
@@ -1,0 +1,64 @@
+import { FileCodeIcon } from "lucide-react";
+
+import { asRecord, type PanelHandle } from "../core/panel";
+import { definePanelFamily } from "../react/view";
+
+export interface FilePayload {
+  readonly path: string;
+  /** Where a jump-to-line request last pointed. Part of the payload so it survives a reload. */
+  readonly line?: number;
+}
+
+// Placeholder content — see ./README.md.
+const MOCK_FILES = [
+  "packages/server/src/harness/session.ts",
+  "apps/app/src/features/chat/chat.tsx",
+  "packages/contract/src/domain.ts",
+];
+
+const mockSource = (path: string): string[] =>
+  Array.from({ length: 24 }, (_, index) => `// ${path}:${index + 1}`);
+
+let nextMockFile = 0;
+
+/**
+ * A family with no `create`: every open path is its own tab, but nothing about
+ * one needs state beyond the payload. `newPayload` is only here so the "+"
+ * menu has something to open — a real file panel would be opened with a path
+ * from a picker, a diff row, or a link in the transcript, and would omit it.
+ */
+export const filePanel = definePanelFamily({
+  type: "file",
+  key: (payload: FilePayload) => payload.path,
+  label: (payload) => payload.path.slice(payload.path.lastIndexOf("/") + 1),
+  title: "File",
+  newPayload: () => ({ path: MOCK_FILES[nextMockFile++ % MOCK_FILES.length]! }),
+  parse: (raw) => {
+    const { path, line } = asRecord(raw) ?? {};
+    if (typeof path !== "string") return null;
+    return typeof line === "number" ? { path, line } : { path };
+  },
+  view: {
+    icon: FileCodeIcon,
+    render: (instance) => <FilePanelView instance={instance} />,
+  },
+});
+
+function FilePanelView({ instance }: { instance: PanelHandle<FilePayload> }) {
+  const { path, line } = instance.payload;
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="text-muted-foreground shrink-0 border-b px-3 py-1.5 text-xs">{path}</div>
+      <pre className="min-h-0 flex-1 overflow-auto p-3 font-mono text-xs leading-relaxed">
+        {mockSource(path).map((text, index) => (
+          <div key={index} className={index + 1 === line ? "bg-primary/10 -mx-3 px-3" : undefined}>
+            <span className="text-muted-foreground/60 me-3 inline-block w-6 text-end">
+              {index + 1}
+            </span>
+            {text}
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}

--- a/apps/app/src/components/layout/content-panel/panels/terminal-panel.tsx
+++ b/apps/app/src/components/layout/content-panel/panels/terminal-panel.tsx
@@ -1,0 +1,106 @@
+import { TerminalIcon } from "lucide-react";
+import { useStore } from "zustand";
+import { createStore, type StoreApi } from "zustand/vanilla";
+
+import { asRecord, type PanelInstance } from "../core/panel";
+import { definePanelFamily } from "../react/view";
+
+interface TerminalPayload {
+  readonly terminalId: string;
+  /**
+   * Shown on the tab. In the payload rather than the instance because the tab
+   * strip labels a panel it has never activated — and a reload has to redraw
+   * that strip before any instance exists.
+   */
+  readonly title: string;
+}
+
+interface TerminalState {
+  readonly lines: readonly string[];
+}
+
+/**
+ * The scrollback lives here and nowhere else — not in the panel store, which
+ * persists, and not in the view, which unmounts. This is the shape t3code got
+ * wrong: it kept per-terminal state in the panel store, which forced that store
+ * to grow terminal-specific methods and made it the one thing standing between
+ * "add a panel type" and "touch eleven places". An instance gives it a home the
+ * host cannot see.
+ */
+interface TerminalExtra {
+  readonly store: StoreApi<TerminalState>;
+  run(command: string): void;
+  dispose(): void;
+}
+
+type TerminalInstance = PanelInstance<TerminalPayload, TerminalExtra>;
+
+let nextTerminal = 0;
+
+// Placeholder content — see ./README.md.
+const GREETING = ["$ pnpm dev", "  VITE ready in 412 ms", "  ➜  Local: http://localhost:5173/"];
+
+export const terminalPanel = definePanelFamily({
+  type: "terminal",
+  key: (payload: TerminalPayload) => payload.terminalId,
+  label: (payload) => payload.title,
+  title: "Terminal",
+  newPayload: () => {
+    const n = ++nextTerminal;
+    return { terminalId: `terminal-${n}`, title: `zsh ${n}` };
+  },
+  parse: (raw) => {
+    const { terminalId, title } = asRecord(raw) ?? {};
+    if (typeof terminalId !== "string") return null;
+    return { terminalId, title: typeof title === "string" ? title : "Terminal" };
+  },
+  create: () => {
+    const store = createStore<TerminalState>(() => ({ lines: GREETING }));
+    return {
+      store,
+      // Annotated: `Extra` is inferred *from* this literal, so nothing
+      // contextually types the parameter yet.
+      run: (command: string) =>
+        store.setState((state) => ({
+          lines: [...state.lines, `$ ${command}`, `  ${command}: command not found`],
+        })),
+      // Closing the tab is what kills the shell — unmounting is not. Navigating
+      // away unmounts and must leave it running.
+      dispose: () => store.setState({ lines: [] }),
+    };
+  },
+  view: {
+    icon: TerminalIcon,
+    render: (instance) => <TerminalPanelView instance={instance} />,
+  },
+});
+
+function TerminalPanelView({ instance }: { instance: TerminalInstance }) {
+  const lines = useStore(instance.store, (state) => state.lines);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <pre className="bg-muted/20 min-h-0 flex-1 overflow-auto p-3 font-mono text-xs leading-relaxed">
+        {lines.join("\n")}
+      </pre>
+      <form
+        className="shrink-0 border-t"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const input = event.currentTarget.elements.namedItem("command");
+          if (!(input instanceof HTMLInputElement) || input.value === "") return;
+          instance.run(input.value);
+          input.value = "";
+        }}
+      >
+        <input
+          name="command"
+          aria-label={`${instance.payload.title} input`}
+          placeholder="Type a command…"
+          autoComplete="off"
+          className="placeholder:text-muted-foreground/60 w-full bg-transparent px-3 py-2 font-mono text-xs outline-none"
+        />
+      </form>
+    </div>
+  );
+}

--- a/apps/app/src/components/layout/content-panel/react/context.ts
+++ b/apps/app/src/components/layout/content-panel/react/context.ts
@@ -1,0 +1,20 @@
+import { createContext, use } from "react";
+
+import type { ContentPanel } from "../core/content-panel";
+import type { AnyPanelView } from "./view";
+
+export interface ContentPanelContextValue {
+  readonly contentPanel: ContentPanel<AnyPanelView>;
+  /** null outside a session route (`/draft`, `/`), where there is nothing to scope panels to. */
+  readonly sessionId: string | null;
+}
+
+export const ContentPanelContext = createContext<ContentPanelContextValue | null>(null);
+
+export function useContentPanelContext(): ContentPanelContextValue {
+  const value = use(ContentPanelContext);
+  if (value === null) {
+    throw new Error("Content panel hooks need a <ContentPanelProvider> above them.");
+  }
+  return value;
+}

--- a/apps/app/src/components/layout/content-panel/react/hooks.ts
+++ b/apps/app/src/components/layout/content-panel/react/hooks.ts
@@ -1,0 +1,58 @@
+import { useMemo } from "react";
+import { useStore } from "zustand";
+
+import type { PanelPresentation, PanelSnapshot } from "../core/content-panel";
+import type { PanelDefinition, PanelInstance, PayloadArgs } from "../core/panel";
+import { useContentPanelContext } from "./context";
+import type { AnyPanelView } from "./view";
+
+/** Session-level operations, with the session already bound. Panel-level ones live on the instance. */
+export interface ContentPanelSession {
+  readonly sessionId: string;
+  open<Type extends string, Payload, Extra extends object>(
+    definition: PanelDefinition<Type, Payload, Extra, AnyPanelView>,
+    ...payload: PayloadArgs<Payload>
+  ): PanelInstance<Payload, Extra>;
+  /** By type, for a "+" menu entry — the definition is the registry's business. */
+  openNew(type: string): void;
+  activate(id: string): void;
+  close(id: string): void;
+  setPresentation(presentation: PanelPresentation): void;
+  toggleVisibility(): void;
+}
+
+/**
+ * Zero subscriptions: the returned object is stable, so a component that only
+ * opens panels never re-renders when the panel state moves. Reads of current
+ * state happen inside the callbacks, through `getState`.
+ *
+ * null outside a session route.
+ */
+export function useContentPanel(): ContentPanelSession | null {
+  const { contentPanel, sessionId } = useContentPanelContext();
+  return useMemo(() => {
+    if (sessionId === null) return null;
+    return {
+      sessionId,
+      open: (definition, ...payload) => contentPanel.open(sessionId, definition, ...payload),
+      openNew: (type) => contentPanel.openNew(sessionId, type),
+      activate: (id) => contentPanel.activate(sessionId, id),
+      close: (id) => contentPanel.close(sessionId, id),
+      setPresentation: (presentation) => contentPanel.setPresentation(sessionId, presentation),
+      toggleVisibility: () => contentPanel.toggleVisibility(sessionId),
+    };
+  }, [contentPanel, sessionId]);
+}
+
+/**
+ * The one subscription entry point; granularity is the caller's to choose.
+ * The selector must return something `Object.is`-stable — every field on the
+ * snapshot is, so select fields rather than deriving new objects here, and
+ * never select the snapshot itself.
+ */
+export function usePanelSnapshot<Selected>(
+  selector: (snapshot: PanelSnapshot<AnyPanelView>) => Selected,
+): Selected {
+  const { contentPanel, sessionId } = useContentPanelContext();
+  return useStore(contentPanel.store, (state) => selector(contentPanel.snapshot(state, sessionId)));
+}

--- a/apps/app/src/components/layout/content-panel/react/outlet.tsx
+++ b/apps/app/src/components/layout/content-panel/react/outlet.tsx
@@ -1,0 +1,219 @@
+import { Button } from "@vibest/ui/components/button";
+import { Empty, EmptyContent, EmptyDescription } from "@vibest/ui/components/empty";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@vibest/ui/components/menu";
+import { cn } from "@vibest/ui/lib/utils";
+import { Maximize2Icon, Minimize2Icon, PlusIcon, XIcon } from "lucide-react";
+import { useEffect, useRef, type ReactNode } from "react";
+
+import type { OpenPanel } from "../core/content-panel";
+import { type ContentPanelSession, useContentPanel, usePanelSnapshot } from "./hooks";
+import type { AnyPanelView } from "./view";
+
+/**
+ * Where the active panel renders: its own card beside the chat's, its tab strip,
+ * and the empty state. Knows nothing about any particular panel — everything it
+ * shows comes off the snapshot.
+ *
+ * A card, not a column inside the chat's: the two are siblings that each own
+ * their chrome, so the panel's tab strip is its own header line rather than a
+ * tenant of the chat's. The margins mirror `SidebarInset`'s so the gap between
+ * the cards matches the gap to the sidebar.
+ */
+export function ContentPanelOutlet({ className }: { className?: string }): ReactNode {
+  const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
+  const session = useContentPanel();
+
+  // Off a session the snapshot is always hidden, so the first clause covers it;
+  // the second is what narrows `session` for everything below.
+  if (presentation === "hidden" || session === null) return null;
+
+  return (
+    <div
+      className={cn(
+        "bg-background relative flex min-h-0 min-w-0 flex-col overflow-hidden border [-webkit-app-region:no-drag]",
+        "md:my-1.5 md:me-1.5 md:rounded-xl md:shadow-sm/5",
+        presentation === "maximized" ? "flex-1" : "w-[28rem] shrink-0",
+        className,
+      )}
+      data-content-panel={presentation}
+    >
+      <TabStrip presentation={presentation} session={session} />
+      <PanelBody session={session} />
+    </div>
+  );
+}
+
+function TabStrip({
+  presentation,
+  session,
+}: {
+  presentation: "docked" | "maximized";
+  session: ContentPanelSession;
+}): ReactNode {
+  const panels = usePanelSnapshot((snapshot) => snapshot.panels);
+  const activeId = usePanelSnapshot((snapshot) => snapshot.active?.id ?? null);
+  const scroller = useRef<HTMLDivElement>(null);
+
+  // One effect here rather than one per tab: a scroll offset is not state to
+  // derive, and the strip overflows well before it runs out of panels, so
+  // without this the tab you just opened can land off the end of it.
+  useEffect(() => {
+    if (activeId === null) return;
+    scroller.current
+      ?.querySelector("[data-panel-tab-active]")
+      ?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeId]);
+
+  return (
+    <div className="flex h-10 shrink-0 items-center gap-1 overflow-hidden border-b ps-1.5 pe-1">
+      {/*
+       * The scroller sizes to its content and shrinks — it is deliberately not
+       * `flex-1`. "+" is its sibling, so it stays pinned just past the last
+       * visible tab instead of scrolling off the end with them. `scrollbar-hide`
+       * because a bar here would eat the height it scrolls in.
+       */}
+      <div
+        ref={scroller}
+        className="scrollbar-hide flex min-w-0 items-center gap-0.5 overflow-x-auto"
+      >
+        {panels.map((panel) => (
+          <Tab key={panel.id} panel={panel} active={panel.id === activeId} session={session} />
+        ))}
+      </div>
+      {panels.length > 0 ? <AddPanelMenu session={session} /> : null}
+      <Button
+        className="ms-auto"
+        variant="ghost"
+        size="icon-xs"
+        aria-label={presentation === "maximized" ? "Restore panel size" : "Maximize panel"}
+        onClick={() =>
+          session.setPresentation(presentation === "maximized" ? "docked" : "maximized")
+        }
+      >
+        {presentation === "maximized" ? (
+          <Minimize2Icon className="size-3.5" />
+        ) : (
+          <Maximize2Icon className="size-3.5" />
+        )}
+      </Button>
+      {/*
+       * No hide button here: `ContentPanelToggle` already is one, and it has to
+       * live outside the panel anyway to bring it back. Two controls for one
+       * boolean is the duplication that button would be.
+       */}
+    </div>
+  );
+}
+
+function Tab({
+  panel,
+  active,
+  session,
+}: {
+  panel: OpenPanel<AnyPanelView>;
+  active: boolean;
+  session: ContentPanelSession;
+}): ReactNode {
+  const Icon = panel.view.icon;
+  return (
+    <div
+      // How the strip finds the tab to scroll into view.
+      data-panel-tab-active={active || undefined}
+      className={cn(
+        "group flex h-7 max-w-40 shrink-0 items-center gap-1 rounded-md ps-1.5 pe-1 text-xs",
+        active
+          ? "bg-accent text-foreground"
+          : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+      )}
+      // A middle click closes the tab, the way every tabbed thing does.
+      onAuxClick={(event) => {
+        if (event.button !== 1) return;
+        event.preventDefault();
+        session.close(panel.id);
+      }}
+    >
+      <button
+        type="button"
+        className="flex min-w-0 items-center gap-1.5"
+        onClick={() => session.activate(panel.id)}
+        title={panel.label}
+      >
+        <Icon className="size-3.5 shrink-0" />
+        <span className="truncate">{panel.label}</span>
+      </button>
+      <button
+        type="button"
+        className="hover:bg-muted flex size-4 shrink-0 items-center justify-center rounded-sm opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+        aria-label={`Close ${panel.label}`}
+        onClick={() => session.close(panel.id)}
+      >
+        <XIcon className="size-3" />
+      </button>
+    </div>
+  );
+}
+
+function AddPanelMenu({ session }: { session: ContentPanelSession }): ReactNode {
+  const openable = usePanelSnapshot((snapshot) => snapshot.openable);
+  if (openable.length === 0) return null;
+
+  return (
+    <Menu>
+      <MenuTrigger
+        className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex size-6 shrink-0 items-center justify-center rounded-md"
+        aria-label="Open a panel"
+      >
+        <PlusIcon className="size-3.5" />
+      </MenuTrigger>
+      <MenuPopup align="start" side="bottom" sideOffset={6} className="min-w-44">
+        {openable.map((entry) => {
+          const Icon = entry.view.icon;
+          return (
+            <MenuItem key={entry.type} onClick={() => session.openNew(entry.type)}>
+              <Icon className="size-4" />
+              {entry.title}
+            </MenuItem>
+          );
+        })}
+      </MenuPopup>
+    </Menu>
+  );
+}
+
+function PanelBody({ session }: { session: ContentPanelSession }): ReactNode {
+  const active = usePanelSnapshot((snapshot) => snapshot.active);
+  if (active === null) return <EmptyState session={session} />;
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      {/* Reading `instance` is what materializes the panel — only this one. */}
+      {active.view.render(active.instance)}
+    </div>
+  );
+}
+
+function EmptyState({ session }: { session: ContentPanelSession }): ReactNode {
+  const openable = usePanelSnapshot((snapshot) => snapshot.openable);
+  return (
+    <Empty className="py-6 md:py-6">
+      <EmptyContent>
+        <EmptyDescription>Choose what to show alongside the chat.</EmptyDescription>
+        <div className="grid w-full grid-cols-2 gap-2">
+          {openable.map((entry) => {
+            const Icon = entry.view.icon;
+            return (
+              <button
+                key={entry.type}
+                type="button"
+                onClick={() => session.openNew(entry.type)}
+                className="bg-card hover:bg-accent/60 flex min-h-20 flex-col items-start rounded-lg border p-3 text-start transition"
+              >
+                <Icon className="mb-2 size-4" />
+                <span className="text-sm font-medium">{entry.title}</span>
+              </button>
+            );
+          })}
+        </div>
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/apps/app/src/components/layout/content-panel/react/outlet.tsx
+++ b/apps/app/src/components/layout/content-panel/react/outlet.tsx
@@ -3,7 +3,7 @@ import { Empty, EmptyContent, EmptyDescription } from "@vibest/ui/components/emp
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@vibest/ui/components/menu";
 import { cn } from "@vibest/ui/lib/utils";
 import { Maximize2Icon, Minimize2Icon, PlusIcon, XIcon } from "lucide-react";
-import { useEffect, useRef, type ReactNode } from "react";
+import { type ComponentProps, useEffect, useRef, type ReactNode } from "react";
 
 import type { OpenPanel } from "../core/content-panel";
 import { type ContentPanelSession, useContentPanel, usePanelSnapshot } from "./hooks";
@@ -19,7 +19,9 @@ import type { AnyPanelView } from "./view";
  * tenant of the chat's. The margins mirror `SidebarInset`'s so the gap between
  * the cards matches the gap to the sidebar.
  */
-export function ContentPanelOutlet({ className }: { className?: string }): ReactNode {
+export type ContentPanelOutletProps = ComponentProps<"aside">;
+
+export function ContentPanelOutlet({ className, ...props }: ContentPanelOutletProps): ReactNode {
   const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
   const session = useContentPanel();
 
@@ -28,18 +30,20 @@ export function ContentPanelOutlet({ className }: { className?: string }): React
   if (presentation === "hidden" || session === null) return null;
 
   return (
-    <div
+    <aside
+      data-slot="content-panel"
+      data-state={presentation}
       className={cn(
         "bg-background relative flex min-h-0 min-w-0 flex-col overflow-hidden border [-webkit-app-region:no-drag]",
         "md:my-1.5 md:me-1.5 md:rounded-xl md:shadow-sm/5",
-        presentation === "maximized" ? "flex-1" : "w-[28rem] shrink-0",
+        presentation === "maximized" ? "flex-1" : "w-112 shrink-0",
         className,
       )}
-      data-content-panel={presentation}
+      {...props}
     >
       <TabStrip presentation={presentation} session={session} />
       <PanelBody session={session} />
-    </div>
+    </aside>
   );
 }
 
@@ -60,7 +64,7 @@ function TabStrip({
   useEffect(() => {
     if (activeId === null) return;
     scroller.current
-      ?.querySelector("[data-panel-tab-active]")
+      ?.querySelector("[data-slot=content-panel-tab][data-active]")
       ?.scrollIntoView({ block: "nearest", inline: "nearest" });
   }, [activeId]);
 
@@ -117,8 +121,10 @@ function Tab({
   const Icon = panel.view.icon;
   return (
     <div
-      // How the strip finds the tab to scroll into view.
-      data-panel-tab-active={active || undefined}
+      data-slot="content-panel-tab"
+      // `data-active`, as both `tabs` and `sidebar` spell it. Also how the strip
+      // finds the tab to scroll into view.
+      data-active={active || undefined}
       className={cn(
         "group flex h-7 max-w-40 shrink-0 items-center gap-1 rounded-md ps-1.5 pe-1 text-xs",
         active
@@ -134,6 +140,8 @@ function Tab({
     >
       <button
         type="button"
+        // Which tab is current must not be carried by the background alone.
+        aria-current={active || undefined}
         className="flex min-w-0 items-center gap-1.5"
         onClick={() => session.activate(panel.id)}
         title={panel.label}
@@ -197,19 +205,24 @@ function EmptyState({ session }: { session: ContentPanelSession }): ReactNode {
     <Empty className="py-6 md:py-6">
       <EmptyContent>
         <EmptyDescription>Choose what to show alongside the chat.</EmptyDescription>
-        <div className="grid w-full grid-cols-2 gap-2">
+        {/*
+         * Ghost buttons, not bordered tiles: this is already inside the panel's
+         * card, and cards do not nest (design.md). The published Button carries
+         * the hover, focus ring and coarse-pointer step for free.
+         */}
+        <div className="grid w-full grid-cols-2 gap-1">
           {openable.map((entry) => {
             const Icon = entry.view.icon;
             return (
-              <button
+              <Button
                 key={entry.type}
-                type="button"
+                variant="ghost"
+                className="justify-start"
                 onClick={() => session.openNew(entry.type)}
-                className="bg-card hover:bg-accent/60 flex min-h-20 flex-col items-start rounded-lg border p-3 text-start transition"
               >
-                <Icon className="mb-2 size-4" />
-                <span className="text-sm font-medium">{entry.title}</span>
-              </button>
+                <Icon />
+                {entry.title}
+              </Button>
             );
           })}
         </div>

--- a/apps/app/src/components/layout/content-panel/react/provider.tsx
+++ b/apps/app/src/components/layout/content-panel/react/provider.tsx
@@ -14,11 +14,14 @@ import type { AnyPanelView } from "./view";
  * for the benefit of one. A panel that needs a workspace path takes it in its
  * payload — already persisted and parsed — or resolves it in its own view.
  */
-export function ContentPanelProvider(props: {
+export interface ContentPanelProviderProps {
   readonly contentPanel: ContentPanel<AnyPanelView>;
+  /** null off a session route; every panel hook below degrades to a no-op. */
   readonly sessionId: string | null;
   readonly children: ReactNode;
-}): ReactNode {
+}
+
+export function ContentPanelProvider(props: ContentPanelProviderProps): ReactNode {
   const { contentPanel, sessionId, children } = props;
   const value = useMemo(() => ({ contentPanel, sessionId }), [contentPanel, sessionId]);
   return <ContentPanelContext value={value}>{children}</ContentPanelContext>;

--- a/apps/app/src/components/layout/content-panel/react/provider.tsx
+++ b/apps/app/src/components/layout/content-panel/react/provider.tsx
@@ -1,0 +1,25 @@
+import { type ReactNode, useMemo } from "react";
+
+import type { ContentPanel } from "../core/content-panel";
+import { ContentPanelContext } from "./context";
+import type { AnyPanelView } from "./view";
+
+/**
+ * Carries the global host plus the identity everything below binds to. The
+ * host itself is created outside React and outlives every route; only the
+ * `sessionId` binding is React's business.
+ *
+ * `sessionId` and nothing else, deliberately: an ambient channel for values
+ * particular panels want (a cwd, a git ref) would widen every consumer's memo
+ * for the benefit of one. A panel that needs a workspace path takes it in its
+ * payload — already persisted and parsed — or resolves it in its own view.
+ */
+export function ContentPanelProvider(props: {
+  readonly contentPanel: ContentPanel<AnyPanelView>;
+  readonly sessionId: string | null;
+  readonly children: ReactNode;
+}): ReactNode {
+  const { contentPanel, sessionId, children } = props;
+  const value = useMemo(() => ({ contentPanel, sessionId }), [contentPanel, sessionId]);
+  return <ContentPanelContext value={value}>{children}</ContentPanelContext>;
+}

--- a/apps/app/src/components/layout/content-panel/react/register.tsx
+++ b/apps/app/src/components/layout/content-panel/react/register.tsx
@@ -1,0 +1,25 @@
+import { useLayoutEffect } from "react";
+
+import type { AnyPanelDefinition } from "../core/panel";
+import { useContentPanelContext } from "./context";
+import type { AnyPanelView } from "./view";
+
+/**
+ * Registers a batch and retracts it on unmount, which is what makes conditional
+ * registration just conditional rendering. One layout effect for the whole
+ * list, not one per definition: each registration invalidates every derived tab
+ * list, so a per-definition effect would discard it N times before first paint.
+ *
+ * Layout effect rather than effect: the open panels come back from storage on
+ * the first render, so registering after paint would show an empty tab strip
+ * for a frame.
+ */
+export function RegisterPanels({
+  definitions,
+}: {
+  readonly definitions: readonly AnyPanelDefinition<AnyPanelView>[];
+}): null {
+  const { contentPanel } = useContentPanelContext();
+  useLayoutEffect(() => contentPanel.registerAll(definitions), [contentPanel, definitions]);
+  return null;
+}

--- a/apps/app/src/components/layout/content-panel/react/register.tsx
+++ b/apps/app/src/components/layout/content-panel/react/register.tsx
@@ -14,11 +14,11 @@ import type { AnyPanelView } from "./view";
  * the first render, so registering after paint would show an empty tab strip
  * for a frame.
  */
-export function RegisterPanels({
-  definitions,
-}: {
+export interface RegisterPanelsProps {
   readonly definitions: readonly AnyPanelDefinition<AnyPanelView>[];
-}): null {
+}
+
+export function RegisterPanels({ definitions }: RegisterPanelsProps): null {
   const { contentPanel } = useContentPanelContext();
   useLayoutEffect(() => contentPanel.registerAll(definitions), [contentPanel, definitions]);
   return null;

--- a/apps/app/src/components/layout/content-panel/react/toggle.tsx
+++ b/apps/app/src/components/layout/content-panel/react/toggle.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@vibest/ui/components/button";
 import { cn } from "@vibest/ui/lib/utils";
 import { PanelRightIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
 import { useContentPanel, usePanelSnapshot } from "./hooks";
 
@@ -12,7 +12,9 @@ import { useContentPanel, usePanelSnapshot } from "./hooks";
  *
  * Renders nothing off a session — there is no panel to toggle.
  */
-export function ContentPanelToggle({ className }: { className?: string }): ReactNode {
+export type ContentPanelToggleProps = ComponentProps<typeof Button>;
+
+export function ContentPanelToggle({ className, ...props }: ContentPanelToggleProps): ReactNode {
   const session = useContentPanel();
   const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
   if (session === null) return null;
@@ -25,6 +27,7 @@ export function ContentPanelToggle({ className }: { className?: string }): React
       aria-pressed={presentation !== "hidden"}
       className={cn(presentation !== "hidden" && "bg-accent", className)}
       onClick={() => session.toggleVisibility()}
+      {...props}
     >
       <PanelRightIcon className="size-3.5" />
     </Button>

--- a/apps/app/src/components/layout/content-panel/react/toggle.tsx
+++ b/apps/app/src/components/layout/content-panel/react/toggle.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@vibest/ui/components/button";
+import { cn } from "@vibest/ui/lib/utils";
+import { PanelRightIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { useContentPanel, usePanelSnapshot } from "./hooks";
+
+/**
+ * Show/hide, for a header or a toolbar. Lives here rather than at its one call
+ * site because "open the content panel" is a thing many places will want, and
+ * each of them would otherwise re-derive the same two hooks.
+ *
+ * Renders nothing off a session — there is no panel to toggle.
+ */
+export function ContentPanelToggle({ className }: { className?: string }): ReactNode {
+  const session = useContentPanel();
+  const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
+  if (session === null) return null;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      aria-label="Toggle content panel"
+      aria-pressed={presentation !== "hidden"}
+      className={cn(presentation !== "hidden" && "bg-accent", className)}
+      onClick={() => session.toggleVisibility()}
+    >
+      <PanelRightIcon className="size-3.5" />
+    </Button>
+  );
+}

--- a/apps/app/src/components/layout/content-panel/react/view.ts
+++ b/apps/app/src/components/layout/content-panel/react/view.ts
@@ -1,0 +1,62 @@
+import type { ComponentType, ReactNode } from "react";
+
+import {
+  definePanel as defineCorePanel,
+  definePanelFamily as defineCorePanelFamily,
+  type PanelDefinition,
+  type PanelHandle,
+  type PanelInstance,
+  type SingletonPanelInput,
+} from "../core/panel";
+
+/**
+ * The half of a panel the core deliberately doesn't understand. It reaches the
+ * host as an opaque `View` and comes back out through the snapshot.
+ */
+export interface PanelView<Instance = PanelHandle<unknown>> {
+  readonly icon: ComponentType<{ className?: string }>;
+  render(instance: Instance): ReactNode;
+}
+
+/**
+ * The erased form the registry stores, so `PanelView<FileInstance>` and
+ * `PanelView<TerminalInstance>` can sit in one list. Same reason
+ * `AnyPanelDefinition` needs it: `render` consumes an instance, and no concrete
+ * type is assignable from every panel's. Unreachable in practice — the host
+ * only ever hands `render` the instance it took from that same definition.
+ */
+// oxlint-disable-next-line typescript/no-explicit-any
+export type AnyPanelView = PanelView<any>;
+
+/**
+ * The core's constructors with `view` narrowed, so `render` receives the
+ * instance this definition actually produces. Features import from here.
+ *
+ * Both derive their input from `PanelDefinition` rather than restating its
+ * fields: a field added to the core would otherwise be silently unreachable
+ * from every feature, since this is the only door they come through.
+ */
+export function definePanel<
+  const Type extends string,
+  Extra extends object = object,
+  Payload = void,
+>(
+  definition: SingletonPanelInput<Type, Payload, Extra, View<Payload, Extra>>,
+): PanelDefinition<Type, Payload, Extra, View<Payload, Extra>> {
+  return defineCorePanel(definition);
+}
+
+export function definePanelFamily<
+  const Type extends string,
+  Payload,
+  Extra extends object = object,
+>(
+  definition: PanelDefinition<Type, Payload, Extra, View<Payload, Extra>> & {
+    readonly key: (payload: Payload) => string;
+  },
+): PanelDefinition<Type, Payload, Extra, View<Payload, Extra>> {
+  return defineCorePanelFamily(definition);
+}
+
+/** The view a definition with this payload and these extras must supply. */
+type View<Payload, Extra> = PanelView<PanelInstance<Payload, Extra>>;

--- a/apps/app/src/content-panel.ts
+++ b/apps/app/src/content-panel.ts
@@ -1,0 +1,29 @@
+import { ContentPanel } from "@/components/layout/content-panel/core/content-panel";
+import type { AnyPanelDefinition } from "@/components/layout/content-panel/core/panel";
+import { browserPanel } from "@/components/layout/content-panel/panels/browser-panel";
+import { diffPanel } from "@/components/layout/content-panel/panels/diff-panel";
+import { filePanel } from "@/components/layout/content-panel/panels/file-panel";
+import { terminalPanel } from "@/components/layout/content-panel/panels/terminal-panel";
+import type { AnyPanelView } from "@/components/layout/content-panel/react/view";
+
+/**
+ * The global host. Created here rather than at the composition root so
+ * non-React callers — a command-palette entry, a keyboard map, a link handler
+ * inside a renderer — can reach the same object the hooks wrap.
+ */
+export const contentPanel = new ContentPanel<AnyPanelView>({ storage: window.localStorage });
+
+/**
+ * Registered unconditionally at mount. Definitions are a few bytes of data, so
+ * they register eagerly even when their content is code-split — a panel that
+ * registers late has its tab pop in, and worse, an active panel restored from
+ * storage leaves the container blank until it arrives. Conditional
+ * registration is for panels that genuinely may not exist (harness-specific,
+ * git-only), not for deferring load.
+ */
+export const STATIC_PANELS: readonly AnyPanelDefinition<AnyPanelView>[] = [
+  terminalPanel,
+  filePanel,
+  diffPanel,
+  browserPanel,
+];

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { createRootRouteWithContext, Outlet, useNavigate } from "@tanstack/react-router";
+import { createRootRouteWithContext, Outlet, useMatch, useNavigate } from "@tanstack/react-router";
 import {
   SidebarInset,
   SidebarProvider,
@@ -9,6 +9,12 @@ import {
 import { cn } from "@vibest/ui/lib/utils";
 
 import { AppSidebar } from "@/components/layout/app-sidebar";
+import { usePanelSnapshot } from "@/components/layout/content-panel/react/hooks";
+import { ContentPanelOutlet } from "@/components/layout/content-panel/react/outlet";
+import { ContentPanelProvider } from "@/components/layout/content-panel/react/provider";
+import { RegisterPanels } from "@/components/layout/content-panel/react/register";
+import { ContentPanelToggle } from "@/components/layout/content-panel/react/toggle";
+import { contentPanel, STATIC_PANELS } from "@/content-panel";
 import { useSessionListSync } from "@/features/projects/use-session-list-sync";
 import type { AppClients } from "@/lib/orpc";
 import { usePlatform } from "@/platform-context";
@@ -38,6 +44,21 @@ function RootLayout() {
   const navigate = useNavigate();
   const { os } = usePlatform();
 
+  // The content panel is session-scoped, but it is bound here rather than in the
+  // session route: it is a card of the shell, peer to the chat's, and maximizing
+  // it has to be able to take the chat card's width.
+  //
+  // A named match, not `useParams({ strict: false })`: this component *is* the
+  // root route's, so the nearest match is always the root — which has no params
+  // — and the session route's would never be seen. The match's loaderData is
+  // also the ref the server confirmed, unlike the URL's search hints. Off a
+  // session route it is null and every panel hook degrades to a no-op.
+  const sessionId = useMatch({
+    from: "/session/$sessionId",
+    shouldThrow: false,
+    select: (match) => match.loaderData?.sessionId ?? null,
+  });
+
   const handleNewChat = () => navigate({ to: "/draft" });
 
   return (
@@ -47,7 +68,13 @@ function RootLayout() {
     // scroll the document instead of the message list.
     <SidebarProvider className="h-svh overflow-hidden [-webkit-app-region:drag]">
       <AppSidebar onNewChat={handleNewChat} />
-      <CardPanel />
+      {/* Adds no DOM, so the two cards below are flex children of the shell. */}
+      <ContentPanelProvider contentPanel={contentPanel} sessionId={sessionId ?? null}>
+        <RegisterPanels definitions={STATIC_PANELS} />
+        <CardPanel />
+        {/* A sibling card, not a column inside the chat's — see the outlet. */}
+        <ContentPanelOutlet />
+      </ContentPanelProvider>
       <ShellToggle hasTrafficLights={os === "macos"} />
     </SidebarProvider>
   );
@@ -87,9 +114,18 @@ function CardPanel() {
   // Collapsed, the card slides under the toggle + traffic lights — pad so the
   // title clears them.
   const collapsedDesktop = !isMobile && state === "collapsed";
+  // Maximizing squeezes this card to nothing rather than unmounting it: the
+  // route lives inside, and unmounting would dispose the composer's editor.
+  const maximized = usePanelSnapshot((snapshot) => snapshot.presentation === "maximized");
 
   return (
-    <SidebarInset className="flex min-h-0 flex-col overflow-hidden border [-webkit-app-region:no-drag] md:peer-data-[variant=inset]:m-1.5 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-1.5">
+    <SidebarInset
+      className={cn(
+        "flex min-h-0 flex-col overflow-hidden border [-webkit-app-region:no-drag] md:peer-data-[variant=inset]:m-1.5 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-1.5",
+        // Border and rounding off too — at zero width they would draw a sliver.
+        maximized && "w-0 flex-none border-0 md:peer-data-[variant=inset]:rounded-none",
+      )}
+    >
       <header
         className={cn(
           // Divider is a box-shadow (no layout space) so it can't nudge the
@@ -103,6 +139,7 @@ function CardPanel() {
           <span className="font-medium">New chat</span>
           <span className="text-muted-foreground">Playground</span>
         </div>
+        <ContentPanelToggle className="ms-auto [-webkit-app-region:no-drag]" />
       </header>
       {/*
        * Always the Outlet, never a router-state-driven swap: `isLoading` flips
@@ -112,7 +149,7 @@ function CardPanel() {
        * whatever the user had typed. Slow route loaders are already covered by
        * the router's own `defaultPendingComponent` (see router.tsx).
        */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <Outlet />
       </div>
     </SidebarInset>


### PR DESCRIPTION
A second card in the shell, peer to the chat's, hosting panels registered by
type rather than enumerated in a union. Groundwork — the four panels it ships
are placeholders.

## The shape

**Singleton and family differ only by whether a definition carries a `key`
function.** Nothing else in the host branches on it, and the host knows no panel
type at all. Registration is open: an unregistered type in persisted state is
skipped, not dropped, so a code-split or conditionally registered panel restores
itself when it arrives.

Three tiers:

| | |
|---|---|
| `core/` | React-free. The whole model is driven from a synchronous test with no renderer. Its zustand store holds only what is both UI-reactive *and* worth persisting. |
| `react/` | Binds that to a session. One subscription hook (`usePanelSnapshot`), one zero-subscription accessor (`useContentPanel`). |
| instances | Everything else a panel owns. Materialized lazily, outlive navigation, die on `close` — never on unmount. |

The instance tier is the part t3code's equivalent gets wrong: it keeps
per-terminal state in the panel store, which forces that store to grow
terminal-specific methods and makes it the one thing standing between "add a
panel type" and "touch eleven places".

There is **one tab strip and it belongs to the host**. A panel wanting several
of something opens several panels.

## The placeholders

`panels/` covers every shape the host has to support, so it is proven before a
real panel is written — and is deletable in one go.

| | arity | own instance | demonstrates |
|---|---|---|---|
| `diff` | singleton | — | the thin default handle; opening twice is once |
| `file` | family (`key: path`) | — | one tab per key, opened with a payload from elsewhere |
| `browser` | family (`key: tabId`) | ✓ | payload as source of truth, spinner as instance state |
| `terminal` | family (`key: id`) | ✓ | live scrollback that must not be persisted |

Their content is fake. Filling them in needs server work that does not exist
yet: `rpc/fs.ts` has `readFileString` but `browse` lists directories only, and
`GitService` has just `status`/`branch` and is not wired into the router.

## Notes for review

- **`useMatch({ from: "/session/$sessionId", shouldThrow: false })`, not
  `useParams({ strict: false })`.** The shell component *is* the root route's,
  so the nearest match is always the root — which has no params. Its
  `loaderData` is also the ref the server confirmed, unlike the URL's hints.
- **Maximizing squeezes the chat card to zero width rather than unmounting it.**
  The route lives inside, and unmounting disposes the composer's Tiptap editor.
- **Two caches, keyed on their own inputs.** A tab click replaces the session
  object but not its `panels` array, so the strip is not rebuilt; `openable`
  depends on the registry alone and is shared across sessions.
- **`forget()` has no caller yet.** Nothing hard-deletes a session, and
  archiving is reversible, so forgetting there would lose a user's tabs. It is
  the reclaim path for when a delete flow lands.
- The second commit is the pass against `.agents/rules/ui-components.md` and
  `design.md`, both of which landed while this branch was open.

## Verified

`pnpm typecheck`, 105 tests (19 new, no renderer needed), `lint:check`,
`format:check`, react-doctor 80/100 with no error-level findings.

Driven in the browser: family tabs, singleton idempotence, instance state
surviving tab switches and navigation, tabs restored from storage with their
buffers reset, maximize/restore, close-falls-back-to-neighbour, and the panel
absent off a session route. Clean console.