### PR TITLE
perf(app): keep sidebar project panels mounted and composite their motion

### DIFF
--- a/apps/app/src/features/projects/panel-motion.ts
+++ b/apps/app/src/features/projects/panel-motion.ts
@@ -1,0 +1,39 @@
+/**
+ * How both sidebar collapsibles animate — the Projects group and each project
+ * inside it. Pair it with `keepMounted` on the same panel; the two fix
+ * different halves of the same stutter, and the second one is the load-bearing
+ * half once a sidebar holds real session counts.
+ *
+ * **`keepMounted`.** Without it base-ui unmounts the panel's subtree on close
+ * (`shouldRender = mounted || open`), so every expand rebuilds every row. At 10
+ * projects / 600 sessions that was a 60–80ms long task on each expand — one
+ * blocking chunk, which is what reads as "I clicked and it hung". With it, the
+ * rows stay in the DOM behind `hidden` + `display:none` (nothing focusable, so
+ * no a11y regression) and the long task disappears: eight runs measured a worst
+ * frame of 18.6–32.3ms and no long task at all. The cost is ~4000 nodes kept
+ * alive; that trade is worth one less blocking chunk per click.
+ *
+ * **The transition.** `CollapsiblePanel` ships `transition-[height]
+ * duration-200` from the vendored component, and `height` is not compositable:
+ * every frame of it costs a style recalc + layout of the subtree. On a 39-row
+ * sidebar that made a click take 245ms to settle (31ms of it dead before
+ * anything moved); riding `opacity` + `translate` instead puts the layout in one
+ * shot and settles in 14ms. At 600 rows this part measures as a wash — mount
+ * cost dominates there — so it earns its place on the small-sidebar case, not
+ * the large one.
+ *
+ * `cn()` is tailwind-merge, so `transition-[opacity,translate]` replaces the
+ * vendored `transition-[height]` and `duration-150` replaces its `duration-200`.
+ * The panel's own `h-(--collapsible-panel-height)` and `data-*-style:h-0` stay —
+ * they just no longer interpolate, so the height snaps and the motion is
+ * composited. One consequence to know: on close the height zeroes immediately
+ * and `overflow-hidden` clips the fade, so collapsing reads as instant while
+ * expanding fades in. `ai-elements/reasoning.tsx` makes the same trade.
+ *
+ * Keep this a transition, never a keyframe animation: base-ui's
+ * `getAnimationType` warns when a panel has both, and silently picks one.
+ */
+export const COLLAPSIBLE_PANEL_MOTION: string =
+  "transition-[opacity,translate] duration-150 ease-out " +
+  "data-starting-style:-translate-y-1 data-starting-style:opacity-0 " +
+  "data-ending-style:-translate-y-1 data-ending-style:opacity-0";

--- a/apps/app/src/features/projects/project-list.tsx
+++ b/apps/app/src/features/projects/project-list.tsx
@@ -11,6 +11,7 @@ import {
 } from "@vibest/ui/components/sidebar";
 import { ChevronRight, FolderPlus } from "lucide-react";
 
+import { COLLAPSIBLE_PANEL_MOTION } from "@/features/projects/panel-motion";
 import { ProjectSessionsGroup } from "@/features/projects/project-sessions-group";
 import { useProjects } from "@/features/projects/use-projects";
 
@@ -34,7 +35,9 @@ export function ProjectList({ onImport }: { onImport: () => void }) {
           <FolderPlus />
           <span className="sr-only">Import project</span>
         </SidebarGroupAction>
-        <CollapsiblePanel>
+        {/* keepMounted: rebuilding every project's rows on each expand is a long
+            task once the sidebar is real-sized — see panel-motion.ts. */}
+        <CollapsiblePanel className={COLLAPSIBLE_PANEL_MOTION} keepMounted>
           <SidebarGroupContent className="flex flex-col gap-2">
             {(projects.data ?? []).map((project) => (
               <ProjectSessionsGroup key={project.id} project={project} />

--- a/apps/app/src/features/projects/project-sessions-group.tsx
+++ b/apps/app/src/features/projects/project-sessions-group.tsx
@@ -15,6 +15,7 @@ import {
 } from "@vibest/ui/components/sidebar";
 import { Folder, FolderOpen, SquarePen } from "lucide-react";
 
+import { COLLAPSIBLE_PANEL_MOTION } from "@/features/projects/panel-motion";
 import { useProjectSessions } from "@/features/projects/use-project-sessions";
 
 /**
@@ -57,7 +58,9 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
           {/* Names the button per project: element content wins over `title` in the accessible-name computation, so a bare "New chat" would make every project's action announce identically. */}
           <span className="sr-only">New chat in {project.name}</span>
         </SidebarGroupAction>
-        <CollapsiblePanel>
+        {/* keepMounted: see panel-motion.ts — an unmounting panel makes every
+            expand rebuild this project's whole session list. */}
+        <CollapsiblePanel className={COLLAPSIBLE_PANEL_MOTION} keepMounted>
           <SidebarGroupContent>
             <SidebarMenu>
               {sessions.map((session) => (


### PR DESCRIPTION
Expanding the sidebar's Projects group stuttered. Two separate causes; the first one is the load-bearing half.

## Remounting the whole list on every expand

base-ui unmounts a closed panel's subtree (`shouldRender = mounted || open`), so each expand rebuilt every row. At **10 projects / 600 sessions** that was a **60–80ms long task per click** — one blocking chunk, which is what reads as "I clicked and it hung". A probe caught 603 rows appearing in a single frame at t=75.6ms.

`keepMounted` holds the rows in the DOM behind `hidden` + `display:none`. Verified: **0 focusable elements** while closed, so keyboard and screen readers can't reach them — no a11y change. Cost is ~4000 nodes kept alive and +0.7MB heap.

| expand, 600 rows | worst frame | long task |
| --- | --- | --- |
| before | 50 / 51 / 66.7ms | 74 / 70 / 70ms |
| after | 18.6–32.3ms across 8 runs | none |

## Interpolating `height`

`height` isn't compositable — every frame of the transition costs a style recalc plus a layout of the subtree. On a 39-row sidebar a click took **245ms** to settle, 31ms of it dead before anything moved. Riding `opacity` + `translate` does the layout in one shot and settles in **14ms**, dropping layouts per expand/collapse cycle from 26.8 to 6.4.

At 600 rows this half measures as a wash — mount cost dominates — so it earns its place on the small-sidebar case, not the large one.

## Why the call sites

`packages/ui/src/components/collapsible` is vendored from the coss registry and would lose the edit on the next `--overwrite` refresh (`docs/adr/0001`). Both overrides ride the call sites instead; `cn()` is tailwind-merge, so `transition-[opacity,translate]` replaces the vendored `transition-[height]`. `ai-elements/reasoning.tsx` already uses the same trick.

## One visible consequence

On close the height zeroes immediately and `overflow-hidden` clips the fade, so **collapsing reads as instant while expanding fades in**. `reasoning.tsx` makes the same trade. Flagging it in case the asymmetry isn't wanted.

## Testing

Measured over CDP against a seeded 10-project / 600-session store, dev build with react-scan loaded. `turbo run typecheck --filter=@vibest/app` clean, 85 tests pass, lint/format clean.
