### PR TITLE
fix(server): stop storing the version inside the session record body

### DIFF
--- a/packages/server/src/harness/session-repository.ts
+++ b/packages/server/src/harness/session-repository.ts
@@ -10,7 +10,6 @@ import type { Session } from "../types";
  * check schema Type → Session.
  */
 const SessionSchema = Schema.Struct({
-  version: Schema.Literal(1),
   sessionId: Schema.String,
   projectId: Schema.String,
   harnessAgentId: Schema.Literals(["claude-code", "codex", "pi"]),
@@ -63,7 +62,8 @@ export const makeHarnessAgentSessionRepository = (sessionsDir: string) =>
     const sessions = yield* makeJsonCollection({
       dir: sessionsDir,
       schema: SessionSchema,
-      // Pre-envelope records are the bare body, already in the v1 shape.
+      // Pre-envelope records are the bare body with the version inlined, from
+      // before the envelope existed to hold it; decoding drops that key.
       legacy: { schema: SessionSchema, migrate: (session) => session },
     });
     const entryId = (projectId: string, sessionId: string) => `${projectId}/${sessionId}`;

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -408,7 +408,6 @@ export const makeHarnessAgentSessionService = (deps: {
           return manager.open(harnessAgentId, { cwd }, config ?? {}, ref).pipe(
             Effect.flatMap((session) => {
               const metadata: Session = {
-                version: 1,
                 sessionId,
                 projectId,
                 harnessAgentId,

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -18,8 +18,9 @@ export type { Project } from "@vibest/contract";
 
 /**
  * Server-owned recovery record for one session, persisted at
- * `storage/sessions/<projectId>/<sessionId>.json`. The filename mirrors
- * `sessionId`, which is also stored in the body so a loaded record is
+ * `storage/sessions/<projectId>/<sessionId>.json`, inside a `{version, data}`
+ * envelope that owns the version — this record does not carry one. The filename
+ * mirrors `sessionId`, which is also stored in the body so a loaded record is
  * self-contained; `harnessSessionId` is the agent-native id (claude session
  * uuid / codex thread id) the server translates to when calling the harness.
  *
@@ -32,7 +33,6 @@ export type { Project } from "@vibest/contract";
  * See docs/adr/0002-session-info-storage-floor-harness-overlay.md.
  */
 export interface Session {
-  readonly version: 1;
   readonly sessionId: string;
   readonly projectId: string;
   readonly harnessAgentId: HarnessAgentId;

--- a/packages/server/test/harness/session-repository.test.ts
+++ b/packages/server/test/harness/session-repository.test.ts
@@ -26,7 +26,6 @@ const makeLayer = (home: string) =>
   ).pipe(Layer.provide(NodePlatformLayer));
 
 const meta = (sessionId: string, projectId: string, harnessSessionId: string): Session => ({
-  version: 1,
   sessionId,
   projectId,
   harnessAgentId: "claude-code",
@@ -56,7 +55,6 @@ describe("SessionRepository", () => {
     );
     expect(read.sessionId).toBe("sess-1");
     expect(read.harnessSessionId).toBe("claude-uuid-1");
-    expect(read.version).toBe(1);
   });
 
   it("persists at storage/sessions/<projectId>/<sessionId>.json, sessionId in the body too", async () => {
@@ -72,12 +70,20 @@ describe("SessionRepository", () => {
     expect(raw.version).toBe(1);
     expect(raw.data.sessionId).toBe("sess-1");
     expect(raw.data.projectId).toBe("proj-a");
+    // The envelope owns the version; the body must not carry a second copy.
+    expect(raw.data).not.toHaveProperty("version");
   });
 
   it("reads a pre-envelope record and adopts it into envelope form", async () => {
     const file = path.join(home, "storage", "sessions", "proj-a", "sess-1.json");
     await fs.mkdir(path.dirname(file), { recursive: true });
-    await fs.writeFile(file, JSON.stringify(meta("sess-1", "proj-a", "claude-uuid-1")), "utf8");
+    // Pre-envelope records inline the version, from before the envelope
+    // existed to hold it — adoption lifts it out rather than keeping both.
+    await fs.writeFile(
+      file,
+      JSON.stringify({ version: 1, ...meta("sess-1", "proj-a", "claude-uuid-1") }),
+      "utf8",
+    );
 
     const read = await run(
       Effect.gen(function* () {
@@ -90,6 +96,7 @@ describe("SessionRepository", () => {
     const raw = JSON.parse(await fs.readFile(file, "utf8"));
     expect(raw.version).toBe(1);
     expect(raw.data.sessionId).toBe("sess-1");
+    expect(raw.data).not.toHaveProperty("version");
   });
 
   it("lists all sessions of a project", async () => {


### PR DESCRIPTION
Supersedes #192 — same change, rebased onto current `main` (the old branch conflicted with the archiving work in `session-service.ts`).

## The bug

`makeJsonCollection` writes a `{version, data}` envelope and picks the version schema before touching `data` — the version is the engine's, deliberately outside user data. The projects store passes a bare `Project[]` as its schema and gets `{"version":1,"data":[…]}`.

Sessions passed a schema with `version` in it, so every record on disk reads:

```json
{"version":1,"data":{"version":1,"sessionId":"e27f1854-…",…}}
```

Nothing ever read the inner one — `Session.version` has zero consumers across `packages/server`, `packages/contract` and `apps/app`.

## Why it mattered

It is what made the `legacy` step look right.

Pre-envelope records inline their version, because back then there was no envelope to hold it. With `version` still in the current schema, `legacy: { schema: SessionSchema, migrate: identity }` typechecked and mostly worked, and its comment — *"Pre-envelope records are the bare body, already in the v1 shape"* — read as true. So the two shapes were treated as identical, and the field where they genuinely differ went unnoticed until an old record hit it:

```
JsonStoreDecodeError: SchemaError: Missing key
  at ["sessionId"]
```

The oldest records predate `sessionId` in the body — it lived only in the filename. Since `list` fails whole-project on an undecodable record, one of them empties a project's sidebar group. Those records are bad data and were deleted; `sessionId` stays required on both sides. But the reason nobody could see that from the code is this redundant field.

## The change

`version` comes out of `SessionSchema` and out of the `Session` interface. The envelope owns it.

No migration, by design: existing records keep their stale inner `version` until something rewrites them. Excess keys are dropped on decode, so those records still read fine, and the next write emits `{"version":1,"data":{"sessionId":…}}` with no inner copy. Nothing walks the store to clean them up.

The `legacy` step keeps the identity migrate, which is now honest for the same reason it is honest in the projects store: the pre-envelope body really does decode to the current shape, its inlined version being exactly the key the envelope took over.

## Test

`persists at …` now asserts the body carries no `version`. The pre-envelope test writes its fixture with the version inlined, the way a real old file has it, and asserts adoption lifts it out instead of keeping both — which is also what covers the "excess key is dropped" claim above, since that fixture's `version` reaches the same `SessionSchema` an existing envelope record would.

`turbo run test typecheck --filter=@vibest/server` → 374 passed, 2 skipped, no type errors.
