### PR TITLE
feat(app): render the turn-summary body flush left

### DIFF
--- a/apps/app/src/features/chat/components/transcript/message-view.tsx
+++ b/apps/app/src/features/chat/components/transcript/message-view.tsx
@@ -1,6 +1,10 @@
-import { Tool, ToolContent, ToolHeader } from "@vibest/ui/ai-elements/tool";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@vibest/ui/components/collapsible";
 import { isToolUIPart, type UIMessage } from "ai";
-import { ListTreeIcon } from "lucide-react";
+import { ListTreeIcon, SquareMinusIcon, SquarePlusIcon } from "lucide-react";
 import { useMemo } from "react";
 
 import { AssistantMessage } from "./assistant-message";
@@ -39,19 +43,45 @@ function CollapsibleAssistantMessage({
   }
   return (
     <div>
-      <Tool>
-        <ToolHeader icon={ListTreeIcon}>{summary.label}</ToolHeader>
-        <ToolContent>
+      <Collapsible className="not-prose w-full py-1">
+        <SummaryTrigger label={summary.label} />
+        {/* Flush left, unlike a tool card's body: what folds here is whole
+            messages, so indenting them behind a rule would nest the whole
+            transcript one level in. */}
+        <CollapsibleContent className="mt-2 space-y-2 transition-opacity data-ending-style:opacity-0 data-starting-style:opacity-0">
           <AssistantMessage
             message={message}
             parts={summary.workParts}
             isStreaming={false}
             showActions={false}
           />
-        </ToolContent>
-      </Tool>
+        </CollapsibleContent>
+      </Collapsible>
       <AssistantMessage message={message} parts={summary.answerParts} isStreaming={false} />
     </div>
+  );
+}
+
+// The turn's icon swaps to a +/- box on hover or once open, the same
+// affordance ToolHeader gives a tool card. Local rather than borrowed: this
+// row summarises a turn, not a tool call, so it doesn't belong to that family.
+function SummaryTrigger({ label }: { label: string }) {
+  return (
+    <CollapsibleTrigger
+      className="group"
+      render={
+        <div className="text-muted-foreground hover:text-foreground flex w-full cursor-pointer items-center gap-2 overflow-hidden">
+          <span className="relative">
+            <ListTreeIcon className="size-4 group-hover:opacity-0 group-data-[panel-open]:opacity-0" />
+            <div className="absolute inset-0 size-4 opacity-0 group-hover:opacity-100 group-data-[panel-open]:opacity-100">
+              <SquarePlusIcon className="size-4 group-data-[panel-open]:hidden" />
+              <SquareMinusIcon className="hidden size-4 group-data-[panel-open]:block" />
+            </div>
+          </span>
+          <span className="truncate text-sm">{label}</span>
+        </div>
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## What

The first collapse layer in the transcript — the one that folds a settled assistant turn's work behind a `3 tool calls · 1 thought` summary — rendered its body indented behind `ToolContent`'s left rule. That rule is right for a single tool card, where the body really is "the detail of this one call". It's wrong here: the folded content is whole messages (text, tool batches, the model talking to itself), so every message inside got double-indented and the fold read as a nested card rather than a section of the turn.

## How

Build the disclosure from the `Collapsible` primitives with a local `SummaryTrigger`, instead of borrowing `Tool` / `ToolHeader` / `ToolContent`.

That family is named and styled for a tool call, and this row summarises a *turn*. Half-borrowing it — a `Tool` wrapper around a raw `CollapsibleContent` — would leave the call site straddling two layers, so it takes the whole thing locally. `ToolBatch` next door already builds its own trigger the same way.

`SummaryTrigger` keeps the existing affordance (ListTree icon swapping to a +/- box on hover or once open). That markup overlaps `ToolHeader`'s; the duplication is the price of not filing a turn summary under the tool-card family, and the reason is in a comment.

`packages/ui` is untouched. Layer 3 (the `Ran 4 commands` tool-batch accordion) and the per-tool cards are unaffected — they own their own `Collapsible` and keep their indent.

## Verification

`pnpm check` (oxlint + oxfmt + typecheck across all packages) — 10/10 green.

Driven at runtime against a real transcript: collapsed shows the ListTree icon, expanding swaps it to the minus box, the body sits flush left with the trigger and the final answer, and the batch accordions inside still indent as before.