### PR TITLE
fix(app): keep an in-flight prompt when the server restarts under it

### DIFF
--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -38,6 +38,9 @@ class FakeTransport implements ChatSessionTransport {
   getMessagesCalls = 0;
   promptCalls: Array<{ messageId: string; parts: ReadonlyArray<PromptPart> }> = [];
   promptError: unknown = null;
+  // When set, prompt blocks on it — for tests where the RPC is still in flight
+  // (a dropped socket queues it until the link reconnects).
+  promptGate: Promise<void> | null = null;
   responded: Array<{ requestId: string; response: AgentResponse }> = [];
 
   subscribe(onEvent: (event: ChatTransportEvent) => void): () => void {
@@ -48,6 +51,7 @@ class FakeTransport implements ChatSessionTransport {
   }
   prompt = async (input: { messageId: string; parts: ReadonlyArray<PromptPart> }) => {
     this.promptCalls.push(input);
+    if (this.promptGate) await this.promptGate;
     if (this.promptError) throw this.promptError;
     return { turnId: "turn-receipt" };
   };
@@ -151,6 +155,34 @@ describe("Chat hydration", () => {
     const last = chat.store.getState().messages.at(-1)!;
     expect(last.role).toBe("assistant");
     expect(assistantText(last)).toBe("after the restart");
+  });
+
+  // The server goes down while a prompt is queued on the dropped socket: the
+  // link holds the call, so the send is still pending when the server comes
+  // back. Its snapshot is idle and its settled transcript has never seen the
+  // prompt — neither may erase the optimistic bubble the user is looking at.
+  it("keeps an in-flight prompt when the server restarts under it", async () => {
+    const { chat, transport, attach } = makeChat();
+    transport.history = [userMessage("user-1", "hello")];
+    await attach({ cursor: 8 });
+
+    let releasePrompt: () => void = () => undefined;
+    transport.promptGate = new Promise((resolve) => {
+      releasePrompt = resolve;
+    });
+    const sent = chat.prompt("still queued");
+    await settle();
+    expect(chat.store.getState().messages).toHaveLength(2);
+    expect(chat.store.getState().status).toBe("submitted");
+
+    // The rebuilt session restarts its seq counter and knows nothing yet.
+    await attach({ cursor: 0 });
+
+    expect(chat.store.getState().messages.map((message) => message.role)).toEqual(["user", "user"]);
+    expect(chat.store.getState().status).toBe("submitted");
+
+    releasePrompt();
+    await sent;
   });
 
   it("lays the history floor before folding buffered or live chunks", async () => {

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -185,6 +185,51 @@ describe("Chat hydration", () => {
     await sent;
   });
 
+  // The other half of the same rule, and the reason "submitted" alone can't
+  // stand in for an unsettled prompt: a phase can also arrive on a live event
+  // from a turn that isn't ours. Idle moves us off "submitted" while our own
+  // prompt is still on the wire, so only the in-flight count still knows the
+  // settled transcript is missing a message.
+  it("keeps an in-flight prompt when another client's turn ends", async () => {
+    const { chat, transport, attach, live } = makeChat();
+    transport.history = [userMessage("user-1", "hello")];
+    await attach({ cursor: 8 });
+
+    let releasePrompt: () => void = () => undefined;
+    transport.promptGate = new Promise((resolve) => {
+      releasePrompt = resolve;
+    });
+    const sent = chat.prompt("still queued");
+    await settle();
+    expect(chat.store.getState().messages).toHaveLength(2);
+
+    // Not our turn, and not completed — so it both lands an idle phase and
+    // triggers the reconcile.
+    live(9, { type: "session.turn.ended", turnId: "other", outcome: "canceled", phase: "idle" });
+    await settle();
+    expect(chat.store.getState().messages).toHaveLength(2);
+
+    releasePrompt();
+    await sent;
+  });
+
+  // The counter is the RPC's own window, not the spinner's: once the prompt
+  // has landed, a snapshot is allowed to speak for it again. Holding
+  // "submitted" until a live event arrives would strand this case — the whole
+  // turn ran while detached, so the re-attach is the only thing left to clear
+  // the spinner.
+  it("clears the spinner from a snapshot once the prompt has landed", async () => {
+    const { chat, transport, attach } = makeChat();
+    transport.history = [userMessage("user-1", "hello")];
+    await attach({ cursor: 8 });
+    await chat.prompt("second");
+    expect(chat.store.getState().status).toBe("submitted");
+
+    transport.history = [userMessage("user-1", "hello"), userMessage("assistant-1", "reply")];
+    await attach({ cursor: 20 });
+    expect(chat.store.getState().status).toBe("ready");
+  });
+
   it("lays the history floor before folding buffered or live chunks", async () => {
     const { chat, transport, attach, live } = makeChat();
     transport.history = [userMessage("user-1", "hello")];

--- a/apps/app/src/features/chat/runtime/chat.ts
+++ b/apps/app/src/features/chat/runtime/chat.ts
@@ -93,6 +93,11 @@ export class Chat {
   // internally and still complete, with the retried tail persisted but never
   // streamed — reconcile from history at turn end regardless of outcome.
   readonly #erroredTurnIds = new Set<string>();
+  // Prompts whose RPC has not settled. The link queues a call across a dropped
+  // socket, so a prompt can outlive the server it was aimed at: nothing the
+  // server says in the meantime — snapshot phase, settled transcript — has
+  // seen it, and neither may erase the optimistic bubble it put on screen.
+  #promptsInFlight = 0;
   #cursor = 0;
   #historyLoaded = false;
   // Non-null while the history floor is loading: live events queue here so
@@ -392,7 +397,11 @@ export class Chat {
     if (this.#needsReconcile) void this.#reconcileHistory();
 
     this.#cursor = Math.max(this.#cursor, snapshot.cursor);
-    this.#setStatus(statusFromPhase(snapshot.status.phase));
+    // A prompt still on the wire is invisible to the server, so this phase
+    // predates it — the same reason `#apply` never copies a phase off the
+    // prompt events. Leave the sender's "submitted" standing; the RPC's own
+    // outcome, and the events it triggers, move the status from here.
+    if (this.#promptsInFlight === 0) this.#setStatus(statusFromPhase(snapshot.status.phase));
   }
 
   #replayActiveTurn(activeTurn: NonNullable<SessionRuntimeSnapshot["activeTurn"]>): void {
@@ -480,6 +489,11 @@ export class Chat {
         return;
       }
       if (history.length === 0) return;
+      // An unacknowledged prompt cannot be in the settled transcript, so a
+      // replace would drop the bubble the sender is looking at. Checked on its
+      // own rather than through the status: a snapshot hydrated mid-flight can
+      // leave the status disagreeing with what is actually pending.
+      if (this.#promptsInFlight > 0) return;
       if (this.#state.status === "streaming" || this.#state.status === "submitted") return;
       if (this.#turnFolds.size > 0) return;
       this.#state.messages = Array.from(history);
@@ -544,6 +558,7 @@ export class Chat {
     this.#state.error = undefined;
     this.#state.pushMessage(toUserMessage(messageId, parts));
     this.#setStatus("submitted");
+    this.#promptsInFlight += 1;
     try {
       await this.#transport.prompt({ messageId, parts });
     } catch (promptError) {
@@ -551,6 +566,8 @@ export class Chat {
         promptError instanceof Error ? promptError : new Error(String(promptError));
       this.#setStatus("error");
       throw promptError;
+    } finally {
+      this.#promptsInFlight -= 1;
     }
   };
 


### PR DESCRIPTION
## The report

> After I restart the server the page doesn't reload — I send again, the first message is lost, and only the second one gets a reply.

## What is actually happening

The retrying works. `RecoveringSubscription` re-attaches forever (500ms doubling to a 10s ceiling), and the oRPC WebSocket link reconnects with `maxAttempt: Infinity`, so a `prompt` issued while the server is down does not fail — the link holds it and delivers it once the server is back. Verified against a real kill/restart: the call resolves and the agent replies.

The message is not lost. **The user's own bubble is erased from the transcript**, and the reply then renders directly under the previous turn — which reads on screen as "that message went nowhere, the next one got answered".

## Cause

1. `Chat.prompt()` pushes the optimistic user message, sets `status = "submitted"`, and awaits an RPC that is now queued on a dead socket.
2. The server comes back with a rebuilt session, so its seq counter restarts. The re-attach hits `snapshot.cursor < #cursor`, resets the cursor and sets `#needsReconcile`, which fires `#reconcileHistory()`.
3. Still synchronously, `#hydrateFromSnapshot` ends with `#setStatus(statusFromPhase(snapshot.status.phase))`. The snapshot is idle — the server has never seen the queued prompt — so `"submitted"` becomes `"ready"`.
4. `#reconcileHistory()` resumes after its `await`. The `status === "submitted"` guard that exists precisely to protect an optimistic prompt is now false, so it replaces `messages` with the settled transcript, which does not contain the prompt. The bubble is gone.

`#apply` already refuses to copy a phase off the prompt events for exactly this reason ("the prompt events carry a phase the sender's optimistic 'submitted' state must outlive"). Snapshot hydration was not following the same rule.

## Fix

Track prompts whose RPC has not settled (`#promptsInFlight`) and let neither path speak for them:

- `#hydrateFromSnapshot` no longer moves the status while a prompt is in flight — the snapshot's phase predates it.
- `#reconcileHistory` returns early while a prompt is in flight; an unacknowledged prompt cannot be in the settled transcript. `#needsReconcile` stays set, so the read retries at the next turn boundary.

### Why a dedicated field, and why both halves

Reviewer's first instinct will be that `status === "submitted"` already means this, or that fixing the hydration makes the reconcile guard redundant. Both were tried; each leaves a hole, and each hole now has a test.

**`"submitted"` outlives the RPC.** It is cleared by the next server-stamped phase, not by the call returning. Gating hydration on `status !== "submitted"` therefore forbids the one thing that can clear the spinner when a whole turn ran while we were detached — no live event ever lands, so the re-attach snapshot is all that is left. That variant strands the UI on `"submitted"` forever (`clears the spinner from a snapshot once the prompt has landed`). The counter is the RPC's own window: it drops to zero the moment the prompt lands, and the snapshot gets its say back.

**Phases arrive on live events too, not just snapshots.** Another client's turn ending (`turn.ended`, phase `idle`, non-completed outcome) both knocks us off `"submitted"` and triggers a reconcile, while our own prompt is still on the wire. Without the second guard the bubble goes exactly the same way (`keeps an in-flight prompt when another client's turn ends`).

The distinction the field draws: `#promptsInFlight` is a fact about the transport (the server has not acknowledged this), `status` is a rendering state (what to show right now). This bug was caused by using the latter as a proxy for the former, so reusing it as the fix only moves the failure.

A counter rather than a boolean because `prompt()` is not serialized — the composer can fire again before the first call settles.

## Verification

- Regression test `keeps an in-flight prompt when the server restarts under it`. Confirmed red before the fix (`expected [ 'user' ] to deeply equal [ 'user', 'user' ]`), green after.
- Two more tests pinning the design, each confirmed red against the simpler variant it rules out.
- `turbo run test --filter=@vibest/app` — 113 passed.
- `typecheck`, `lint:check`, `format:check` clean.
- Driven in the browser against a real `kill -9` + restart: before, the bubble vanished and only the reply remained; after, the bubble survives and the reply lands under it.
