### PR TITLE
refactor(app): frame the draft composer with CardFrame

### DIFF
--- a/apps/app/src/features/projects/project-select.tsx
+++ b/apps/app/src/features/projects/project-select.tsx
@@ -28,20 +28,8 @@ export function ProjectSelect({
       }}
       value={value}
     >
-      {/*
-        Borderless, because it sits in the draft composer's CardFrame header and
-        should read as the frame's own label rather than a control stacked above
-        it. `select.tsx` is vendored (ADR 0001) and its CVA has no ghost variant,
-        so this is a class override — `before:hidden` included, since the base
-        draws a 1px inner shadow with that pseudo-element and dropping the border
-        alone still leaves a line. focus-visible ring and border stay.
-        `justify-self-start` is load-bearing: CardFrameHeader is a grid, and a
-        lone child would otherwise stretch and push the chevron to the far right.
-        The negative inset lines the label up with the composer text below it.
-
-        The name is only the folder's basename, so two projects can share one —
-        the path (on the trigger's title) is what actually tells them apart.
-      */}
+      {/* The name is only the folder's basename, so two projects can share one —
+          the path is what actually tells them apart. */}
       <SelectTrigger
         className="hover:bg-accent -mx-5.5 w-auto min-w-0 justify-self-start border-transparent bg-transparent shadow-none before:hidden dark:bg-transparent"
         size="sm"

--- a/apps/app/src/features/projects/project-select.tsx
+++ b/apps/app/src/features/projects/project-select.tsx
@@ -6,6 +6,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@vibest/ui/components/select";
+import { cn } from "@vibest/ui/lib/utils";
 
 // Project picker for the draft surface. There is no default: a new session must
 // name its project explicitly, so `null` is a real state the composer blocks on.
@@ -13,10 +14,13 @@ export function ProjectSelect({
   projects,
   value,
   onChange,
+  className,
 }: {
   projects: ReadonlyArray<Project>;
   value: string | null;
   onChange: (projectId: string) => void;
+  /** Applied to the trigger — the caller owns how the picker sits in its frame. */
+  className?: string;
 }) {
   const selected = projects.find((project) => project.id === value);
 
@@ -30,7 +34,7 @@ export function ProjectSelect({
     >
       {/* The name is only the folder's basename, so two projects can share one —
           the path is what actually tells them apart. */}
-      <SelectTrigger className="w-auto min-w-48" size="sm" title={selected?.path}>
+      <SelectTrigger className={cn("w-auto min-w-48", className)} size="sm" title={selected?.path}>
         <SelectValue placeholder="Select a project" />
       </SelectTrigger>
       <SelectContent>

--- a/apps/app/src/features/projects/project-select.tsx
+++ b/apps/app/src/features/projects/project-select.tsx
@@ -6,7 +6,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@vibest/ui/components/select";
-import { cn } from "@vibest/ui/lib/utils";
 
 // Project picker for the draft surface. There is no default: a new session must
 // name its project explicitly, so `null` is a real state the composer blocks on.
@@ -14,13 +13,10 @@ export function ProjectSelect({
   projects,
   value,
   onChange,
-  className,
 }: {
   projects: ReadonlyArray<Project>;
   value: string | null;
   onChange: (projectId: string) => void;
-  /** Applied to the trigger — the caller owns how the picker sits in its frame. */
-  className?: string;
 }) {
   const selected = projects.find((project) => project.id === value);
 
@@ -32,9 +28,25 @@ export function ProjectSelect({
       }}
       value={value}
     >
-      {/* The name is only the folder's basename, so two projects can share one —
-          the path is what actually tells them apart. */}
-      <SelectTrigger className={cn("w-auto min-w-48", className)} size="sm" title={selected?.path}>
+      {/*
+        Borderless, because it sits in the draft composer's CardFrame header and
+        should read as the frame's own label rather than a control stacked above
+        it. `select.tsx` is vendored (ADR 0001) and its CVA has no ghost variant,
+        so this is a class override — `before:hidden` included, since the base
+        draws a 1px inner shadow with that pseudo-element and dropping the border
+        alone still leaves a line. focus-visible ring and border stay.
+        `justify-self-start` is load-bearing: CardFrameHeader is a grid, and a
+        lone child would otherwise stretch and push the chevron to the far right.
+        The negative inset lines the label up with the composer text below it.
+
+        The name is only the folder's basename, so two projects can share one —
+        the path (on the trigger's title) is what actually tells them apart.
+      */}
+      <SelectTrigger
+        className="hover:bg-accent -mx-5.5 w-auto min-w-0 justify-self-start border-transparent bg-transparent shadow-none before:hidden dark:bg-transparent"
+        size="sm"
+        title={selected?.path}
+      >
         <SelectValue placeholder="Select a project" />
       </SelectTrigger>
       <SelectContent>

--- a/apps/app/src/routes/draft.tsx
+++ b/apps/app/src/routes/draft.tsx
@@ -301,12 +301,10 @@ function DraftRoute() {
         {/* Tighter than the stock py-4: one borderless control needs less room
             than the title/description pair the header is padded for. */}
         <CardFrameHeader className="py-2">
-          {/* The picker is the whole header — borderless so it reads as the
-              frame's own label rather than a second control stacked above the
-              composer. The negative inset pulls its text back onto the header's
-              padding edge; the hover tint is what still says it's clickable. */}
+          {/* The picker is the whole header — it carries its own borderless
+              styling, so it reads as the frame's label rather than a second
+              control stacked above the composer. */}
           <ProjectSelect
-            className="hover:bg-accent -mx-5.5 min-w-0 justify-self-start border-transparent bg-transparent shadow-none before:hidden dark:bg-transparent"
             // Harness config survives a project switch — it says how the session
             // runs, not what it is about. A pick the new project's catalog
             // doesn't offer is dropped by the resolvers, not carried into the

--- a/apps/app/src/routes/draft.tsx
+++ b/apps/app/src/routes/draft.tsx
@@ -14,6 +14,7 @@ import {
   PromptInputTools,
 } from "@vibest/ui/ai-elements/prompt-input";
 import { Button } from "@vibest/ui/components/button";
+import { Card, CardFrame, CardFrameHeader } from "@vibest/ui/components/card";
 import {
   Empty,
   EmptyContent,
@@ -289,26 +290,53 @@ function DraftRoute() {
 
   return (
     <div className="flex h-full items-center justify-center p-4">
-      <div className="flex w-full max-w-2xl flex-col gap-2">
-        <ProjectSelect
-          // Harness config survives a project switch — it says how the session
-          // runs, not what it is about. A pick the new project's catalog doesn't
-          // offer is dropped by the resolvers, not carried into the session.
-          onChange={(next) =>
-            navigate({
-              to: "/draft",
-              search: (prev) => ({ ...prev, projectId: next }),
-              replace: true,
-            })
+      {/*
+        CardFrame lifts the project pick out of the composer and into the frame
+        that holds it: what the session is *about* sits above, how it runs stays
+        on the composer toolbar below. The frame's own padding is the breathing
+        room on both sides of the header — the composer Card butts up against
+        the frame edge, so no gap utility here.
+      */}
+      <CardFrame className="w-full max-w-2xl">
+        {/* Tighter than the stock py-4: one borderless control needs less room
+            than the title/description pair the header is padded for. */}
+        <CardFrameHeader className="py-2">
+          {/* The picker is the whole header — borderless so it reads as the
+              frame's own label rather than a second control stacked above the
+              composer. The negative inset pulls its text back onto the header's
+              padding edge; the hover tint is what still says it's clickable. */}
+          <ProjectSelect
+            className="hover:bg-accent -mx-5.5 min-w-0 justify-self-start border-transparent bg-transparent shadow-none before:hidden dark:bg-transparent"
+            // Harness config survives a project switch — it says how the session
+            // runs, not what it is about. A pick the new project's catalog
+            // doesn't offer is dropped by the resolvers, not carried into the
+            // session.
+            onChange={(next) =>
+              navigate({
+                to: "/draft",
+                search: (prev) => ({ ...prev, projectId: next }),
+                replace: true,
+              })
+            }
+            projects={projects.data}
+            value={selected?.id ?? null}
+          />
+        </CardFrameHeader>
+        {/*
+          The composer *is* the Card: rendering the form as the frame's card
+          slot keeps a single element (no wrapper div between them), which is
+          what CardFrame's inset/clip styling targets. Card's own border wins
+          over PromptInput's standalone ring, as it should inside a frame.
+        */}
+        <Card
+          render={
+            <PromptInput
+              onSubmit={(e) => {
+                e.preventDefault();
+                void controller?.submit();
+              }}
+            />
           }
-          projects={projects.data}
-          value={selected?.id ?? null}
-        />
-        <PromptInput
-          onSubmit={(e) => {
-            e.preventDefault();
-            void controller?.submit();
-          }}
         >
           <ChatInputProvider controller={controller}>
             <ChatInput />
@@ -349,8 +377,8 @@ function DraftRoute() {
               <PromptInputSubmit disabled={!hasContent || !selected || startSession.isPending} />
             </PromptInputToolbar>
           </ChatInputProvider>
-        </PromptInput>
-      </div>
+        </Card>
+      </CardFrame>
     </div>
   );
 }

--- a/apps/app/src/routes/draft.tsx
+++ b/apps/app/src/routes/draft.tsx
@@ -290,25 +290,12 @@ function DraftRoute() {
 
   return (
     <div className="flex h-full items-center justify-center p-4">
-      {/*
-        CardFrame lifts the project pick out of the composer and into the frame
-        that holds it: what the session is *about* sits above, how it runs stays
-        on the composer toolbar below. The frame's own padding is the breathing
-        room on both sides of the header — the composer Card butts up against
-        the frame edge, so no gap utility here.
-      */}
       <CardFrame className="w-full max-w-2xl">
-        {/* Tighter than the stock py-4: one borderless control needs less room
-            than the title/description pair the header is padded for. */}
         <CardFrameHeader className="py-2">
-          {/* The picker is the whole header — it carries its own borderless
-              styling, so it reads as the frame's label rather than a second
-              control stacked above the composer. */}
           <ProjectSelect
             // Harness config survives a project switch — it says how the session
-            // runs, not what it is about. A pick the new project's catalog
-            // doesn't offer is dropped by the resolvers, not carried into the
-            // session.
+            // runs, not what it is about. A pick the new project's catalog doesn't
+            // offer is dropped by the resolvers, not carried into the session.
             onChange={(next) =>
               navigate({
                 to: "/draft",
@@ -320,12 +307,6 @@ function DraftRoute() {
             value={selected?.id ?? null}
           />
         </CardFrameHeader>
-        {/*
-          The composer *is* the Card: rendering the form as the frame's card
-          slot keeps a single element (no wrapper div between them), which is
-          what CardFrame's inset/clip styling targets. Card's own border wins
-          over PromptInput's standalone ring, as it should inside a frame.
-        */}
         <Card
           render={
             <PromptInput


### PR DESCRIPTION
Rebuilds the `/draft` new-session surface on the coss `CardFrame` pattern
(`@coss/p-card-11` — "CardFrame with header action"). The project pick and the
composer used to be two stacked boxes with a `gap-2` between them, which read as
two unrelated controls; now they are one frame, with the project pick as the
frame's header and the composer as the card inside it.

![draft composer](https://fileout.iamdin.workers.dev/f/Tna9SqpK)

_(screenshot link expires 2026-08-14)_

## Notes for review

- **The composer form _is_ the frame's card slot** — `<Card render={<PromptInput/>}>`,
  not a `Card` wrapping a `PromptInput`. `CardFrame`'s inset/clip styling targets
  its direct `[data-slot=card]` child, so an intermediate div would break the
  seam. This is the Base UI `render` composition the stack rules call for.
- **The picker is borderless, and owns that styling itself.** `select.tsx` is
  vendored (ADR 0001) and its CVA exposes only a `size` axis, so there is no ghost
  variant to reach for and editing it would be discarded on the next `--overwrite`.
  The flattening is therefore a class override, and it lives on `ProjectSelect`'s
  own trigger rather than being passed in — the component has exactly one call
  site, so a `className` prop would only have routed the styling through the route
  and back. `before:hidden` matters: the base draws its 1px inner shadow with that
  pseudo-element, so dropping the border alone still leaves a line.
  `focus-visible:ring` / `focus-visible:border-ring` are untouched, so keyboard
  focus stays visible, and `hover:bg-accent` is what still says the thing is
  clickable.
- `-mx-5.5` aligns the trigger's text with the composer's placeholder below it;
  `justify-self-start` is load-bearing because `CardFrameHeader` is a grid and the
  lone child would otherwise stretch, pushing the chevron to the far right.
- `CardFrameHeader` runs at `py-2` instead of the stock `py-4` — one borderless
  control needs less room than the title/description pair that padding is sized for.
- **`ChatInputComposer` (live session) is untouched.** It has no project picker,
  so there was nothing to lift into a header.

## Verification

- `turbo run typecheck --filter=@vibest/app`, `pnpm lint:check`, `pnpm format` — clean
- Driven at runtime on `/draft`: frame layout, project switch (URL + trigger label),
  submit-button enable/disable, and a real submit through the form's `onSubmit`
  → `session.create` → navigation to `/session/<id>`. That last one is the only
  behavioural risk in the change (the `render` swap could have dropped the
  handler) and it works.
