### PR TITLE
feat: support renaming session titles

### DIFF
--- a/apps/app/src/features/projects/rename-session-dialog.tsx
+++ b/apps/app/src/features/projects/rename-session-dialog.tsx
@@ -1,0 +1,123 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
+import { MAX_SESSION_TITLE_CHARS, type SessionSummary } from "@vibest/contract";
+import { Button } from "@vibest/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPopup,
+  DialogTitle,
+} from "@vibest/ui/components/dialog";
+import { Input } from "@vibest/ui/components/input";
+import { Label } from "@vibest/ui/components/label";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { reconcileSessionRenameSuccess } from "@/features/projects/session-list-cache";
+
+/**
+ * Give a session a title of your own. Mount only while open — the draft title
+ * resets by unmounting on close, the same way the import dialog resets its
+ * browsing state.
+ *
+ * The server publishes `session.renamed` only after the title is durable, and
+ * the app's one global event consumer folds that event into every active or
+ * archived session list. Success also performs a guarded local reconciliation
+ * for the initiating tab: it repairs a non-replay subscription gap without
+ * overwriting a different title that a newer event has already applied.
+ */
+export function RenameSessionDialog({
+  session,
+  onClose,
+}: {
+  readonly session: SessionSummary;
+  onClose: () => void;
+}) {
+  const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState(session.title ?? "");
+  // The wire schema takes a trimmed, non-empty title; trimming here makes
+  // " foo " a rename rather than a validation error the user must decode.
+  const title = draft.trim();
+
+  const rename = useMutation({
+    mutationFn: (variables: {
+      readonly title: string;
+      readonly previousTitle: string | undefined;
+    }) =>
+      orpcQueryUtils.session.rename.call({
+        ref: {
+          projectId: session.projectId,
+          harnessAgentId: session.harnessAgentId,
+          sessionId: session.sessionId,
+        },
+        title: variables.title,
+      }),
+    onSuccess: (_result, variables) => {
+      const ref = {
+        projectId: session.projectId,
+        harnessAgentId: session.harnessAgentId,
+        sessionId: session.sessionId,
+      };
+      reconcileSessionRenameSuccess(
+        queryClient,
+        (projectId, archived) =>
+          orpcQueryUtils.session.list.queryOptions({ input: { projectId, archived } }).queryKey,
+        ref,
+        variables.previousTitle,
+        variables.title,
+      );
+      onClose();
+    },
+    onError: (error) => toast.error(`Failed to rename session: ${error.message}`),
+  });
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && !rename.isPending && onClose()}>
+      <DialogPopup className="max-w-md">
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            rename.mutate({ title, previousTitle: session.title });
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Rename session</DialogTitle>
+            <DialogDescription>
+              The title is yours — a later prompt never overwrites it.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col items-start gap-2 px-6 pb-4">
+            <Label htmlFor="session-title">Title</Label>
+            <Input
+              autoFocus
+              disabled={rename.isPending}
+              id="session-title"
+              maxLength={MAX_SESSION_TITLE_CHARS}
+              onChange={(event) => setDraft(event.target.value)}
+              onFocus={(event) => event.currentTarget.select()}
+              placeholder="New chat"
+              value={draft}
+            />
+          </div>
+          <DialogFooter>
+            <DialogClose
+              render={<Button disabled={rename.isPending} type="button" variant="outline" />}
+            >
+              Cancel
+            </DialogClose>
+            <Button
+              disabled={rename.isPending || title === "" || title === session.title}
+              type="submit"
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/app/src/features/projects/session-actions-menu.tsx
+++ b/apps/app/src/features/projects/session-actions-menu.tsx
@@ -3,8 +3,11 @@ import { useNavigate, useParams, useRouteContext } from "@tanstack/react-router"
 import type { SessionSummary } from "@vibest/contract";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@vibest/ui/components/menu";
 import { SidebarMenuAction } from "@vibest/ui/components/sidebar";
-import { Archive, ArchiveRestore, Ellipsis } from "lucide-react";
+import { Archive, ArchiveRestore, Ellipsis, Pencil } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
+
+import { RenameSessionDialog } from "@/features/projects/rename-session-dialog";
 
 /** Session mutations live behind one actions-menu capability boundary. */
 export function SessionActionsMenu({ session }: { readonly session: SessionSummary }) {
@@ -13,6 +16,7 @@ export function SessionActionsMenu({ session }: { readonly session: SessionSumma
   const queryClient = useQueryClient();
   // strict: false — the menu also renders on routes without a sessionId.
   const { sessionId: activeSessionId } = useParams({ strict: false });
+  const [renaming, setRenaming] = useState(false);
   const title = session.title ?? "New chat";
 
   const setArchived = useMutation({
@@ -48,27 +52,37 @@ export function SessionActionsMenu({ session }: { readonly session: SessionSumma
   });
 
   return (
-    <Menu>
-      <MenuTrigger
-        render={
-          <SidebarMenuAction
-            aria-label={`Actions for ${title}`}
-            disabled={setArchived.isPending}
-            showOnHover
-          />
-        }
-      >
-        <Ellipsis />
-      </MenuTrigger>
-      <MenuPopup align="start" side="right">
-        <MenuItem
-          disabled={setArchived.isPending}
-          onClick={() => setArchived.mutate(!session.archived)}
+    <>
+      <Menu>
+        <MenuTrigger
+          render={
+            <SidebarMenuAction
+              aria-label={`Actions for ${title}`}
+              disabled={setArchived.isPending}
+              showOnHover
+            />
+          }
         >
-          {session.archived ? <ArchiveRestore /> : <Archive />}
-          {session.archived ? "Restore" : "Archive"}
-        </MenuItem>
-      </MenuPopup>
-    </Menu>
+          <Ellipsis />
+        </MenuTrigger>
+        <MenuPopup align="start" side="right">
+          <MenuItem onClick={() => setRenaming(true)}>
+            <Pencil />
+            Rename
+          </MenuItem>
+          <MenuItem
+            disabled={setArchived.isPending}
+            onClick={() => setArchived.mutate(!session.archived)}
+          >
+            {session.archived ? <ArchiveRestore /> : <Archive />}
+            {session.archived ? "Restore" : "Archive"}
+          </MenuItem>
+        </MenuPopup>
+      </Menu>
+      {/* Mounted only while open so the draft title starts from the current
+          title every time, and unmounted before the menu's own exit animation
+          has anywhere to put focus back. */}
+      {renaming && <RenameSessionDialog onClose={() => setRenaming(false)} session={session} />}
+    </>
   );
 }

--- a/apps/app/src/features/projects/session-list-cache.test.ts
+++ b/apps/app/src/features/projects/session-list-cache.test.ts
@@ -1,8 +1,12 @@
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import type { ListSessionsOutput, SessionRef, ServerEvent } from "@vibest/contract";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { applySessionListEvent, type ListKeyFor } from "./session-list-cache";
+import {
+  applySessionListEvent,
+  type ListKeyFor,
+  reconcileSessionRenameSuccess,
+} from "./session-list-cache";
 
 const ref: SessionRef = {
   projectId: "project-1",
@@ -108,9 +112,114 @@ describe("applySessionListEvent", () => {
 
   it("renames and deletes rows in place", () => {
     const queryClient = seed([row(), row({ sessionId: "session-2", title: "other" })]);
-    applySessionListEvent(queryClient, listKeyFor, { ref, type: "session.renamed", name: "named" });
+    applySessionListEvent(queryClient, listKeyFor, {
+      ref,
+      type: "session.renamed",
+      title: "named",
+    });
     expect(rows(queryClient)?.[0]?.title).toBe("named");
     applySessionListEvent(queryClient, listKeyFor, { ref, type: "session.deleted" });
     expect(rows(queryClient)?.map((s) => s.sessionId)).toEqual(["session-2"]);
+  });
+
+  // Duplicate delivery is harmless: re-writing the array for an already
+  // applied title would re-render every row for no change.
+  it("keeps the array identity when a rename event carries the title already shown", () => {
+    const queryClient = seed([row({ title: "named" })]);
+    const before = rows(queryClient);
+    applySessionListEvent(queryClient, listKeyFor, {
+      ref,
+      type: "session.renamed",
+      title: "named",
+    });
+    expect(rows(queryClient)).toBe(before);
+  });
+
+  // Rename events write the cache directly and never fetch. Driven through a
+  // live QueryObserver because an inactive query would not expose an accidental
+  // refetch — that would prove nothing.
+  it("writes a rename straight into a live cache without refetching it", async () => {
+    const queryClient = new QueryClient();
+    const key = listKeyFor(ref.projectId, false);
+    let fetches = 0;
+    const observer = new QueryObserver(queryClient, {
+      queryKey: key,
+      queryFn: () => {
+        fetches += 1;
+        return [row()];
+      },
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    try {
+      // Wait for the row to land, not just for queryFn to be entered — the
+      // counter ticks before the result is written.
+      await vi.waitFor(() => expect(rows(queryClient)).toHaveLength(1));
+      expect(fetches).toBe(1);
+
+      applySessionListEvent(queryClient, listKeyFor, {
+        ref,
+        type: "session.renamed",
+        title: "named",
+      });
+      expect(rows(queryClient)?.[0]?.title).toBe("named");
+      expect(fetches).toBe(1);
+
+      // The contrast: invalidating the same live query *does* go back out.
+      await queryClient.invalidateQueries({ queryKey: key });
+      expect(fetches).toBe(2);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  // The event carries the complete title, so an existing row needs no refetch.
+  it("folds a rename in place without invalidating either list", () => {
+    const queryClient = seed([row()]);
+    applySessionListEvent(queryClient, listKeyFor, {
+      ref,
+      type: "session.renamed",
+      title: "named",
+    });
+    expect(rows(queryClient)?.[0]?.title).toBe("named");
+    expect(queryClient.getQueryState(listKeyFor(ref.projectId, false))?.isInvalidated).toBe(false);
+    expect(
+      queryClient.getQueryState(listKeyFor(ref.projectId, true))?.isInvalidated,
+    ).toBeUndefined();
+  });
+
+  it("invalidates both lists when a rename targets a row we don't hold", () => {
+    const queryClient = seed([]);
+    queryClient.setQueryData<ListSessionsOutput>(listKeyFor(ref.projectId, true), []);
+    applySessionListEvent(queryClient, listKeyFor, {
+      ref,
+      type: "session.renamed",
+      title: "named",
+    });
+    expect(queryClient.getQueryState(listKeyFor(ref.projectId, false))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(listKeyFor(ref.projectId, true))?.isInvalidated).toBe(true);
+  });
+});
+
+describe("reconcileSessionRenameSuccess", () => {
+  it("patches the starting title when the firehose event was missed", () => {
+    const queryClient = seed([row({ title: "before" })]);
+    reconcileSessionRenameSuccess(queryClient, listKeyFor, ref, "before", "after");
+    expect(rows(queryClient)?.[0]?.title).toBe("after");
+  });
+
+  it("preserves a different title already applied by a newer event", () => {
+    const queryClient = seed([row({ title: "newer" })]);
+    const before = rows(queryClient);
+    reconcileSessionRenameSuccess(queryClient, listKeyFor, ref, "before", "after");
+    expect(rows(queryClient)).toBe(before);
+    expect(rows(queryClient)?.[0]?.title).toBe("newer");
+  });
+
+  it("invalidates both lists when the initiating tab no longer holds the row", () => {
+    const queryClient = seed([]);
+    queryClient.setQueryData<ListSessionsOutput>(listKeyFor(ref.projectId, true), []);
+    reconcileSessionRenameSuccess(queryClient, listKeyFor, ref, "before", "after");
+    expect(queryClient.getQueryState(listKeyFor(ref.projectId, false))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(listKeyFor(ref.projectId, true))?.isInvalidated).toBe(true);
   });
 });

--- a/apps/app/src/features/projects/session-list-cache.ts
+++ b/apps/app/src/features/projects/session-list-cache.ts
@@ -44,6 +44,12 @@ const patchLists = (
   return found;
 };
 
+const invalidateLists = (queryClient: QueryClient, listKeys: ReadonlyArray<QueryKey>): void => {
+  for (const listKey of listKeys) {
+    void queryClient.invalidateQueries({ queryKey: listKey });
+  }
+};
+
 const removeFromLists = (
   queryClient: QueryClient,
   listKeys: ReadonlyArray<QueryKey>,
@@ -63,8 +69,8 @@ const removeFromLists = (
  * Session-scoped events contribute only their server-stamped `phase` (the
  * runtime stamps its post-event phase, so this copies rather than re-derives);
  * chunk events are skipped for traffic — their phase never differs from the
- * lifecycle event that opened the turn. A phase or title for a row we don't
- * hold is dropped or resolved by one list refetch — the next load carries it.
+ * lifecycle event that opened the turn. A title for a row we don't hold is
+ * resolved by one list refetch — the authoritative read carries the summary.
  */
 export const applySessionListEvent = (
   queryClient: QueryClient,
@@ -89,19 +95,21 @@ export const applySessionListEvent = (
       const found = patchLists(queryClient, listKeys, event.ref.sessionId, (row) =>
         event.title !== undefined ? { ...row, title: event.title } : row,
       );
-      if (!found) {
-        for (const listKey of listKeys) {
-          void queryClient.invalidateQueries({ queryKey: listKey });
-        }
-      }
+      if (!found) invalidateLists(queryClient, listKeys);
       break;
     }
-    case "session.renamed":
-      patchLists(queryClient, listKeys, event.ref.sessionId, (row) => ({
-        ...row,
-        title: event.name,
-      }));
+    case "session.renamed": {
+      // Same-title short-circuit as the phase patch above: a row already
+      // carrying this title keeps its identity, so duplicate delivery stays
+      // idempotent and does not re-render the whole list. A missing row means
+      // another client may have created and renamed the session before this
+      // client ever listed it, so pull the complete summary once.
+      const found = patchLists(queryClient, listKeys, event.ref.sessionId, (row) =>
+        row.title === event.title ? row : { ...row, title: event.title },
+      );
+      if (!found) invalidateLists(queryClient, listKeys);
       break;
+    }
     case "session.archived": {
       const sourceKey = listKeyFor(event.ref.projectId, !event.archived);
       const destinationKey = listKeyFor(event.ref.projectId, event.archived);
@@ -117,7 +125,29 @@ export const applySessionListEvent = (
     case "session.created":
       // The creating tab already seeded this row optimistically; a title-less
       // row elsewhere has nothing to show yet. Other clients pick the session
-      // up on its first prompt's `session.updated`, or their next list load.
+      // up on its first prompt's `session.updated`, a manual rename, or their
+      // next list load.
       break;
   }
+};
+
+/**
+ * Reconcile the initiating tab after a successful rename RPC. The firehose is
+ * still the primary path, but it has no replay: if this response lands during
+ * a subscription gap, patch the row that still carries the dialog's starting
+ * title. A different current title is treated as a newer event and preserved.
+ */
+export const reconcileSessionRenameSuccess = (
+  queryClient: QueryClient,
+  listKeyFor: ListKeyFor,
+  ref: ServerEvent["ref"],
+  previousTitle: string | undefined,
+  title: string,
+): void => {
+  const listKeys = [listKeyFor(ref.projectId, false), listKeyFor(ref.projectId, true)];
+  const found = patchLists(queryClient, listKeys, ref.sessionId, (row) => {
+    if (row.title === title || row.title !== previousTitle) return row;
+    return { ...row, title };
+  });
+  if (!found) invalidateLists(queryClient, listKeys);
 };

--- a/docs/2026-07-11-harness-agent-ai-sdk-package-plan.md
+++ b/docs/2026-07-11-harness-agent-ai-sdk-package-plan.md
@@ -417,7 +417,7 @@ export const SessionDeleted = defineEvent({
 });
 export const SessionRenamed = defineEvent({
   type: "session.renamed",
-  schema: { sessionId: z.string(), name: z.string() },
+  schema: { sessionId: z.string(), title: z.string() },
 });
 export const ProjectUpdated = defineEvent({
   type: "project.updated",

--- a/docs/design/session-agent-design.md
+++ b/docs/design/session-agent-design.md
@@ -773,7 +773,7 @@ type ListSessionsOutput = {
 };
 
 type RenameSessionInput = SessionRef & {
-  name: string;
+  title: string;
 };
 
 type RenameSessionOutput = void;
@@ -1398,7 +1398,7 @@ type ServerEvent = {
     }
   | {
       type: "session.renamed";
-      name: string;
+      title: string;
     }
   | {
       type: "session.message.chunk";

--- a/docs/wayfinder/session-streaming-refactor/tickets/09-impl-list-rename-delete.md
+++ b/docs/wayfinder/session-streaming-refactor/tickets/09-impl-list-rename-delete.md
@@ -24,7 +24,7 @@ blocked-by: [07-impl-create-resume.md]
 
 - **list**（`rpc/session.ts`）：把 `SessionService.list` 的每条 `SessionSummary` 与 `SessionRuntimeRegistry.status(ref)` 合并——活跃会话带 `status.phase`，非活跃（`SessionNotActive`，`catchTag` 兜住）不带 status（`SessionSummary.status` 本就 optional）。`historyAvailable` 暂恒 `true`（注释指向 10/11 做真实 per-session 判定）。
 - **delete**：维持 `registry.stop → bus.closeSession → SessionService.delete(harness.close + repo.remove，幂等/容忍缺失) → bus.publish(session.deleted)`。
-- **rename**：未做服务端持久化，保留现有「校验 ref + 广播 `session.renamed`」的 broadcast-only stub（刷新不留存）；原生标题写入待 harness native-title 面（见 map「Not yet specified」）。
+- **rename（当时状态）**：未做服务端持久化，保留现有「校验 ref + 广播 `session.renamed`」的 broadcast-only stub（刷新不留存）；原生标题写入待 harness native-title 面（见 map「Not yet specified」）。后续 `feat/session-rename` 已改为持久化服务端 metadata 的 `title`，并统一 RPC 与事件 payload 使用 `title`。
 - **测试**：`session-service.test.ts` 加 delete 单测（关原生 + 删元数据 → list 空）；`rpc-session.test.ts` 抽 `setup()` 复用，加集成测「active 有 status → close 后无 status → delete 后列表空」。server 41 测绿、全仓 `build test typecheck` 19/19 绿、lint/format 干净。
 
 **未接线/遗留**：app 侧边栏仍消费 mock（`components/layout/app-sidebar.tsx`），接真实 `session.list` 归客户端工作（12 或独立 UI ticket）；原生标题（rename）与原生历史删除（delete 的另一半）待 harness 面，已登记入 map「Not yet specified」。

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -272,7 +272,7 @@ export type CollectionEvent = { readonly ref: SessionRef } & (
   | { readonly type: "session.updated"; readonly title?: string }
   | { readonly type: "session.archived"; readonly archived: boolean }
   | { readonly type: "session.deleted" }
-  | { readonly type: "session.renamed"; readonly name: string }
+  | { readonly type: "session.renamed"; readonly title: string }
 );
 
 export type ServerEvent = SessionScopedEvent | CollectionEvent;
@@ -628,9 +628,23 @@ export type SessionSummary = {
 /** `session.list` returns the summaries directly — one shape, no wrapper. */
 export type ListSessionsOutput = ReadonlyArray<SessionSummary>;
 
+/**
+ * Longest title a client may give a session. The title is persisted on the
+ * session record and broadcast to every client on rename, so it is bounded
+ * here rather than left to whatever a caller sends.
+ */
+export const MAX_SESSION_TITLE_CHARS = 120;
+
 export const RenameSessionInputSchema = Schema.Struct({
   ref: SessionRefSchema,
-  name: Schema.NonEmptyString,
+  // `isTrimmed` with `isNonEmpty` is what rejects a whitespace-only title: the
+  // server stores the string as given, and a blank title would render as an
+  // unnamed row that no amount of renaming visibly fixes.
+  title: Schema.String.check(
+    Schema.isTrimmed(),
+    Schema.isNonEmpty(),
+    Schema.isMaxLength(MAX_SESSION_TITLE_CHARS),
+  ),
 });
 export type RenameSessionInput = typeof RenameSessionInputSchema.Type;
 

--- a/packages/contract/test/schema.test.ts
+++ b/packages/contract/test/schema.test.ts
@@ -8,6 +8,8 @@ import {
   HarnessProbeInputSchema,
   HarnessProbeOutputSchema,
   ListSessionsInputSchema,
+  MAX_SESSION_TITLE_CHARS,
+  RenameSessionInputSchema,
   type ServerEvent,
   serverErrors,
   ServerErrorCodes,
@@ -46,6 +48,32 @@ describe("ArchiveSessionInput", () => {
   it("requires an explicit archived state", () => {
     expect(accepts(ArchiveSessionInputSchema, { ref, archived: true })).toBe(true);
     expect(accepts(ArchiveSessionInputSchema, { ref })).toBe(false);
+  });
+});
+
+describe("RenameSessionInput", () => {
+  it("accepts a trimmed, non-empty title within the bound", () => {
+    expect(accepts(RenameSessionInputSchema, { ref, title: "Login bug" })).toBe(true);
+    expect(
+      accepts(RenameSessionInputSchema, { ref, title: "x".repeat(MAX_SESSION_TITLE_CHARS) }),
+    ).toBe(true);
+  });
+
+  it("rejects a title that would render as a blank row", () => {
+    expect(accepts(RenameSessionInputSchema, { ref, title: "" })).toBe(false);
+    expect(accepts(RenameSessionInputSchema, { ref, title: "   " })).toBe(false);
+    // Untrimmed rather than blank, but the server stores the string as given.
+    expect(accepts(RenameSessionInputSchema, { ref, title: " Login bug " })).toBe(false);
+  });
+
+  it("rejects a title past the bound", () => {
+    expect(
+      accepts(RenameSessionInputSchema, { ref, title: "x".repeat(MAX_SESSION_TITLE_CHARS + 1) }),
+    ).toBe(false);
+  });
+
+  it("rejects the legacy name field", () => {
+    expect(accepts(RenameSessionInputSchema, { ref, name: "Login bug" })).toBe(false);
   });
 });
 

--- a/packages/server/src/harness/events/framework.ts
+++ b/packages/server/src/harness/events/framework.ts
@@ -81,7 +81,7 @@ export const SessionDeleted = defineEvent({
 });
 export const SessionRenamed = defineEvent({
   type: "session.renamed",
-  schema: { sessionId: Schema.String, name: Schema.String },
+  schema: { sessionId: Schema.String, title: Schema.String },
 });
 export const ProjectUpdated = defineEvent({
   type: "project.updated",

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -10,7 +10,7 @@ import type {
   SessionSummary,
 } from "@vibest/contract";
 import type { UIMessage } from "ai";
-import { Context, Crypto, Effect, FileSystem, Layer } from "effect";
+import { Context, Crypto, Effect, FileSystem, Layer, Semaphore } from "effect";
 
 import { Paths } from "../config/paths";
 import {
@@ -125,10 +125,16 @@ export type HarnessAgentSessionServiceShape = {
   readonly delete: (
     ref: SessionRef,
   ) => Effect.Effect<void, SessionNotFound | SessionRefMismatch | StoreReadError | StoreWriteError>;
+  /**
+   * Set a session title by hand. The title is ours to own (see {@link deriveTitle}),
+   * so this is a plain metadata write — the harness is never told, and a
+   * user-chosen title survives every later prompt because
+   * `readAndStampTitleFromFirstPrompt` only fills a record that has none.
+   */
   readonly rename: (
     ref: SessionRef,
-    name: string,
-  ) => Effect.Effect<void, SessionNotFound | SessionRefMismatch | StoreReadError>;
+    title: string,
+  ) => Effect.Effect<void, SessionNotFound | SessionRefMismatch | StoreReadError | StoreWriteError>;
   readonly archive: (
     ref: SessionRef,
     archived: boolean,
@@ -293,6 +299,23 @@ export const makeHarnessAgentSessionService = (deps: {
 }): HarnessAgentSessionServiceShape => {
   const { manager, registry, repo, bus, newSessionId } = deps;
 
+  // Metadata updates are read-modify-write operations over one JSON record.
+  // Serialize each session independently so two fields changed at once cannot
+  // overwrite each other from stale snapshots, while a slow harness shutdown
+  // for one session never stalls metadata work for every other session. Locks
+  // stay keyed for this service's lifetime: retaining one tiny semaphore per
+  // touched session avoids replacing a lock while delete waiters still hold it.
+  const metadataMutationLocks = new Map<string, ReturnType<typeof Semaphore.makeUnsafe>>();
+  const withMetadataMutation = <A, E, R>(
+    ref: SessionRef,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> => {
+    const key = `${ref.projectId}\0${ref.sessionId}`;
+    const lock = metadataMutationLocks.get(key) ?? Semaphore.makeUnsafe(1);
+    metadataMutationLocks.set(key, lock);
+    return lock.withPermit(effect);
+  };
+
   // The permission mode is our closed vocabulary, so membership in the
   // harness's declared subset is checked here — the boundary between the
   // wire and the adapters — and rejected loudly. Opaque values (model) get
@@ -380,24 +403,27 @@ export const makeHarnessAgentSessionService = (deps: {
   // SessionRefMismatch) before the manager is asked for anything. It just no
   // longer supplies an address — the manager is keyed by the ref itself.
   // The first prompt establishes the session title. Best-effort: a failed
-  // title write must never block the prompt itself. A record that already has
-  // a title (any later prompt) is left alone. On a real write we publish
-  // `session.updated` so every client patches the row — the specific event
-  // that reconciles the optimistic title, in place of any timer.
-  const stampTitleFromFirstPrompt = (metadata: Session, parts: PromptInput["parts"]) => {
-    if (metadata.title !== undefined) return Effect.void;
-    const title = deriveTitle(parts);
-    if (title === undefined) return Effect.void;
-    const ref: SessionRef = {
-      projectId: metadata.projectId,
-      harnessAgentId: metadata.harnessAgentId,
-      sessionId: metadata.sessionId,
-    };
-    return repo.write({ ...metadata, title }).pipe(
-      Effect.andThen(bus.publish({ ref, type: "session.updated", title })),
-      Effect.catchTag("StoreWriteError", () => Effect.void),
+  // title write must never block the prompt itself. Re-read while holding the
+  // metadata gate so a concurrent manual rename always wins rather than being
+  // overwritten from the prompt's stale snapshot. On a real write we publish
+  // `session.updated` before releasing the gate, preserving write/event order.
+  const readAndStampTitleFromFirstPrompt = (ref: SessionRef, parts: PromptInput["parts"]) =>
+    withMetadataMutation(
+      ref,
+      readChecked(ref).pipe(
+        Effect.flatMap((metadata) => {
+          if (metadata.title !== undefined) return Effect.succeed(metadata);
+          const title = deriveTitle(parts);
+          if (title === undefined) return Effect.succeed(metadata);
+          const updated = { ...metadata, title };
+          return repo.write(updated).pipe(
+            Effect.andThen(bus.publish({ ref, type: "session.updated", title })),
+            Effect.as(updated),
+            Effect.catchTag("StoreWriteError", () => Effect.succeed(metadata)),
+          );
+        }),
+      ),
     );
-  };
 
   return {
     create: (projectId, harnessAgentId, cwd, config) =>
@@ -431,10 +457,16 @@ export const makeHarnessAgentSessionService = (deps: {
       ),
 
     prepare: (ref, cwd) =>
-      readChecked(ref).pipe(
-        Effect.tap((metadata) =>
-          metadata.cwd === cwd ? Effect.void : repo.write({ ...metadata, cwd }),
+      withMetadataMutation(
+        ref,
+        readChecked(ref).pipe(
+          Effect.flatMap((metadata) => {
+            if (metadata.cwd === cwd) return Effect.succeed(metadata);
+            const updated = { ...metadata, cwd };
+            return repo.write(updated).pipe(Effect.as(updated));
+          }),
         ),
+      ).pipe(
         Effect.flatMap((metadata) =>
           registry
             .get(ref.harnessAgentId)
@@ -460,33 +492,51 @@ export const makeHarnessAgentSessionService = (deps: {
       ),
 
     delete: (ref) =>
-      readChecked(ref).pipe(
-        Effect.andThen(manager.close(ref)),
-        Effect.andThen(bus.closeSession(ref, "session_deleted")),
-        Effect.andThen(repo.remove(ref.projectId, ref.sessionId)),
-        Effect.andThen(bus.publish({ ref, type: "session.deleted" })),
+      withMetadataMutation(
+        ref,
+        readChecked(ref).pipe(
+          Effect.andThen(manager.close(ref)),
+          Effect.andThen(bus.closeSession(ref, "session_deleted")),
+          Effect.andThen(repo.remove(ref.projectId, ref.sessionId)),
+          Effect.andThen(bus.publish({ ref, type: "session.deleted" })),
+        ),
       ),
 
-    rename: (ref, name) =>
-      resolveHarnessSessionId(ref).pipe(
-        Effect.andThen(bus.publish({ ref, type: "session.renamed", name })),
+    rename: (ref, title) =>
+      withMetadataMutation(
+        ref,
+        readChecked(ref).pipe(
+          Effect.flatMap((metadata) =>
+            // Persist before announcing: a rename every client has applied but
+            // no record carries would come back on the next list load. A no-op
+            // rename writes and publishes nothing.
+            metadata.title === title
+              ? Effect.void
+              : repo
+                  .write({ ...metadata, title })
+                  .pipe(Effect.andThen(bus.publish({ ref, type: "session.renamed", title }))),
+          ),
+        ),
       ),
 
     archive: (ref, archived) =>
-      readChecked(ref).pipe(
-        Effect.flatMap((metadata) => {
-          const changed = (metadata.archived ?? false) !== archived;
-          const persist = changed ? repo.write({ ...metadata, archived }) : Effect.void;
-          // Archive is also a lifecycle boundary: persist first so a failed
-          // metadata write never kills live work. Restore stays cold until open.
-          const close = archived
-            ? manager.close(ref).pipe(Effect.andThen(bus.closeSession(ref, "session_closed")))
-            : Effect.void;
-          const publish = changed
-            ? bus.publish({ ref, type: "session.archived", archived })
-            : Effect.void;
-          return persist.pipe(Effect.andThen(close), Effect.andThen(publish));
-        }),
+      withMetadataMutation(
+        ref,
+        readChecked(ref).pipe(
+          Effect.flatMap((metadata) => {
+            const changed = (metadata.archived ?? false) !== archived;
+            const persist = changed ? repo.write({ ...metadata, archived }) : Effect.void;
+            // Archive is also a lifecycle boundary: persist first so a failed
+            // metadata write never kills live work. Restore stays cold until open.
+            const close = archived
+              ? manager.close(ref).pipe(Effect.andThen(bus.closeSession(ref, "session_closed")))
+              : Effect.void;
+            const publish = changed
+              ? bus.publish({ ref, type: "session.archived", archived })
+              : Effect.void;
+            return persist.pipe(Effect.andThen(close), Effect.andThen(publish));
+          }),
+        ),
       ),
 
     // A pure read of our own records — display data is self-owned (title from
@@ -561,10 +611,9 @@ export const makeHarnessAgentSessionService = (deps: {
 
     prompt: (input) =>
       Effect.gen(function* () {
-        const metadata = yield* readChecked(input.ref);
         const userInput = yield* toUserInput(input.parts);
         // The first prompt names the session before it reaches the harness.
-        yield* stampTitleFromFirstPrompt(metadata, input.parts);
+        const metadata = yield* readAndStampTitleFromFirstPrompt(input.ref, input.parts);
         const messageId = input.messageId ?? (yield* newSessionId);
 
         // Broadcast the accepted prompt *before* the harness call so it always

--- a/packages/server/src/rpc/session.ts
+++ b/packages/server/src/rpc/session.ts
@@ -118,7 +118,7 @@ export const sessionRouter = orpc.router({
   }),
   rename: orpc.rename.effect(function* ({ input, errors }) {
     const sessions = yield* HarnessAgentSessionService;
-    yield* sessions.rename(input.ref, input.name).pipe(
+    yield* sessions.rename(input.ref, input.title).pipe(
       Effect.catchTags({
         SessionNotFound: (e) =>
           Effect.fail(errors.NOT_FOUND({ message: `session ${e.sessionId} not found` })),

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { isSessionScopedEvent, type SessionRef } from "@vibest/contract";
 import type { UIMessage } from "ai";
-import { Crypto, Effect, FileSystem, type Scope, Stream } from "effect";
+import { Crypto, Effect, Fiber, FileSystem, type Scope, Stream } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { type EventBusShape, makeEventBus } from "../../src/events/event-bus";
@@ -68,6 +68,8 @@ describe("HarnessAgentSessionService", () => {
       turn?: "open" | "finished";
       // The harness rejects every prompt (a turn is already running).
       promptFails?: boolean;
+      // Optional close hook for exercising lifecycle contention.
+      close?: (sessionId: string) => Promise<void>;
     },
     program: (fixture: Fixture) => Effect.Effect<A, E, Scope.Scope | FileSystem.FileSystem>,
   ) =>
@@ -124,7 +126,13 @@ describe("HarnessAgentSessionService", () => {
             ...(opts.history !== undefined ? { getMessages: Effect.succeed(opts.history) } : {}),
             close: Effect.sync(() => {
               spy.close.push(sessionId);
-            }),
+            }).pipe(
+              Effect.andThen(
+                opts.close === undefined
+                  ? Effect.void
+                  : Effect.promise(() => opts.close?.(sessionId) ?? Promise.resolve()),
+              ),
+            ),
           });
           const adapter = {
             id: "claude-code",
@@ -703,5 +711,126 @@ describe("HarnessAgentSessionService", () => {
     );
     expect(listed).toHaveLength(1);
     expect(listed[0]?.title).toBeUndefined();
+  });
+
+  // The rename used to be broadcast-only, so every client showed the new title
+  // until the next list load read the old one back off disk.
+  it("rename persists the title across a restart", async () => {
+    const result = await run({}, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        yield* fixture.service.rename(ref, "Login bug");
+        const listed = yield* fixture.service.list("proj-a", false);
+        const restarted = yield* fixture.restart;
+        return { listed, afterRestart: yield* restarted.service.list("proj-a", false) };
+      }),
+    );
+    expect(result.listed[0]?.title).toBe("Login bug");
+    expect(result.afterRestart[0]?.title).toBe("Login bug");
+  });
+
+  it("publishes session.renamed per change, and nothing for a no-op rename", async () => {
+    const result = await run({}, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        return yield* Effect.scoped(
+          Effect.gen(function* () {
+            const stream = yield* fixture.bus.subscribe({ kind: "global" });
+            yield* fixture.service.rename(ref, "First title");
+            yield* fixture.service.rename(ref, "First title"); // no-op: no event
+            yield* fixture.service.rename(ref, "Second title");
+            const items = yield* Stream.runCollect(Stream.take(stream, 2));
+            return Array.from(items);
+          }),
+        );
+      }),
+    );
+    expect(
+      result.map((item) =>
+        item.type === "event" && item.event.type === "session.renamed"
+          ? item.event.title
+          : item.type,
+      ),
+    ).toEqual(["First title", "Second title"]);
+  });
+
+  // The title is the user's once they have chosen one: the first-prompt stamp
+  // only fills a record that has none.
+  it("keeps a hand-chosen title through the first prompt", async () => {
+    const listed = await run({}, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        yield* fixture.service.rename(ref, "Login bug");
+        yield* fixture.service.prompt({ ref, parts: [{ type: "text", text: "first" }] });
+        return yield* fixture.service.list("proj-a", false);
+      }),
+    );
+    expect(listed[0]?.title).toBe("Login bug");
+  });
+
+  it("preserves rename and archive changes made concurrently", async () => {
+    const stored = await run({}, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        yield* Effect.all(
+          [fixture.service.rename(ref, "Login bug"), fixture.service.archive(ref, true)],
+          { concurrency: "unbounded" },
+        );
+        return yield* fixture.repo.read(ref.projectId, ref.sessionId);
+      }),
+    );
+    expect(stored.title).toBe("Login bug");
+    expect(stored.archived).toBe(true);
+  });
+
+  it("keeps the manual title when rename races the first prompt stamp", async () => {
+    const listed = await run({}, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        yield* Effect.all(
+          [
+            fixture.service.prompt({ ref, parts: [{ type: "text", text: "automatic title" }] }),
+            fixture.service.rename(ref, "Login bug"),
+          ],
+          { concurrency: "unbounded" },
+        );
+        return yield* fixture.service.list("proj-a", false);
+      }),
+    );
+    expect(listed[0]?.title).toBe("Login bug");
+  });
+
+  it("does not let one slow session close stall another session's rename", async () => {
+    let releaseClose!: () => void;
+    let markCloseStarted!: () => void;
+    const closeStarted = new Promise<void>((resolve) => {
+      markCloseStarted = resolve;
+    });
+    const closeReleased = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+
+    const stored = await run(
+      {
+        close: async (sessionId) => {
+          if (sessionId !== "native-1") return;
+          markCloseStarted();
+          await closeReleased;
+        },
+      },
+      (fixture) =>
+        Effect.gen(function* () {
+          const slow = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+          const other = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+          const archiving = yield* Effect.forkChild(fixture.service.archive(slow, true));
+          yield* Effect.promise(() => closeStarted);
+          yield* fixture.service.rename(other, "Still responsive");
+          releaseClose();
+          yield* Fiber.join(archiving);
+          return yield* fixture.repo.read(other.projectId, other.sessionId);
+        }),
+    );
+
+    expect(stored.title).toBe("Still responsive");
   });
 });

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -174,7 +174,7 @@ describe("session router", () => {
     }
   });
 
-  it("lists, archives, restores, and deletes sessions", async () => {
+  it("lists, renames, archives, restores, and deletes sessions", async () => {
     const { client, workspace, dispose } = await setup();
     try {
       const project = await client.project.create({ path: workspace });
@@ -187,6 +187,10 @@ describe("session router", () => {
       expect(active[0]?.sessionId).toBe(ref.sessionId);
       expect(active[0]?.status?.phase).toBeDefined();
       expect(active[0]?.archived).toBe(false);
+
+      await client.session.rename({ ref, title: "Login bug" });
+      const renamed = await client.session.list({ projectId: project.id });
+      expect(renamed[0]?.title).toBe("Login bug");
 
       await client.session.archive({ ref, archived: true });
       const archived = await client.session.list({ projectId: project.id, archived: true });
@@ -208,6 +212,35 @@ describe("session router", () => {
       await client.session.delete({ ref });
       const empty = await client.session.list({ projectId: project.id, archived: false });
       expect(empty).toHaveLength(0);
+    } finally {
+      await dispose();
+    }
+  });
+
+  // The renaming client can repaint its own row optimistically; this is the
+  // path it cannot cover — a second client learning the new title without
+  // being told to go re-read the list. The firehose carries the title itself,
+  // which is what lets the fold patch in place instead of invalidating.
+  it("announces a rename on the global firehose, carrying the new title", async () => {
+    const { client, workspace, dispose } = await setup();
+    try {
+      const project = await client.project.create({ path: workspace });
+      const ref = await client.session.create({ projectId: project.id, harnessAgentId: "codex" });
+
+      // Subscribed before the rename: the live stream has no replay, so an
+      // event this observer misses is an event it never learns about.
+      const observer = await client.session.subscribe({ scope: { kind: "global" } });
+      await client.session.rename({ ref, title: "Login bug" });
+
+      let announced: string | undefined;
+      for await (const item of observer) {
+        if (item.type !== "event") continue;
+        if (item.event.type === "session.renamed") {
+          announced = item.event.title;
+          break;
+        }
+      }
+      expect(announced).toBe("Login bug");
     } finally {
       await dispose();
     }


### PR DESCRIPTION
## Summary

- add a Rename action and title dialog to project session rows
- persist manual session titles before publishing `session.renamed`, with per-session serialization across metadata mutations
- keep active and archived session-list caches synchronized across clients and recover from missed events
- validate trimmed, non-empty titles up to 120 characters
- standardize the rename RPC and event payload on `title`

## Verification

- `pnpm check`
- `pnpm test --filter=@vibest/contract --filter=@vibest/server --filter=@vibest/app --force`
  - contract: 42 tests passed
  - server: 381 passed, 2 skipped
  - app: 117 tests passed
- independent review: no blocking findings
