### PR TITLE
ci: persist Turborepo cache

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,7 +66,7 @@ jobs:
       # content-addressed cache explicitly. The outer key isolates incompatible
       # runner/toolchain state; Turborepo still validates every task's inputs.
       - name: Restore Turborepo cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: .turbo
           key: >-

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,6 +12,12 @@ permissions:
 env:
   CI: "true"
 
+# A newer commit makes older runs for the same PR or branch obsolete. Cancel it
+# before it consumes another slot on the single self-hosted runner.
+concurrency:
+  group: quality-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Check
@@ -55,6 +61,18 @@ jobs:
         shell: bash
 
       - run: pnpm install --frozen-lockfile
+
+      # Checkout cleans ignored files on every run, so persist Turborepo's
+      # content-addressed cache explicitly. The outer key isolates incompatible
+      # runner/toolchain state; Turborepo still validates every task's inputs.
+      - name: Restore Turborepo cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: .turbo
+          key: >-
+            turbo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', 'mise.lock', 'pnpm-lock.yaml', 'turbo.json') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', 'mise.lock', 'pnpm-lock.yaml', 'turbo.json') }}-
 
       # All three declare `dependsOn: ["^build"]`, so Turborepo builds the
       # upstream workspace packages on demand and caches the results.

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://turborepo.com/schema.v2.json",
+  "globalDependencies": ["mise.toml", "mise.lock"],
+  "globalEnv": ["CI"],
   "tasks": {
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary

- cancel superseded quality runs on the self-hosted runner
- persist the Turborepo cache between GitHub Actions runs
- include the locked toolchain and CI environment in Turbo cache invalidation
- use the Node 24-based `actions/cache` v5 action

## Validation

- actionlint
- `pnpm run format:check`
- `pnpm run lint:check`
- `pnpm turbo run build test typecheck`

## GitHub Actions benchmark

| Run | Quality job | Turbo step | Cache |
| --- | ---: | ---: | --- |
| Recent `main` baseline | 2m46s | 96s | 0/19 |
| First PR run (cold) | 2m24s | 85s | 0/19 |
| Warm PR run | **58s** | **371ms** | **19/19** |

The warm end-to-end quality job is about **65% faster** than the recent `main` baseline. On normal source changes, Turbo will rerun affected tasks and reuse unaffected task results.