### PR TITLE
fix(app): bind shell layout to the active session

### DIFF
--- a/.agents/rules/frontend-state.md
+++ b/.agents/rules/frontend-state.md
@@ -31,7 +31,11 @@ for per-agent tool rendering.
   projects.
 - **Only composition roots may combine features**: `routes/`,
   `app-interface.tsx`, and the app shell in `components/layout/`. Those four
-  files are the whole allow-list today.
+  files are the whole allow-list today. `routes/__root.tsx` is the shell's one
+  route-identity seam: it reads the authoritative session-route loader ref and
+  composes the project sidebar, card heading, and content-panel binding from it.
+  `AppShell` stays structural through sidebar/main slots; `CardPanel` receives
+  display primitives and neither component interprets routes or Project state.
 - **`components/` is for what no single feature owns** — the shell
   (`layout/`) and generic pieces (`loader.tsx`). Base and composite UI belongs
   in `@vibest/ui`, not here.
@@ -55,9 +59,14 @@ for per-agent tool rendering.
 [dep])`) or it re-runs every render and loses referential stability; say so in
   a comment so nobody "simplifies" the `useCallback` away.
 - Zustand here is not a global store: each `Chat` instance creates its own vanilla
-  store as the AI SDK `ChatState`. `ChatManager` caches Chat instances by
-  sessionId so transcripts survive navigation, and is constructed at App mount
-  (module scope has no host connection yet).
+  store as the AI SDK `ChatState`. `ChatManager` caches Chat instances by the
+  complete `SessionRef` so transcripts survive navigation without crossing
+  project/harness identity, and is constructed at App mount (module scope has no
+  host connection yet).
+- Content-panel tabs, live instances, provider bindings, and panel handles use
+  the complete `SessionRef`; new shell state is never keyed by a bare sessionId.
+  The v1 migration bucket is the sole exception: its globally unique UUID key is
+  read only through an authoritative route ref and re-keyed on the first write.
 - `useSessionListSync` is the only consumer of the global event firehose; session
   events (chunks, requests) belong to the per-session chat transport.
 - The live stream has no replay: subscribe before `session.prompt`, and recover

--- a/.agents/rules/frontend-state.md
+++ b/.agents/rules/frontend-state.md
@@ -64,9 +64,9 @@ for per-agent tool rendering.
   project/harness identity, and is constructed at App mount (module scope has no
   host connection yet).
 - Content-panel tabs, live instances, provider bindings, and panel handles use
-  the complete `SessionRef`; new shell state is never keyed by a bare sessionId.
-  The v1 migration bucket is the sole exception: its globally unique UUID key is
-  read only through an authoritative route ref and re-keyed on the first write.
+  the complete `SessionRef`; shell state is never keyed by a bare sessionId.
+  Content-panel persistence is disposable client state: do not add storage
+  versions or migrations. An incompatible shape may be discarded.
 - `useSessionListSync` is the only consumer of the global event firehose; session
   events (chunks, requests) belong to the per-session chat transport.
 - The live stream has no replay: subscribe before `session.prompt`, and recover

--- a/.agents/rules/frontend-state.md
+++ b/.agents/rules/frontend-state.md
@@ -34,8 +34,10 @@ for per-agent tool rendering.
   files are the whole allow-list today. `routes/__root.tsx` is the shell's one
   route-identity seam: it reads the authoritative session-route loader ref and
   composes the project sidebar, card heading, and content-panel binding from it.
-  `AppShell` stays structural through sidebar/main slots; `CardPanel` receives
-  display primitives and neither component interprets routes or Project state.
+  `AppShell` stays structural through its compound `Sidebar`/`Main` children;
+  child components are composed as JSX children, never passed through named
+  props. `CardPanel` receives display primitives and neither component
+  interprets routes or Project state.
 - **`components/` is for what no single feature owns** — the shell
   (`layout/`) and generic pieces (`loader.tsx`). Base and composite UI belongs
   in `@vibest/ui`, not here.

--- a/.agents/rules/frontend-state.md
+++ b/.agents/rules/frontend-state.md
@@ -34,10 +34,10 @@ for per-agent tool rendering.
   files are the whole allow-list today. `routes/__root.tsx` is the shell's one
   route-identity seam: it reads the authoritative session-route loader ref and
   composes the project sidebar, card heading, and content-panel binding from it.
-  `AppShell` stays structural through its compound `Sidebar`/`Main` children;
-  child components are composed as JSX children, never passed through named
-  props. `CardPanel` receives display primitives and neither component
-  interprets routes or Project state.
+  `AppShell` stays structural through `AppShellSidebar`/`AppShellMain`
+  children; child components are composed as JSX children, never passed through
+  named props or attached as static properties. `CardPanel` receives display
+  primitives and neither component interprets routes or Project state.
 - **`components/` is for what no single feature owns** — the shell
   (`layout/`) and generic pieces (`loader.tsx`). Base and composite UI belongs
   in `@vibest/ui`, not here.

--- a/.agents/rules/frontend-state.md
+++ b/.agents/rules/frontend-state.md
@@ -35,9 +35,11 @@ for per-agent tool rendering.
   route-identity seam: it reads the authoritative session-route loader ref and
   composes the project sidebar, card heading, and content-panel binding from it.
   `AppShell` stays structural through `AppShellSidebar`/`AppShellMain`
-  children; child components are composed as JSX children, never passed through
-  named props or attached as static properties. `CardPanel` receives display
-  primitives and neither component interprets routes or Project state.
+  children; child components are composed as JSX children and consume shared
+  layout state from the shell context. Never pass them through named props,
+  attach them as static properties, or inspect `children` to extract slots.
+  `CardPanel` receives display primitives and neither component interprets
+  routes or Project state.
 - **`components/` is for what no single feature owns** — the shell
   (`layout/`) and generic pieces (`loader.tsx`). Base and composite UI belongs
   in `@vibest/ui`, not here.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,8 +9,8 @@ A working directory the user has registered with the server, identified by a ser
 _Avoid_: workspace, repo, cwd (for the Project field)
 
 **SessionRef**:
-The composite identity `{ projectId, harnessAgentId, sessionId }` that every session operation addresses. `sessionId` is a server-generated opaque UUID, unique within a project.
-_Avoid_: bare sessionId as a wire identity
+The composite identity `{ projectId, harnessAgentId, sessionId }` that every session operation addresses. `sessionId` is a server-generated, globally unique opaque UUID so a bookmarked URL can reverse-resolve its complete ref; clients still use the complete ref for operations, caches, and persisted state.
+_Avoid_: bare sessionId as a wire identity or client-state key
 
 **Harness session id**:
 The agent-native session identity (Claude session UUID, Codex thread ID) held in the session's metadata. Internal plumbing for resume/history — never exposed as wire identity.
@@ -79,7 +79,7 @@ What `definePanel` / `definePanelFamily` produce — the type, how to label it, 
 _Avoid_: PanelSpec, panel config, panel registration
 
 **PanelHandle / PanelInstance**:
-The handle is what every panel gets: id, sessionId, live `payload`, and `activate` / `close` / `setPayload` / `reopen`. A definition's `create` returns _extra_ members, which the host prototype-links onto the handle to make the **instance**. Instance state is live and unpersisted (a scrollback, a spinner); it outlives navigation and dies on `close`, never on unmount. Materialized lazily — the tab strip draws a restored tab without one, so reopening ten tabs spawns nothing until each is rendered.
+The handle is what every panel gets: id, the complete `SessionRef`, live `payload`, and `activate` / `close` / `setPayload` / `reopen`. The host keys persisted tabs and live instances by that complete ref — never by a bare sessionId. A definition's `create` returns _extra_ members, which the host prototype-links onto the handle to make the **instance**. Instance state is live and unpersisted (a scrollback, a spinner); it outlives navigation and dies on `close`, never on unmount. Materialized lazily — the tab strip draws a restored tab without one, so reopening ten tabs spawns nothing until each is rendered.
 _Avoid_: panel object, panel controller
 
 **Tab strip**:

--- a/apps/app/src/components/layout/app-shell.tsx
+++ b/apps/app/src/components/layout/app-shell.tsx
@@ -1,5 +1,5 @@
 import { useSidebar } from "@vibest/ui/components/sidebar";
-import type { ReactNode } from "react";
+import { Children, isValidElement, type ReactNode } from "react";
 
 import { useContentPanel, usePanelSnapshot } from "@/components/layout/content-panel/react/hooks";
 import { ContentPanelOutlet } from "@/components/layout/content-panel/react/outlet";
@@ -11,18 +11,43 @@ import {
   ShellSidebarPanel,
 } from "@/components/layout/shell-panels";
 
-/** Structural shell only; the root composition owns the semantic surfaces. */
-export interface AppShellProps {
+export interface AppShellSlotProps {
   readonly children: ReactNode;
-  readonly sidebar: ReactNode;
 }
 
-export function AppShell({ children, sidebar }: AppShellProps) {
+function AppShellSidebar({ children }: AppShellSlotProps): ReactNode {
+  return children;
+}
+
+function AppShellMain({ children }: AppShellSlotProps): ReactNode {
+  return children;
+}
+
+const contentOf = (
+  children: ReactNode,
+  Slot: (props: AppShellSlotProps) => ReactNode,
+): ReactNode => {
+  for (const child of Children.toArray(children)) {
+    if (isValidElement<AppShellSlotProps>(child) && child.type === Slot) {
+      return child.props.children;
+    }
+  }
+  return null;
+};
+
+/** Structural shell only; the root composition owns the semantic surfaces. */
+export interface AppShellRootProps {
+  readonly children: ReactNode;
+}
+
+function AppShellRoot({ children }: AppShellRootProps) {
   const { isMobile } = useSidebar();
   const session = useContentPanel();
   const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
   const contentVisible = presentation !== "hidden" && session !== null;
   const maximized = presentation === "maximized";
+  const sidebar = contentOf(children, AppShellSidebar);
+  const main = contentOf(children, AppShellMain);
 
   return (
     <>
@@ -42,7 +67,7 @@ export function AppShell({ children, sidebar }: AppShellProps) {
             session?.setPresentation(collapsed ? "maximized" : "docked")
           }
         >
-          {children}
+          {main}
         </ShellMainPanel>
         {contentVisible && (
           <>
@@ -56,3 +81,8 @@ export function AppShell({ children, sidebar }: AppShellProps) {
     </>
   );
 }
+
+export const AppShell = Object.assign(AppShellRoot, {
+  Main: AppShellMain,
+  Sidebar: AppShellSidebar,
+});

--- a/apps/app/src/components/layout/app-shell.tsx
+++ b/apps/app/src/components/layout/app-shell.tsx
@@ -1,7 +1,6 @@
 import { useSidebar } from "@vibest/ui/components/sidebar";
+import type { ReactNode } from "react";
 
-import { AppSidebar } from "@/components/layout/app-sidebar";
-import { CardPanel } from "@/components/layout/card-panel";
 import { useContentPanel, usePanelSnapshot } from "@/components/layout/content-panel/react/hooks";
 import { ContentPanelOutlet } from "@/components/layout/content-panel/react/outlet";
 import {
@@ -12,12 +11,13 @@ import {
   ShellSidebarPanel,
 } from "@/components/layout/shell-panels";
 
+/** Structural shell only; the root composition owns the semantic surfaces. */
 export interface AppShellProps {
-  hasTrafficLights: boolean;
-  onNewChat: () => void;
+  readonly children: ReactNode;
+  readonly sidebar: ReactNode;
 }
 
-export function AppShell({ hasTrafficLights, onNewChat }: AppShellProps) {
+export function AppShell({ children, sidebar }: AppShellProps) {
   const { isMobile } = useSidebar();
   const session = useContentPanel();
   const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
@@ -26,13 +26,11 @@ export function AppShell({ hasTrafficLights, onNewChat }: AppShellProps) {
 
   return (
     <>
-      {isMobile && <AppSidebar onNewChat={onNewChat} />}
+      {isMobile && sidebar}
       <ShellGroup hasContentPanel={contentVisible} hasSidebar={!isMobile}>
         {!isMobile && (
           <>
-            <ShellSidebarPanel>
-              <AppSidebar onNewChat={onNewChat} />
-            </ShellSidebarPanel>
+            <ShellSidebarPanel>{sidebar}</ShellSidebarPanel>
             <ShellSeparator disabled={maximized} />
           </>
         )}
@@ -44,7 +42,7 @@ export function AppShell({ hasTrafficLights, onNewChat }: AppShellProps) {
             session?.setPresentation(collapsed ? "maximized" : "docked")
           }
         >
-          <CardPanel hasTrafficLights={hasTrafficLights} />
+          {children}
         </ShellMainPanel>
         {contentVisible && (
           <>

--- a/apps/app/src/components/layout/app-shell.tsx
+++ b/apps/app/src/components/layout/app-shell.tsx
@@ -12,12 +12,14 @@ import {
 } from "@/components/layout/shell-panels";
 
 interface AppShellContextValue {
-  /** Whether the session-bound content-panel column is mounted. */
-  readonly hasVisibleContentPanel: boolean;
-  /** Whether the content panel fills the shell and collapses the main column. */
-  readonly isContentPanelMaximized: boolean;
-  /** Switch the content panel between maximized and docked presentation. */
-  readonly setContentPanelMaximized: (maximized: boolean) => void;
+  readonly contentPanel: {
+    /** Whether the session-bound content-panel column is mounted. */
+    readonly visible: boolean;
+    /** Whether the content panel fills the shell and collapses the main column. */
+    readonly maximized: boolean;
+    /** Switch the content panel between maximized and docked presentation. */
+    readonly setMaximized: (maximized: boolean) => void;
+  };
 }
 
 const AppShellContext = createContext<AppShellContextValue | null>(null);
@@ -34,26 +36,25 @@ export interface AppShellSlotProps {
 
 export function AppShellSidebar({ children }: AppShellSlotProps) {
   const { isMobile } = useSidebar();
-  const { isContentPanelMaximized } = useAppShell();
+  const { contentPanel } = useAppShell();
   if (isMobile) return <>{children}</>;
   return (
     <>
       <ShellSidebarPanel>{children}</ShellSidebarPanel>
-      <ShellSeparator disabled={isContentPanelMaximized} />
+      <ShellSeparator disabled={contentPanel.maximized} />
     </>
   );
 }
 
 export function AppShellMain({ children }: AppShellSlotProps) {
   const { isMobile } = useSidebar();
-  const { hasVisibleContentPanel, isContentPanelMaximized, setContentPanelMaximized } =
-    useAppShell();
+  const { contentPanel } = useAppShell();
   return (
     <ShellMainPanel
-      hasContentPanel={hasVisibleContentPanel}
-      collapsed={isContentPanelMaximized}
-      collapsible={isContentPanelMaximized || (hasVisibleContentPanel && !isMobile)}
-      onCollapsedChange={setContentPanelMaximized}
+      hasContentPanel={contentPanel.visible}
+      collapsed={contentPanel.maximized}
+      collapsible={contentPanel.maximized || (contentPanel.visible && !isMobile)}
+      onCollapsedChange={contentPanel.setMaximized}
     >
       {children}
     </ShellMainPanel>
@@ -76,7 +77,13 @@ export function AppShell({ children }: AppShellRootProps) {
     [session],
   );
   const context = useMemo(
-    () => ({ hasVisibleContentPanel, isContentPanelMaximized, setContentPanelMaximized }),
+    () => ({
+      contentPanel: {
+        visible: hasVisibleContentPanel,
+        maximized: isContentPanelMaximized,
+        setMaximized: setContentPanelMaximized,
+      },
+    }),
     [hasVisibleContentPanel, isContentPanelMaximized, setContentPanelMaximized],
   );
 

--- a/apps/app/src/components/layout/app-shell.tsx
+++ b/apps/app/src/components/layout/app-shell.tsx
@@ -15,9 +15,11 @@ import {
 export interface AppShellProps {
   hasTrafficLights: boolean;
   onNewChat: () => void;
+  projectName: string | undefined;
+  title: string;
 }
 
-export function AppShell({ hasTrafficLights, onNewChat }: AppShellProps) {
+export function AppShell({ hasTrafficLights, onNewChat, projectName, title }: AppShellProps) {
   const { isMobile } = useSidebar();
   const session = useContentPanel();
   const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
@@ -44,7 +46,7 @@ export function AppShell({ hasTrafficLights, onNewChat }: AppShellProps) {
             session?.setPresentation(collapsed ? "maximized" : "docked")
           }
         >
-          <CardPanel hasTrafficLights={hasTrafficLights} />
+          <CardPanel hasTrafficLights={hasTrafficLights} projectName={projectName} title={title} />
         </ShellMainPanel>
         {contentVisible && (
           <>

--- a/apps/app/src/components/layout/app-shell.tsx
+++ b/apps/app/src/components/layout/app-shell.tsx
@@ -13,7 +13,6 @@ import {
 
 interface AppShellContextValue {
   readonly contentVisible: boolean;
-  readonly isMobile: boolean;
   readonly maximized: boolean;
   readonly setMainCollapsed: (collapsed: boolean) => void;
 }
@@ -31,7 +30,8 @@ export interface AppShellSlotProps {
 }
 
 export function AppShellSidebar({ children }: AppShellSlotProps) {
-  const { isMobile, maximized } = useAppShell();
+  const { isMobile } = useSidebar();
+  const { maximized } = useAppShell();
   if (isMobile) return <>{children}</>;
   return (
     <>
@@ -42,7 +42,8 @@ export function AppShellSidebar({ children }: AppShellSlotProps) {
 }
 
 export function AppShellMain({ children }: AppShellSlotProps) {
-  const { contentVisible, isMobile, maximized, setMainCollapsed } = useAppShell();
+  const { isMobile } = useSidebar();
+  const { contentVisible, maximized, setMainCollapsed } = useAppShell();
   return (
     <ShellMainPanel
       hasContentPanel={contentVisible}
@@ -71,8 +72,8 @@ export function AppShell({ children }: AppShellRootProps) {
     [session],
   );
   const context = useMemo(
-    () => ({ contentVisible, isMobile, maximized, setMainCollapsed }),
-    [contentVisible, isMobile, maximized, setMainCollapsed],
+    () => ({ contentVisible, maximized, setMainCollapsed }),
+    [contentVisible, maximized, setMainCollapsed],
   );
 
   return (

--- a/apps/app/src/components/layout/app-shell.tsx
+++ b/apps/app/src/components/layout/app-shell.tsx
@@ -15,12 +15,12 @@ export interface AppShellSlotProps {
   readonly children: ReactNode;
 }
 
-function AppShellSidebar({ children }: AppShellSlotProps): ReactNode {
-  return children;
+export function AppShellSidebar({ children }: AppShellSlotProps) {
+  return <>{children}</>;
 }
 
-function AppShellMain({ children }: AppShellSlotProps): ReactNode {
-  return children;
+export function AppShellMain({ children }: AppShellSlotProps) {
+  return <>{children}</>;
 }
 
 const contentOf = (
@@ -40,7 +40,7 @@ export interface AppShellRootProps {
   readonly children: ReactNode;
 }
 
-function AppShellRoot({ children }: AppShellRootProps) {
+export function AppShell({ children }: AppShellRootProps) {
   const { isMobile } = useSidebar();
   const session = useContentPanel();
   const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
@@ -81,8 +81,3 @@ function AppShellRoot({ children }: AppShellRootProps) {
     </>
   );
 }
-
-export const AppShell = Object.assign(AppShellRoot, {
-  Main: AppShellMain,
-  Sidebar: AppShellSidebar,
-});

--- a/apps/app/src/components/layout/app-shell.tsx
+++ b/apps/app/src/components/layout/app-shell.tsx
@@ -1,5 +1,5 @@
 import { useSidebar } from "@vibest/ui/components/sidebar";
-import { Children, isValidElement, type ReactNode } from "react";
+import { createContext, type ReactNode, use, useCallback, useMemo } from "react";
 
 import { useContentPanel, usePanelSnapshot } from "@/components/layout/content-panel/react/hooks";
 import { ContentPanelOutlet } from "@/components/layout/content-panel/react/outlet";
@@ -11,29 +11,49 @@ import {
   ShellSidebarPanel,
 } from "@/components/layout/shell-panels";
 
+interface AppShellContextValue {
+  readonly contentVisible: boolean;
+  readonly isMobile: boolean;
+  readonly maximized: boolean;
+  readonly setMainCollapsed: (collapsed: boolean) => void;
+}
+
+const AppShellContext = createContext<AppShellContextValue | null>(null);
+
+const useAppShell = (): AppShellContextValue => {
+  const value = use(AppShellContext);
+  if (value === null) throw new Error("AppShell composition must be rendered inside AppShell");
+  return value;
+};
+
 export interface AppShellSlotProps {
   readonly children: ReactNode;
 }
 
 export function AppShellSidebar({ children }: AppShellSlotProps) {
-  return <>{children}</>;
+  const { isMobile, maximized } = useAppShell();
+  if (isMobile) return <>{children}</>;
+  return (
+    <>
+      <ShellSidebarPanel>{children}</ShellSidebarPanel>
+      <ShellSeparator disabled={maximized} />
+    </>
+  );
 }
 
 export function AppShellMain({ children }: AppShellSlotProps) {
-  return <>{children}</>;
+  const { contentVisible, isMobile, maximized, setMainCollapsed } = useAppShell();
+  return (
+    <ShellMainPanel
+      hasContentPanel={contentVisible}
+      collapsed={maximized}
+      collapsible={maximized || (contentVisible && !isMobile)}
+      onCollapsedChange={setMainCollapsed}
+    >
+      {children}
+    </ShellMainPanel>
+  );
 }
-
-const contentOf = (
-  children: ReactNode,
-  Slot: (props: AppShellSlotProps) => ReactNode,
-): ReactNode => {
-  for (const child of Children.toArray(children)) {
-    if (isValidElement<AppShellSlotProps>(child) && child.type === Slot) {
-      return child.props.children;
-    }
-  }
-  return null;
-};
 
 /** Structural shell only; the root composition owns the semantic surfaces. */
 export interface AppShellRootProps {
@@ -46,29 +66,19 @@ export function AppShell({ children }: AppShellRootProps) {
   const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
   const contentVisible = presentation !== "hidden" && session !== null;
   const maximized = presentation === "maximized";
-  const sidebar = contentOf(children, AppShellSidebar);
-  const main = contentOf(children, AppShellMain);
+  const setMainCollapsed = useCallback(
+    (collapsed: boolean) => session?.setPresentation(collapsed ? "maximized" : "docked"),
+    [session],
+  );
+  const context = useMemo(
+    () => ({ contentVisible, isMobile, maximized, setMainCollapsed }),
+    [contentVisible, isMobile, maximized, setMainCollapsed],
+  );
 
   return (
-    <>
-      {isMobile && sidebar}
+    <AppShellContext value={context}>
       <ShellGroup hasContentPanel={contentVisible} hasSidebar={!isMobile}>
-        {!isMobile && (
-          <>
-            <ShellSidebarPanel>{sidebar}</ShellSidebarPanel>
-            <ShellSeparator disabled={maximized} />
-          </>
-        )}
-        <ShellMainPanel
-          hasContentPanel={contentVisible}
-          collapsed={maximized}
-          collapsible={maximized || (contentVisible && !isMobile)}
-          onCollapsedChange={(collapsed) =>
-            session?.setPresentation(collapsed ? "maximized" : "docked")
-          }
-        >
-          {main}
-        </ShellMainPanel>
+        {children}
         {contentVisible && (
           <>
             <ShellSeparator />
@@ -78,6 +88,6 @@ export function AppShell({ children }: AppShellRootProps) {
           </>
         )}
       </ShellGroup>
-    </>
+    </AppShellContext>
   );
 }

--- a/apps/app/src/components/layout/app-shell.tsx
+++ b/apps/app/src/components/layout/app-shell.tsx
@@ -15,11 +15,9 @@ import {
 export interface AppShellProps {
   hasTrafficLights: boolean;
   onNewChat: () => void;
-  projectName: string | undefined;
-  title: string;
 }
 
-export function AppShell({ hasTrafficLights, onNewChat, projectName, title }: AppShellProps) {
+export function AppShell({ hasTrafficLights, onNewChat }: AppShellProps) {
   const { isMobile } = useSidebar();
   const session = useContentPanel();
   const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
@@ -46,7 +44,7 @@ export function AppShell({ hasTrafficLights, onNewChat, projectName, title }: Ap
             session?.setPresentation(collapsed ? "maximized" : "docked")
           }
         >
-          <CardPanel hasTrafficLights={hasTrafficLights} projectName={projectName} title={title} />
+          <CardPanel hasTrafficLights={hasTrafficLights} />
         </ShellMainPanel>
         {contentVisible && (
           <>

--- a/apps/app/src/components/layout/app-shell.tsx
+++ b/apps/app/src/components/layout/app-shell.tsx
@@ -12,9 +12,12 @@ import {
 } from "@/components/layout/shell-panels";
 
 interface AppShellContextValue {
-  readonly contentVisible: boolean;
-  readonly maximized: boolean;
-  readonly setMainCollapsed: (collapsed: boolean) => void;
+  /** Whether the session-bound content-panel column is mounted. */
+  readonly hasVisibleContentPanel: boolean;
+  /** Whether the content panel fills the shell and collapses the main column. */
+  readonly isContentPanelMaximized: boolean;
+  /** Switch the content panel between maximized and docked presentation. */
+  readonly setContentPanelMaximized: (maximized: boolean) => void;
 }
 
 const AppShellContext = createContext<AppShellContextValue | null>(null);
@@ -31,25 +34,26 @@ export interface AppShellSlotProps {
 
 export function AppShellSidebar({ children }: AppShellSlotProps) {
   const { isMobile } = useSidebar();
-  const { maximized } = useAppShell();
+  const { isContentPanelMaximized } = useAppShell();
   if (isMobile) return <>{children}</>;
   return (
     <>
       <ShellSidebarPanel>{children}</ShellSidebarPanel>
-      <ShellSeparator disabled={maximized} />
+      <ShellSeparator disabled={isContentPanelMaximized} />
     </>
   );
 }
 
 export function AppShellMain({ children }: AppShellSlotProps) {
   const { isMobile } = useSidebar();
-  const { contentVisible, maximized, setMainCollapsed } = useAppShell();
+  const { hasVisibleContentPanel, isContentPanelMaximized, setContentPanelMaximized } =
+    useAppShell();
   return (
     <ShellMainPanel
-      hasContentPanel={contentVisible}
-      collapsed={maximized}
-      collapsible={maximized || (contentVisible && !isMobile)}
-      onCollapsedChange={setMainCollapsed}
+      hasContentPanel={hasVisibleContentPanel}
+      collapsed={isContentPanelMaximized}
+      collapsible={isContentPanelMaximized || (hasVisibleContentPanel && !isMobile)}
+      onCollapsedChange={setContentPanelMaximized}
     >
       {children}
     </ShellMainPanel>
@@ -65,22 +69,22 @@ export function AppShell({ children }: AppShellRootProps) {
   const { isMobile } = useSidebar();
   const session = useContentPanel();
   const presentation = usePanelSnapshot((snapshot) => snapshot.presentation);
-  const contentVisible = presentation !== "hidden" && session !== null;
-  const maximized = presentation === "maximized";
-  const setMainCollapsed = useCallback(
-    (collapsed: boolean) => session?.setPresentation(collapsed ? "maximized" : "docked"),
+  const hasVisibleContentPanel = presentation !== "hidden" && session !== null;
+  const isContentPanelMaximized = presentation === "maximized";
+  const setContentPanelMaximized = useCallback(
+    (maximized: boolean) => session?.setPresentation(maximized ? "maximized" : "docked"),
     [session],
   );
   const context = useMemo(
-    () => ({ contentVisible, maximized, setMainCollapsed }),
-    [contentVisible, maximized, setMainCollapsed],
+    () => ({ hasVisibleContentPanel, isContentPanelMaximized, setContentPanelMaximized }),
+    [hasVisibleContentPanel, isContentPanelMaximized, setContentPanelMaximized],
   );
 
   return (
     <AppShellContext value={context}>
-      <ShellGroup hasContentPanel={contentVisible} hasSidebar={!isMobile}>
+      <ShellGroup hasContentPanel={hasVisibleContentPanel} hasSidebar={!isMobile}>
         {children}
-        {contentVisible && (
+        {hasVisibleContentPanel && (
           <>
             <ShellSeparator />
             <ShellContentPanel>

--- a/apps/app/src/components/layout/app-sidebar.tsx
+++ b/apps/app/src/components/layout/app-sidebar.tsx
@@ -1,3 +1,4 @@
+import type { SessionRef } from "@vibest/contract";
 import {
   Sidebar,
   SidebarContent,
@@ -18,7 +19,13 @@ import { ImportProjectDialog } from "@/features/projects/import-project-dialog";
 import { ProjectList } from "@/features/projects/project-list";
 import { usePlatform } from "@/platform-context";
 
-export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
+export function AppSidebar({
+  isSessionActive,
+  onNewChat,
+}: {
+  readonly isSessionActive: (ref: SessionRef) => boolean;
+  readonly onNewChat: () => void;
+}) {
   const [importOpen, setImportOpen] = useState(false);
   const { os } = usePlatform();
   const { isMobile, state } = useSidebar();
@@ -64,7 +71,7 @@ export function AppSidebar({ onNewChat }: { onNewChat: () => void }) {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        <ProjectList onImport={() => setImportOpen(true)} />
+        <ProjectList isSessionActive={isSessionActive} onImport={() => setImportOpen(true)} />
       </SidebarContent>
 
       {importOpen && <ImportProjectDialog onClose={() => setImportOpen(false)} />}

--- a/apps/app/src/components/layout/card-panel.tsx
+++ b/apps/app/src/components/layout/card-panel.tsx
@@ -1,34 +1,17 @@
-import { Outlet, useMatch } from "@tanstack/react-router";
+import { Outlet } from "@tanstack/react-router";
 import { SidebarInset, SidebarTrigger, useSidebar } from "@vibest/ui/components/sidebar";
 import { cn } from "@vibest/ui/lib/utils";
 
 import { ContentPanelToggle } from "@/components/layout/content-panel/react/toggle";
-import { useProjectSession } from "@/features/projects/use-project-sessions";
-import { useProject } from "@/features/projects/use-projects";
 
 export interface CardPanelProps {
-  hasTrafficLights: boolean;
+  readonly hasTrafficLights: boolean;
+  readonly heading: string;
+  readonly supportingText?: string;
 }
 
-export function CardPanel({ hasTrafficLights }: CardPanelProps) {
+export function CardPanel({ hasTrafficLights, heading, supportingText }: CardPanelProps) {
   const { state, isMobile } = useSidebar();
-  // This card is part of the app-shell composition root, so it is the seam that
-  // combines route identity with project-owned session metadata. AppShell stays
-  // layout-only instead of exposing Project concepts through pass-through props.
-  const sessionRef = useMatch({
-    from: "/session/$sessionId",
-    shouldThrow: false,
-    select: (match) => match.loaderData ?? null,
-  });
-  const draftProjectId = useMatch({
-    from: "/draft",
-    shouldThrow: false,
-    select: (match) => match.search.projectId ?? null,
-  });
-  const project = useProject(sessionRef?.projectId ?? draftProjectId);
-  const session = useProjectSession(sessionRef?.projectId, sessionRef?.sessionId);
-  const title = sessionRef === null ? "New chat" : (session?.title ?? "New chat");
-  const projectName = project?.name;
   const collapsedDesktop = !isMobile && state === "collapsed";
   const ownsToggle = isMobile || collapsedDesktop;
 
@@ -46,15 +29,15 @@ export function CardPanel({ hasTrafficLights }: CardPanelProps) {
           />
         )}
         <div className="flex min-w-0 items-center gap-2 text-sm">
-          <span className="min-w-0 truncate font-medium" title={title}>
-            {title}
+          <span className="min-w-0 truncate font-medium" title={heading}>
+            {heading}
           </span>
-          {projectName !== undefined && (
+          {supportingText !== undefined && (
             <span
               className="text-muted-foreground max-w-[50%] min-w-0 truncate"
-              title={projectName}
+              title={supportingText}
             >
-              {projectName}
+              {supportingText}
             </span>
           )}
         </div>

--- a/apps/app/src/components/layout/card-panel.tsx
+++ b/apps/app/src/components/layout/card-panel.tsx
@@ -1,17 +1,34 @@
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useMatch } from "@tanstack/react-router";
 import { SidebarInset, SidebarTrigger, useSidebar } from "@vibest/ui/components/sidebar";
 import { cn } from "@vibest/ui/lib/utils";
 
 import { ContentPanelToggle } from "@/components/layout/content-panel/react/toggle";
+import { useProjectSession } from "@/features/projects/use-project-sessions";
+import { useProject } from "@/features/projects/use-projects";
 
 export interface CardPanelProps {
   hasTrafficLights: boolean;
-  projectName: string | undefined;
-  title: string;
 }
 
-export function CardPanel({ hasTrafficLights, projectName, title }: CardPanelProps) {
+export function CardPanel({ hasTrafficLights }: CardPanelProps) {
   const { state, isMobile } = useSidebar();
+  // This card is part of the app-shell composition root, so it is the seam that
+  // combines route identity with project-owned session metadata. AppShell stays
+  // layout-only instead of exposing Project concepts through pass-through props.
+  const sessionRef = useMatch({
+    from: "/session/$sessionId",
+    shouldThrow: false,
+    select: (match) => match.loaderData ?? null,
+  });
+  const draftProjectId = useMatch({
+    from: "/draft",
+    shouldThrow: false,
+    select: (match) => match.search.projectId ?? null,
+  });
+  const project = useProject(sessionRef?.projectId ?? draftProjectId);
+  const session = useProjectSession(sessionRef?.projectId, sessionRef?.sessionId);
+  const title = sessionRef === null ? "New chat" : (session?.title ?? "New chat");
+  const projectName = project?.name;
   const collapsedDesktop = !isMobile && state === "collapsed";
   const ownsToggle = isMobile || collapsedDesktop;
 

--- a/apps/app/src/components/layout/card-panel.tsx
+++ b/apps/app/src/components/layout/card-panel.tsx
@@ -6,9 +6,11 @@ import { ContentPanelToggle } from "@/components/layout/content-panel/react/togg
 
 export interface CardPanelProps {
   hasTrafficLights: boolean;
+  projectName: string | undefined;
+  title: string;
 }
 
-export function CardPanel({ hasTrafficLights }: CardPanelProps) {
+export function CardPanel({ hasTrafficLights, projectName, title }: CardPanelProps) {
   const { state, isMobile } = useSidebar();
   const collapsedDesktop = !isMobile && state === "collapsed";
   const ownsToggle = isMobile || collapsedDesktop;
@@ -26,9 +28,18 @@ export function CardPanel({ hasTrafficLights }: CardPanelProps) {
             className={cn(isMobile ? "-ms-0.5" : "-ms-2", "[-webkit-app-region:no-drag]")}
           />
         )}
-        <div className="flex items-center gap-2 text-sm">
-          <span className="font-medium">New chat</span>
-          <span className="text-muted-foreground">Playground</span>
+        <div className="flex min-w-0 items-center gap-2 text-sm">
+          <span className="min-w-0 truncate font-medium" title={title}>
+            {title}
+          </span>
+          {projectName !== undefined && (
+            <span
+              className="text-muted-foreground max-w-[50%] min-w-0 truncate"
+              title={projectName}
+            >
+              {projectName}
+            </span>
+          )}
         </div>
         <ContentPanelToggle className="ms-auto [-webkit-app-region:no-drag]" />
       </header>

--- a/apps/app/src/components/layout/content-panel/core/content-panel.test.ts
+++ b/apps/app/src/components/layout/content-panel/core/content-panel.test.ts
@@ -37,14 +37,12 @@ const withPanels = (...definitions: Parameters<ContentPanel<null>["register"]>[0
 };
 
 /** A read-only `Storage` standing in for a reload with these panels persisted. */
-const storageHolding = (bySessionKey: unknown, version = 2, writes: string[] = []): Storage => {
-  const state =
-    version === 1 ? { bySessionId: bySessionKey } : { bySessionKey, legacyBySessionId: {} };
-  const value = JSON.stringify({ state, version });
+const storageHolding = (bySessionKey: unknown): Storage => {
+  const value = JSON.stringify({ state: { bySessionKey } });
   return {
     length: 1,
     getItem: (key) => (key === "vibest:content-panel" ? value : null),
-    setItem: (_key, next) => void writes.push(next),
+    setItem: () => {},
     removeItem: () => {},
     clear: () => {},
     key: () => null,
@@ -280,52 +278,6 @@ describe("ContentPanel", () => {
 
     expect(snapshot.active?.instance).toBeDefined();
     expect(created).toBe(1);
-  });
-
-  it("restores a v1 record and claims it on the first write through a SessionRef", () => {
-    const host = new ContentPanel<null>({
-      storage: storageHolding(
-        {
-          "session-1": {
-            presentation: "docked",
-            activeId: "diff",
-            panels: [{ id: "diff", type: "diff" }],
-          },
-        },
-        1,
-      ),
-    });
-    host.register(diff);
-
-    // Snapshot can read the inert legacy record before the first interaction,
-    // so there is no empty-panel flash during an upgrade.
-    expect(snapshotOf(host).panels).toHaveLength(1);
-
-    host.setPresentation(S, "maximized");
-    const state = host.store.getState();
-    expect(state.bySessionKey[sessionRefKey(S)]?.panels).toHaveLength(1);
-    expect(state.legacyBySessionId).toEqual({});
-  });
-
-  it("does not overwrite an unknown future storage version", () => {
-    const writes: string[] = [];
-    const host = new ContentPanel<null>({
-      storage: storageHolding(
-        {
-          [sessionRefKey(S)]: {
-            presentation: "docked",
-            activeId: "diff",
-            panels: [{ id: "diff", type: "diff" }],
-          },
-        },
-        3,
-        writes,
-      ),
-    });
-    host.register(diff);
-
-    expect(snapshotOf(host).panels).toHaveLength(0);
-    expect(writes).toEqual([]);
   });
 
   it("scopes panels by the complete SessionRef", () => {

--- a/apps/app/src/components/layout/content-panel/core/content-panel.test.ts
+++ b/apps/app/src/components/layout/content-panel/core/content-panel.test.ts
@@ -1,4 +1,7 @@
+import type { SessionRef } from "@vibest/contract";
 import { describe, expect, it } from "vitest";
+
+import { sessionRefKey } from "@/lib/session-ref";
 
 import { ContentPanel } from "./content-panel";
 import { definePanel, definePanelFamily, type PanelHandle } from "./panel";
@@ -16,10 +19,16 @@ const file = definePanelFamily({
   view: null,
 });
 
-const S = "session-1";
+const ref = (overrides: Partial<SessionRef> = {}): SessionRef => ({
+  projectId: "11111111-1111-4111-8111-111111111111",
+  harnessAgentId: "pi",
+  sessionId: "session-1",
+  ...overrides,
+});
+const S = ref();
 
-const snapshotOf = (host: ContentPanel<null>, sessionId: string | null = S) =>
-  host.snapshot(host.store.getState(), sessionId);
+const snapshotOf = (host: ContentPanel<null>, sessionRef: SessionRef | null = S) =>
+  host.snapshot(host.store.getState(), sessionRef);
 
 const withPanels = (...definitions: Parameters<ContentPanel<null>["register"]>[0][]) => {
   const host = new ContentPanel<null>();
@@ -28,12 +37,14 @@ const withPanels = (...definitions: Parameters<ContentPanel<null>["register"]>[0
 };
 
 /** A read-only `Storage` standing in for a reload with these panels persisted. */
-const storageHolding = (bySessionId: unknown): Storage => {
-  const value = JSON.stringify({ state: { bySessionId }, version: 1 });
+const storageHolding = (bySessionKey: unknown, version = 2, writes: string[] = []): Storage => {
+  const state =
+    version === 1 ? { bySessionId: bySessionKey } : { bySessionKey, legacyBySessionId: {} };
+  const value = JSON.stringify({ state, version });
   return {
     length: 1,
     getItem: (key) => (key === "vibest:content-panel" ? value : null),
-    setItem: () => {},
+    setItem: (_key, next) => void writes.push(next),
     removeItem: () => {},
     clear: () => {},
     key: () => null,
@@ -249,7 +260,7 @@ describe("ContentPanel", () => {
     });
     const host = new ContentPanel<null>({
       storage: storageHolding({
-        [S]: {
+        [sessionRefKey(S)]: {
           presentation: "docked",
           activeId: "counted:1",
           panels: [
@@ -271,14 +282,64 @@ describe("ContentPanel", () => {
     expect(created).toBe(1);
   });
 
-  it("scopes panels per session", () => {
-    const host = withPanels(diff);
-    host.open(S, diff);
-    host.open("session-2", diff);
-    host.close("session-2", "diff");
+  it("restores a v1 record and claims it on the first write through a SessionRef", () => {
+    const host = new ContentPanel<null>({
+      storage: storageHolding(
+        {
+          "session-1": {
+            presentation: "docked",
+            activeId: "diff",
+            panels: [{ id: "diff", type: "diff" }],
+          },
+        },
+        1,
+      ),
+    });
+    host.register(diff);
 
+    // Snapshot can read the inert legacy record before the first interaction,
+    // so there is no empty-panel flash during an upgrade.
     expect(snapshotOf(host).panels).toHaveLength(1);
-    expect(snapshotOf(host, "session-2").panels).toHaveLength(0);
+
+    host.setPresentation(S, "maximized");
+    const state = host.store.getState();
+    expect(state.bySessionKey[sessionRefKey(S)]?.panels).toHaveLength(1);
+    expect(state.legacyBySessionId).toEqual({});
+  });
+
+  it("does not overwrite an unknown future storage version", () => {
+    const writes: string[] = [];
+    const host = new ContentPanel<null>({
+      storage: storageHolding(
+        {
+          [sessionRefKey(S)]: {
+            presentation: "docked",
+            activeId: "diff",
+            panels: [{ id: "diff", type: "diff" }],
+          },
+        },
+        3,
+        writes,
+      ),
+    });
+    host.register(diff);
+
+    expect(snapshotOf(host).panels).toHaveLength(0);
+    expect(writes).toEqual([]);
+  });
+
+  it("scopes panels by the complete SessionRef", () => {
+    const host = withPanels(diff);
+    const sameIdOtherProject = ref({
+      projectId: "22222222-2222-4222-8222-222222222222",
+    });
+    const handle = host.open(S, diff);
+    host.open(sameIdOtherProject, diff);
+    host.close(sameIdOtherProject, "diff");
+
+    expect(handle.sessionRef).toEqual(S);
+    expect(snapshotOf(host).panels).toHaveLength(1);
+    expect(snapshotOf(host, sameIdOtherProject).panels).toHaveLength(0);
   });
 
   it("forget drops a session and disposes its instances", () => {

--- a/apps/app/src/components/layout/content-panel/core/content-panel.ts
+++ b/apps/app/src/components/layout/content-panel/core/content-panel.ts
@@ -35,8 +35,6 @@ interface SessionPanels {
  */
 export interface ContentPanelState {
   readonly bySessionKey: Readonly<Record<string, SessionPanels>>;
-  /** v1 records waiting for an authoritative SessionRef to claim them. */
-  readonly legacyBySessionId: Readonly<Record<string, SessionPanels>>;
   /**
    * Definitions live in the host's Map: they carry components, they are not UI
    * state. This counter is the only part of the registry the UI reacts to, and
@@ -45,7 +43,7 @@ export interface ContentPanelState {
   readonly registryVersion: number;
 }
 
-type PersistedState = Pick<ContentPanelState, "bySessionKey" | "legacyBySessionId">;
+type PersistedState = Pick<ContentPanelState, "bySessionKey">;
 
 export interface OpenPanel<View> {
   readonly id: string;
@@ -85,18 +83,6 @@ export interface ContentPanelOptions {
 }
 
 const STORAGE_NAME = "vibest:content-panel";
-const STORAGE_VERSION = 2;
-
-const hasFutureStorageVersion = (storage: Storage): boolean => {
-  try {
-    const raw = storage.getItem(STORAGE_NAME);
-    if (raw === null) return false;
-    const parsed = JSON.parse(raw) as { readonly version?: unknown };
-    return typeof parsed.version === "number" && parsed.version > STORAGE_VERSION;
-  } catch {
-    return false;
-  }
-};
 
 const EMPTY_SESSION: SessionPanels = { presentation: "hidden", activeId: null, panels: [] };
 /** Shared so an empty strip is `Object.is`-stable without costing a cache entry. */
@@ -130,42 +116,17 @@ export class ContentPanel<View = unknown> {
   #openable: { registryVersion: number; entries: readonly OpenablePanel<View>[] } | null = null;
 
   constructor(options: ContentPanelOptions = {}) {
-    const initial: ContentPanelState = {
-      bySessionKey: {},
-      legacyBySessionId: {},
-      registryVersion: 0,
-    };
+    const initial: ContentPanelState = { bySessionKey: {}, registryVersion: 0 };
     const { storage } = options;
-    this.store =
-      storage !== undefined && !hasFutureStorageVersion(storage)
-        ? createStore<ContentPanelState>()(
-            persist<ContentPanelState, [], [], PersistedState>(() => initial, {
-              name: STORAGE_NAME,
-              version: STORAGE_VERSION,
-              storage: createJSONStorage(() => storage),
-              partialize: (state) => ({
-                bySessionKey: state.bySessionKey,
-                legacyBySessionId: state.legacyBySessionId,
-              }),
-              // v1 knew only the globally unique session UUID. Keep those records
-              // inert until an authoritative route ref can claim one.
-              migrate: (persisted, version) => {
-                if (version === 1) {
-                  const legacy = persisted as { readonly bySessionId?: unknown };
-                  return {
-                    bySessionKey: {},
-                    legacyBySessionId:
-                      typeof legacy.bySessionId === "object" && legacy.bySessionId !== null
-                        ? (legacy.bySessionId as Readonly<Record<string, SessionPanels>>)
-                        : {},
-                  };
-                }
-                if (version === 2) return persisted as PersistedState;
-                throw new Error(`Unsupported content-panel storage version: ${version}`);
-              },
-            }),
-          )
-        : createStore<ContentPanelState>(() => initial);
+    this.store = storage
+      ? createStore<ContentPanelState>()(
+          persist<ContentPanelState, [], [], PersistedState>(() => initial, {
+            name: STORAGE_NAME,
+            storage: createJSONStorage(() => storage),
+            partialize: (state) => ({ bySessionKey: state.bySessionKey }),
+          }),
+        )
+      : createStore<ContentPanelState>(() => initial);
   }
 
   register(definition: AnyPanelDefinition<View>): () => void {
@@ -273,12 +234,9 @@ export class ContentPanel<View = unknown> {
     }
     this.#tabs.delete(sessionKey);
     this.store.setState((state) => {
-      const hasCurrent = sessionKey in state.bySessionKey;
-      const hasLegacy = sessionRef.sessionId in state.legacyBySessionId;
-      if (!hasCurrent && !hasLegacy) return state;
-      const { [sessionKey]: _current, ...bySessionKey } = state.bySessionKey;
-      const { [sessionRef.sessionId]: _legacy, ...legacyBySessionId } = state.legacyBySessionId;
-      return { bySessionKey, legacyBySessionId };
+      if (!(sessionKey in state.bySessionKey)) return state;
+      const { [sessionKey]: _forgotten, ...bySessionKey } = state.bySessionKey;
+      return { bySessionKey };
     });
   }
 
@@ -299,10 +257,7 @@ export class ContentPanel<View = unknown> {
       return { presentation: "hidden", panels: NO_PANELS, active: null, openable };
     }
     const sessionKey = sessionRefKey(sessionRef);
-    const session =
-      state.bySessionKey[sessionKey] ??
-      state.legacyBySessionId[sessionRef.sessionId] ??
-      EMPTY_SESSION;
+    const session = state.bySessionKey[sessionKey] ?? EMPTY_SESSION;
     const panels = this.#tabsFor(sessionRef, session.panels, state.registryVersion);
     return {
       presentation: session.presentation,
@@ -414,22 +369,14 @@ export class ContentPanel<View = unknown> {
 
   #sessionOf(sessionRef: SessionRef): SessionPanels {
     const state = this.store.getState();
-    return (
-      state.bySessionKey[sessionRefKey(sessionRef)] ??
-      state.legacyBySessionId[sessionRef.sessionId] ??
-      EMPTY_SESSION
-    );
+    return state.bySessionKey[sessionRefKey(sessionRef)] ?? EMPTY_SESSION;
   }
 
   #writeSession(sessionRef: SessionRef, session: SessionPanels): void {
     const sessionKey = sessionRefKey(sessionRef);
-    this.store.setState((state) => {
-      const { [sessionRef.sessionId]: _claimed, ...legacyBySessionId } = state.legacyBySessionId;
-      return {
-        bySessionKey: { ...state.bySessionKey, [sessionKey]: session },
-        legacyBySessionId,
-      };
-    });
+    this.store.setState((state) => ({
+      bySessionKey: { ...state.bySessionKey, [sessionKey]: session },
+    }));
   }
 
   #setPayload(sessionRef: SessionRef, id: string, next: unknown): void {

--- a/apps/app/src/components/layout/content-panel/core/content-panel.ts
+++ b/apps/app/src/components/layout/content-panel/core/content-panel.ts
@@ -1,5 +1,8 @@
+import type { SessionRef } from "@vibest/contract";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { createStore, type StoreApi } from "zustand/vanilla";
+
+import { sessionRefKey } from "@/lib/session-ref";
 
 import {
   type AnyPanelDefinition,
@@ -31,7 +34,9 @@ interface SessionPanels {
  * panel loading its content never re-renders the tab strip.
  */
 export interface ContentPanelState {
-  readonly bySessionId: Readonly<Record<string, SessionPanels>>;
+  readonly bySessionKey: Readonly<Record<string, SessionPanels>>;
+  /** v1 records waiting for an authoritative SessionRef to claim them. */
+  readonly legacyBySessionId: Readonly<Record<string, SessionPanels>>;
   /**
    * Definitions live in the host's Map: they carry components, they are not UI
    * state. This counter is the only part of the registry the UI reacts to, and
@@ -40,7 +45,7 @@ export interface ContentPanelState {
   readonly registryVersion: number;
 }
 
-type PersistedState = Pick<ContentPanelState, "bySessionId">;
+type PersistedState = Pick<ContentPanelState, "bySessionKey" | "legacyBySessionId">;
 
 export interface OpenPanel<View> {
   readonly id: string;
@@ -79,13 +84,26 @@ export interface ContentPanelOptions {
   readonly storage?: Storage;
 }
 
+const STORAGE_NAME = "vibest:content-panel";
+const STORAGE_VERSION = 2;
+
+const hasFutureStorageVersion = (storage: Storage): boolean => {
+  try {
+    const raw = storage.getItem(STORAGE_NAME);
+    if (raw === null) return false;
+    const parsed = JSON.parse(raw) as { readonly version?: unknown };
+    return typeof parsed.version === "number" && parsed.version > STORAGE_VERSION;
+  } catch {
+    return false;
+  }
+};
+
 const EMPTY_SESSION: SessionPanels = { presentation: "hidden", activeId: null, panels: [] };
 /** Shared so an empty strip is `Object.is`-stable without costing a cache entry. */
 const NO_PANELS: readonly never[] = [];
 
-// NUL occurs in neither half, so the two never collide and `forget` can match a
-// session by prefix. A panel id may well contain a space; a separator may not.
-const instanceKey = (sessionId: string, id: string): string => `${sessionId}\0${id}`;
+// NUL cannot occur in the JSON key, so `forget` can match a session by prefix.
+const instanceKey = (ref: SessionRef, id: string): string => `${sessionRefKey(ref)}\0${id}`;
 
 /**
  * The global instance: it owns the registry, the live panel instances, and a
@@ -112,18 +130,42 @@ export class ContentPanel<View = unknown> {
   #openable: { registryVersion: number; entries: readonly OpenablePanel<View>[] } | null = null;
 
   constructor(options: ContentPanelOptions = {}) {
-    const initial: ContentPanelState = { bySessionId: {}, registryVersion: 0 };
+    const initial: ContentPanelState = {
+      bySessionKey: {},
+      legacyBySessionId: {},
+      registryVersion: 0,
+    };
     const { storage } = options;
-    this.store = storage
-      ? createStore<ContentPanelState>()(
-          persist<ContentPanelState, [], [], PersistedState>(() => initial, {
-            name: "vibest:content-panel",
-            version: 1,
-            storage: createJSONStorage(() => storage),
-            partialize: (state) => ({ bySessionId: state.bySessionId }),
-          }),
-        )
-      : createStore<ContentPanelState>(() => initial);
+    this.store =
+      storage !== undefined && !hasFutureStorageVersion(storage)
+        ? createStore<ContentPanelState>()(
+            persist<ContentPanelState, [], [], PersistedState>(() => initial, {
+              name: STORAGE_NAME,
+              version: STORAGE_VERSION,
+              storage: createJSONStorage(() => storage),
+              partialize: (state) => ({
+                bySessionKey: state.bySessionKey,
+                legacyBySessionId: state.legacyBySessionId,
+              }),
+              // v1 knew only the globally unique session UUID. Keep those records
+              // inert until an authoritative route ref can claim one.
+              migrate: (persisted, version) => {
+                if (version === 1) {
+                  const legacy = persisted as { readonly bySessionId?: unknown };
+                  return {
+                    bySessionKey: {},
+                    legacyBySessionId:
+                      typeof legacy.bySessionId === "object" && legacy.bySessionId !== null
+                        ? (legacy.bySessionId as Readonly<Record<string, SessionPanels>>)
+                        : {},
+                  };
+                }
+                if (version === 2) return persisted as PersistedState;
+                throw new Error(`Unsupported content-panel storage version: ${version}`);
+              },
+            }),
+          )
+        : createStore<ContentPanelState>(() => initial);
   }
 
   register(definition: AnyPanelDefinition<View>): () => void {
@@ -153,12 +195,12 @@ export class ContentPanel<View = unknown> {
    * (then told via `reopen`) rather than duplicated. Returns the live instance.
    */
   open<Type extends string, Payload, Extra extends object>(
-    sessionId: string,
+    sessionRef: SessionRef,
     definition: PanelDefinition<Type, Payload, Extra, View>,
     ...payloadArgs: PayloadArgs<Payload>
   ): PanelInstance<Payload, Extra> {
     return this.#openWith(
-      sessionId,
+      sessionRef,
       definition as AnyPanelDefinition<View>,
       payloadArgs[0],
     ) as PanelInstance<Payload, Extra>;
@@ -169,16 +211,16 @@ export class ContentPanel<View = unknown> {
    * type rather than by definition so `openable` stays plain data, shareable
    * across sessions instead of one bound closure per session per definition.
    */
-  openNew(sessionId: string, type: string): void {
+  openNew(sessionRef: SessionRef, type: string): void {
     const definition = this.#definitions.get(type);
     if (!definition) return;
-    this.#openWith(sessionId, definition, definition.newPayload?.());
+    this.#openWith(sessionRef, definition, definition.newPayload?.());
   }
 
-  activate(sessionId: string, id: string): void {
-    const session = this.#sessionOf(sessionId);
+  activate(sessionRef: SessionRef, id: string): void {
+    const session = this.#sessionOf(sessionRef);
     if (!session.panels.some((panel) => panel.id === id)) return;
-    this.#writeSession(sessionId, {
+    this.#writeSession(sessionRef, {
       ...session,
       presentation: session.presentation === "hidden" ? "docked" : session.presentation,
       activeId: id,
@@ -189,31 +231,31 @@ export class ContentPanel<View = unknown> {
    * The low-level door. `instance.close()` comes through here, and it is also
    * how an unresolved record left over from a retired panel type gets purged.
    */
-  close(sessionId: string, id: string): void {
-    const session = this.#sessionOf(sessionId);
+  close(sessionRef: SessionRef, id: string): void {
+    const session = this.#sessionOf(sessionRef);
     const index = session.panels.findIndex((panel) => panel.id === id);
     if (index < 0) return;
-    this.#disposeInstance(sessionId, id);
+    this.#disposeInstance(sessionRef, id);
     const panels = session.panels.filter((panel) => panel.id !== id);
     // Closing the active tab lands on its neighbour, the way an editor does.
     const fallback = panels[Math.min(index, panels.length - 1)] ?? null;
-    this.#writeSession(sessionId, {
+    this.#writeSession(sessionRef, {
       presentation: panels.length === 0 ? "hidden" : session.presentation,
       activeId: session.activeId === id ? (fallback?.id ?? null) : session.activeId,
       panels,
     });
   }
 
-  setPresentation(sessionId: string, presentation: PanelPresentation): void {
-    const session = this.#sessionOf(sessionId);
+  setPresentation(sessionRef: SessionRef, presentation: PanelPresentation): void {
+    const session = this.#sessionOf(sessionRef);
     if (session.presentation === presentation) return;
-    this.#writeSession(sessionId, { ...session, presentation });
+    this.#writeSession(sessionRef, { ...session, presentation });
   }
 
   /** Hidden → docked, anything else → hidden. */
-  toggleVisibility(sessionId: string): void {
-    const { presentation } = this.#sessionOf(sessionId);
-    this.setPresentation(sessionId, presentation === "hidden" ? "docked" : "hidden");
+  toggleVisibility(sessionRef: SessionRef): void {
+    const { presentation } = this.#sessionOf(sessionRef);
+    this.setPresentation(sessionRef, presentation === "hidden" ? "docked" : "hidden");
   }
 
   /**
@@ -221,24 +263,28 @@ export class ContentPanel<View = unknown> {
    * session. No caller yet: nothing in the app hard-deletes a session, and
    * archiving is reversible, so forgetting there would lose a user's tabs.
    */
-  forget(sessionId: string): void {
-    const prefix = `${sessionId}\0`;
+  forget(sessionRef: SessionRef): void {
+    const sessionKey = sessionRefKey(sessionRef);
+    const prefix = `${sessionKey}\0`;
     for (const [key, instance] of this.#instances) {
       if (!key.startsWith(prefix)) continue;
       instance.dispose?.();
       this.#instances.delete(key);
     }
-    this.#tabs.delete(sessionId);
+    this.#tabs.delete(sessionKey);
     this.store.setState((state) => {
-      if (!(sessionId in state.bySessionId)) return state;
-      const { [sessionId]: _removed, ...rest } = state.bySessionId;
-      return { bySessionId: rest };
+      const hasCurrent = sessionKey in state.bySessionKey;
+      const hasLegacy = sessionRef.sessionId in state.legacyBySessionId;
+      if (!hasCurrent && !hasLegacy) return state;
+      const { [sessionKey]: _current, ...bySessionKey } = state.bySessionKey;
+      const { [sessionRef.sessionId]: _legacy, ...legacyBySessionId } = state.legacyBySessionId;
+      return { bySessionKey, legacyBySessionId };
     });
   }
 
   /** The test seam: asserts on instance lifetime without going through a render. */
-  instanceFor(sessionId: string, id: string): PanelHandle<unknown> | undefined {
-    return this.#instances.get(instanceKey(sessionId, id));
+  instanceFor(sessionRef: SessionRef, id: string): PanelHandle<unknown> | undefined {
+    return this.#instances.get(instanceKey(sessionRef, id));
   }
 
   /**
@@ -247,13 +293,17 @@ export class ContentPanel<View = unknown> {
    * identical array — which is what lets `useStore` decide, by `Object.is`, not
    * to re-render. Select fields off this; the wrapper itself is cheap and fresh.
    */
-  snapshot(state: ContentPanelState, sessionId: string | null): PanelSnapshot<View> {
+  snapshot(state: ContentPanelState, sessionRef: SessionRef | null): PanelSnapshot<View> {
     const openable = this.#openableFor(state.registryVersion);
-    if (sessionId === null) {
+    if (sessionRef === null) {
       return { presentation: "hidden", panels: NO_PANELS, active: null, openable };
     }
-    const session = state.bySessionId[sessionId] ?? EMPTY_SESSION;
-    const panels = this.#tabsFor(sessionId, session.panels, state.registryVersion);
+    const sessionKey = sessionRefKey(sessionRef);
+    const session =
+      state.bySessionKey[sessionKey] ??
+      state.legacyBySessionId[sessionRef.sessionId] ??
+      EMPTY_SESSION;
+    const panels = this.#tabsFor(sessionRef, session.panels, state.registryVersion);
     return {
       presentation: session.presentation,
       panels,
@@ -263,14 +313,15 @@ export class ContentPanel<View = unknown> {
   }
 
   #tabsFor(
-    sessionId: string,
+    sessionRef: SessionRef,
     records: readonly PanelRecord[],
     registryVersion: number,
   ): readonly OpenPanel<View>[] {
     // Sessions merely visited never reach the cache, so it stays the size of
     // what the user actually opened.
     if (records.length === 0) return NO_PANELS;
-    const cached = this.#tabs.get(sessionId);
+    const sessionKey = sessionRefKey(sessionRef);
+    const cached = this.#tabs.get(sessionKey);
     if (cached && cached.records === records && cached.registryVersion === registryVersion) {
       return cached.panels;
     }
@@ -281,7 +332,7 @@ export class ContentPanel<View = unknown> {
       const payload = definition.parse ? definition.parse(record.payload) : record.payload;
       if (payload === null) continue;
       // Arrow, so `this` is the host without aliasing it into the literal.
-      const materialize = () => this.#ensureInstance(sessionId, record.id, definition);
+      const materialize = () => this.#ensureInstance(sessionRef, record.id, definition);
       panels.push({
         id: record.id,
         label: definition.label(payload),
@@ -291,7 +342,7 @@ export class ContentPanel<View = unknown> {
         },
       });
     }
-    this.#tabs.set(sessionId, { records, registryVersion, panels });
+    this.#tabs.set(sessionKey, { records, registryVersion, panels });
     return panels;
   }
 
@@ -319,21 +370,21 @@ export class ContentPanel<View = unknown> {
    * conditional collapses to a union and the spread stops type-checking.
    */
   #openWith(
-    sessionId: string,
+    sessionRef: SessionRef,
     definition: AnyPanelDefinition<View>,
     payload: unknown,
   ): PanelHandle<unknown> {
     const id = panelId(definition, payload);
-    const session = this.#sessionOf(sessionId);
+    const session = this.#sessionOf(sessionRef);
     const isOpen = session.panels.some((panel) => panel.id === id);
-    this.#writeSession(sessionId, {
+    this.#writeSession(sessionRef, {
       presentation: session.presentation === "hidden" ? "docked" : session.presentation,
       activeId: id,
       panels: isOpen
         ? session.panels.map((panel) => (panel.id === id ? { ...panel, payload } : panel))
         : [...session.panels, { id, type: definition.type, payload }],
     });
-    const instance = this.#ensureInstance(sessionId, id, definition);
+    const instance = this.#ensureInstance(sessionRef, id, definition);
     // The payload is written first, so `reopen` sees it on the handle too.
     if (isOpen) instance.reopen(payload);
     return instance;
@@ -361,19 +412,29 @@ export class ContentPanel<View = unknown> {
     this.store.setState((state) => ({ registryVersion: state.registryVersion + 1 }));
   }
 
-  #sessionOf(sessionId: string): SessionPanels {
-    return this.store.getState().bySessionId[sessionId] ?? EMPTY_SESSION;
+  #sessionOf(sessionRef: SessionRef): SessionPanels {
+    const state = this.store.getState();
+    return (
+      state.bySessionKey[sessionRefKey(sessionRef)] ??
+      state.legacyBySessionId[sessionRef.sessionId] ??
+      EMPTY_SESSION
+    );
   }
 
-  #writeSession(sessionId: string, session: SessionPanels): void {
-    this.store.setState((state) => ({
-      bySessionId: { ...state.bySessionId, [sessionId]: session },
-    }));
+  #writeSession(sessionRef: SessionRef, session: SessionPanels): void {
+    const sessionKey = sessionRefKey(sessionRef);
+    this.store.setState((state) => {
+      const { [sessionRef.sessionId]: _claimed, ...legacyBySessionId } = state.legacyBySessionId;
+      return {
+        bySessionKey: { ...state.bySessionKey, [sessionKey]: session },
+        legacyBySessionId,
+      };
+    });
   }
 
-  #setPayload(sessionId: string, id: string, next: unknown): void {
-    const session = this.#sessionOf(sessionId);
-    this.#writeSession(sessionId, {
+  #setPayload(sessionRef: SessionRef, id: string, next: unknown): void {
+    const session = this.#sessionOf(sessionRef);
+    this.#writeSession(sessionRef, {
       ...session,
       panels: session.panels.map((panel) =>
         panel.id === id
@@ -391,8 +452,8 @@ export class ContentPanel<View = unknown> {
     });
   }
 
-  #disposeInstance(sessionId: string, id: string): void {
-    const key = instanceKey(sessionId, id);
+  #disposeInstance(sessionRef: SessionRef, id: string): void {
+    const key = instanceKey(sessionRef, id);
     this.#instances.get(key)?.dispose?.();
     this.#instances.delete(key);
   }
@@ -403,14 +464,14 @@ export class ContentPanel<View = unknown> {
    * moment it is rendered — and not before.
    */
   #ensureInstance(
-    sessionId: string,
+    sessionRef: SessionRef,
     id: string,
     definition: AnyPanelDefinition<View>,
   ): PanelHandle<unknown> {
-    const key = instanceKey(sessionId, id);
+    const key = instanceKey(sessionRef, id);
     const existing = this.#instances.get(key);
     if (existing) return existing;
-    const handle = this.#createHandle(sessionId, id);
+    const handle = this.#createHandle(sessionRef, id);
     // Prototype-linked, not spread: `payload` is an accessor on the handle, and
     // copying it would freeze the value it had the moment the panel opened.
     const instance: PanelHandle<unknown> = definition.create
@@ -420,20 +481,20 @@ export class ContentPanel<View = unknown> {
     return instance;
   }
 
-  #createHandle(sessionId: string, id: string): PanelHandle<unknown> {
+  #createHandle(sessionRef: SessionRef, id: string): PanelHandle<unknown> {
     // Arrows throughout: they close over `this` lexically, so the getter below
     // can reach the host without aliasing it.
     const payloadOf = (): unknown =>
-      this.#sessionOf(sessionId).panels.find((panel) => panel.id === id)?.payload;
+      this.#sessionOf(sessionRef).panels.find((panel) => panel.id === id)?.payload;
     return {
       id,
-      sessionId,
+      sessionRef,
       get payload(): unknown {
         return payloadOf();
       },
-      activate: () => this.activate(sessionId, id),
-      close: () => this.close(sessionId, id),
-      setPayload: (next) => this.#setPayload(sessionId, id, next),
+      activate: () => this.activate(sessionRef, id),
+      close: () => this.close(sessionRef, id),
+      setPayload: (next) => this.#setPayload(sessionRef, id, next),
       reopen: () => {},
     };
   }

--- a/apps/app/src/components/layout/content-panel/core/panel.ts
+++ b/apps/app/src/components/layout/content-panel/core/panel.ts
@@ -1,3 +1,5 @@
+import type { SessionRef } from "@vibest/contract";
+
 /**
  * The panel vocabulary. Zero React on purpose: everything here is data or a
  * pure function, so the workspace model in `content-panel.ts` can be driven
@@ -20,7 +22,7 @@
  */
 export interface PanelHandle<Payload> {
   readonly id: string;
-  readonly sessionId: string;
+  readonly sessionRef: SessionRef;
   readonly payload: Payload;
   activate(): void;
   close(): void;

--- a/apps/app/src/components/layout/content-panel/react/context.ts
+++ b/apps/app/src/components/layout/content-panel/react/context.ts
@@ -1,3 +1,4 @@
+import type { SessionRef } from "@vibest/contract";
 import { createContext, use } from "react";
 
 import type { ContentPanel } from "../core/content-panel";
@@ -6,7 +7,7 @@ import type { AnyPanelView } from "./view";
 export interface ContentPanelContextValue {
   readonly contentPanel: ContentPanel<AnyPanelView>;
   /** null outside a session route (`/draft`, `/`), where there is nothing to scope panels to. */
-  readonly sessionId: string | null;
+  readonly sessionRef: SessionRef | null;
 }
 
 export const ContentPanelContext = createContext<ContentPanelContextValue | null>(null);

--- a/apps/app/src/components/layout/content-panel/react/hooks.ts
+++ b/apps/app/src/components/layout/content-panel/react/hooks.ts
@@ -1,3 +1,4 @@
+import type { SessionRef } from "@vibest/contract";
 import { useMemo } from "react";
 import { useStore } from "zustand";
 
@@ -8,7 +9,7 @@ import type { AnyPanelView } from "./view";
 
 /** Session-level operations, with the session already bound. Panel-level ones live on the instance. */
 export interface ContentPanelSession {
-  readonly sessionId: string;
+  readonly sessionRef: SessionRef;
   open<Type extends string, Payload, Extra extends object>(
     definition: PanelDefinition<Type, Payload, Extra, AnyPanelView>,
     ...payload: PayloadArgs<Payload>
@@ -29,19 +30,19 @@ export interface ContentPanelSession {
  * null outside a session route.
  */
 export function useContentPanel(): ContentPanelSession | null {
-  const { contentPanel, sessionId } = useContentPanelContext();
+  const { contentPanel, sessionRef } = useContentPanelContext();
   return useMemo(() => {
-    if (sessionId === null) return null;
+    if (sessionRef === null) return null;
     return {
-      sessionId,
-      open: (definition, ...payload) => contentPanel.open(sessionId, definition, ...payload),
-      openNew: (type) => contentPanel.openNew(sessionId, type),
-      activate: (id) => contentPanel.activate(sessionId, id),
-      close: (id) => contentPanel.close(sessionId, id),
-      setPresentation: (presentation) => contentPanel.setPresentation(sessionId, presentation),
-      toggleVisibility: () => contentPanel.toggleVisibility(sessionId),
+      sessionRef,
+      open: (definition, ...payload) => contentPanel.open(sessionRef, definition, ...payload),
+      openNew: (type) => contentPanel.openNew(sessionRef, type),
+      activate: (id) => contentPanel.activate(sessionRef, id),
+      close: (id) => contentPanel.close(sessionRef, id),
+      setPresentation: (presentation) => contentPanel.setPresentation(sessionRef, presentation),
+      toggleVisibility: () => contentPanel.toggleVisibility(sessionRef),
     };
-  }, [contentPanel, sessionId]);
+  }, [contentPanel, sessionRef]);
 }
 
 /**
@@ -53,6 +54,8 @@ export function useContentPanel(): ContentPanelSession | null {
 export function usePanelSnapshot<Selected>(
   selector: (snapshot: PanelSnapshot<AnyPanelView>) => Selected,
 ): Selected {
-  const { contentPanel, sessionId } = useContentPanelContext();
-  return useStore(contentPanel.store, (state) => selector(contentPanel.snapshot(state, sessionId)));
+  const { contentPanel, sessionRef } = useContentPanelContext();
+  return useStore(contentPanel.store, (state) =>
+    selector(contentPanel.snapshot(state, sessionRef)),
+  );
 }

--- a/apps/app/src/components/layout/content-panel/react/provider.tsx
+++ b/apps/app/src/components/layout/content-panel/react/provider.tsx
@@ -1,3 +1,4 @@
+import type { SessionRef } from "@vibest/contract";
 import { type ReactNode, useMemo } from "react";
 
 import type { ContentPanel } from "../core/content-panel";
@@ -7,22 +8,20 @@ import type { AnyPanelView } from "./view";
 /**
  * Carries the global host plus the identity everything below binds to. The
  * host itself is created outside React and outlives every route; only the
- * `sessionId` binding is React's business.
+ * authoritative `SessionRef` binding is React's business.
  *
- * `sessionId` and nothing else, deliberately: an ambient channel for values
- * particular panels want (a cwd, a git ref) would widen every consumer's memo
- * for the benefit of one. A panel that needs a workspace path takes it in its
- * payload — already persisted and parsed — or resolves it in its own view.
+ * The ref is identity, not an ambient data bag: panel-specific values such as a
+ * workspace path or git ref still belong in that panel's own payload/model.
  */
 export interface ContentPanelProviderProps {
   readonly contentPanel: ContentPanel<AnyPanelView>;
   /** null off a session route; every panel hook below degrades to a no-op. */
-  readonly sessionId: string | null;
+  readonly sessionRef: SessionRef | null;
   readonly children: ReactNode;
 }
 
 export function ContentPanelProvider(props: ContentPanelProviderProps): ReactNode {
-  const { contentPanel, sessionId, children } = props;
-  const value = useMemo(() => ({ contentPanel, sessionId }), [contentPanel, sessionId]);
+  const { contentPanel, sessionRef, children } = props;
+  const value = useMemo(() => ({ contentPanel, sessionRef }), [contentPanel, sessionRef]);
   return <ContentPanelContext value={value}>{children}</ContentPanelContext>;
 }

--- a/apps/app/src/features/chat/runtime/chat-manager.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-manager.test.ts
@@ -5,10 +5,11 @@ import type { AgentResponse } from "./agent-requests";
 import { ChatManager } from "./chat-manager";
 import type { ChatSessionTransport, ChatTransportEvent } from "./chat-transport-port";
 
-const refFor = (sessionId: string): SessionRef => ({
+const refFor = (sessionId: string, overrides: Partial<SessionRef> = {}): SessionRef => ({
   projectId: "project-1",
   harnessAgentId: "claude-code",
   sessionId,
+  ...overrides,
 });
 
 class FakeTransport implements ChatSessionTransport {
@@ -40,12 +41,13 @@ const makeManager = () => {
 };
 
 describe("ChatManager", () => {
-  it("hands out one Chat per session across calls", () => {
+  it("hands out one Chat per complete SessionRef across calls", () => {
     const { manager, transports } = makeManager();
     const first = manager.chatFor(refFor("session-1"));
     expect(manager.chatFor(refFor("session-1"))).toBe(first);
     expect(manager.chatFor(refFor("session-2"))).not.toBe(first);
-    expect(transports).toHaveLength(2);
+    expect(manager.chatFor(refFor("session-1", { projectId: "project-2" }))).not.toBe(first);
+    expect(transports).toHaveLength(3);
   });
 
   it("evicts and unsubscribes a Chat once the session closes", () => {

--- a/apps/app/src/features/chat/runtime/chat-manager.ts
+++ b/apps/app/src/features/chat/runtime/chat-manager.ts
@@ -1,5 +1,7 @@
 import type { SessionRef } from "@vibest/contract";
 
+import { sessionRefKey } from "@/lib/session-ref";
+
 import { Chat } from "./chat";
 import type { ChatSessionTransportFactory } from "./chat-transport-port";
 
@@ -9,7 +11,7 @@ export interface ChatManagerApi {
   chatFor(sessionRef: SessionRef): Chat;
 }
 
-// Owns the live Chat instances keyed by the session's uuid. Sessions survive
+// Owns the live Chat instances keyed by the complete SessionRef. Sessions survive
 // route switches: chatFor() is get-or-create, and nothing disposes a Chat on
 // navigation — its store keeps the transcript for the next mount. The one
 // exception is eviction below. Each Chat gets its own transport, minted from
@@ -27,14 +29,15 @@ export class ChatManager implements ChatManagerApi {
   // on the SessionRef, so cold-loaded session routes and the session-creating
   // caller alike carry the real harness rather than a default.
   chatFor(sessionRef: SessionRef): Chat {
-    const existing = this.#chats.get(sessionRef.sessionId);
+    const key = sessionRefKey(sessionRef);
+    const existing = this.#chats.get(key);
     if (existing) return existing;
     const chat = new Chat({
       sessionRef,
       transport: this.createTransport(sessionRef),
-      onTerminated: () => this.#evict(sessionRef.sessionId),
+      onTerminated: () => this.#evict(key),
     });
-    this.#chats.set(sessionRef.sessionId, chat);
+    this.#chats.set(key, chat);
     return chat;
   }
 
@@ -49,10 +52,10 @@ export class ChatManager implements ChatManagerApi {
   // Safe to look the entry up rather than compare identities: `closed` reaches
   // a Chat only from inside the subscription's async loop, so the `set` below
   // has always run by the time this fires.
-  #evict(sessionId: string): void {
-    const chat = this.#chats.get(sessionId);
+  #evict(key: string): void {
+    const chat = this.#chats.get(key);
     if (!chat) return;
-    this.#chats.delete(sessionId);
+    this.#chats.delete(key);
     chat.dispose();
   }
 }

--- a/apps/app/src/features/projects/project-list.tsx
+++ b/apps/app/src/features/projects/project-list.tsx
@@ -1,3 +1,4 @@
+import type { SessionRef } from "@vibest/contract";
 import {
   Collapsible,
   CollapsiblePanel,
@@ -15,7 +16,13 @@ import { ProjectSessionsGroup } from "@/features/projects/project-sessions-group
 import { useProjects } from "@/features/projects/use-projects";
 
 /** Every imported project, each rendering its own session list. */
-export function ProjectList({ onImport }: { onImport: () => void }) {
+export function ProjectList({
+  isSessionActive,
+  onImport,
+}: {
+  readonly isSessionActive: (ref: SessionRef) => boolean;
+  readonly onImport: () => void;
+}) {
   const projects = useProjects();
 
   return (
@@ -37,7 +44,11 @@ export function ProjectList({ onImport }: { onImport: () => void }) {
         <CollapsiblePanel>
           <SidebarGroupContent className="flex flex-col gap-2">
             {(projects.data ?? []).map((project) => (
-              <ProjectSessionsGroup key={project.id} project={project} />
+              <ProjectSessionsGroup
+                key={project.id}
+                isSessionActive={isSessionActive}
+                project={project}
+              />
             ))}
           </SidebarGroupContent>
         </CollapsiblePanel>

--- a/apps/app/src/features/projects/project-session-row.tsx
+++ b/apps/app/src/features/projects/project-session-row.tsx
@@ -1,19 +1,25 @@
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import type { SessionSummary } from "@vibest/contract";
 import { SidebarMenuButton, SidebarMenuItem } from "@vibest/ui/components/sidebar";
 
 import { SessionActionsMenu } from "@/features/projects/session-actions-menu";
 
 /** One session row: open-session navigation plus composed session actions. */
-export function ProjectSessionRow({ session }: { readonly session: SessionSummary }) {
+export function ProjectSessionRow({
+  active,
+  isActive,
+  session,
+}: {
+  readonly active: boolean;
+  readonly isActive: () => boolean;
+  readonly session: SessionSummary;
+}) {
   const navigate = useNavigate();
-  // strict: false — the sidebar renders on every route, and most have no sessionId.
-  const { sessionId: activeSessionId } = useParams({ strict: false });
 
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
-        isActive={session.sessionId === activeSessionId}
+        isActive={active}
         onClick={() =>
           navigate({
             to: "/session/$sessionId",
@@ -32,7 +38,7 @@ export function ProjectSessionRow({ session }: { readonly session: SessionSummar
           />
         )}
       </SidebarMenuButton>
-      <SessionActionsMenu session={session} />
+      <SessionActionsMenu isActive={isActive} session={session} />
     </SidebarMenuItem>
   );
 }

--- a/apps/app/src/features/projects/project-sessions-group.tsx
+++ b/apps/app/src/features/projects/project-sessions-group.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import type { Project, SessionSummary } from "@vibest/contract";
+import type { Project, SessionRef, SessionSummary } from "@vibest/contract";
 import {
   Collapsible,
   CollapsiblePanel,
@@ -24,7 +24,13 @@ const EMPTY_SESSIONS: ReadonlyArray<SessionSummary> = [];
  * panel is open (two icon entities, not a rotation). This component owns only
  * grouping and fetching; each row composes its own navigation and actions.
  */
-export function ProjectSessionsGroup({ project }: { project: Project }) {
+export function ProjectSessionsGroup({
+  isSessionActive,
+  project,
+}: {
+  readonly isSessionActive: (ref: SessionRef) => boolean;
+  readonly project: Project;
+}) {
   const navigate = useNavigate();
   const sessions = useProjectSessions(project.id);
   const rows = sessions.data ?? EMPTY_SESSIONS;
@@ -60,7 +66,12 @@ export function ProjectSessionsGroup({ project }: { project: Project }) {
           <SidebarGroupContent>
             <SidebarMenu>
               {rows.map((session) => (
-                <ProjectSessionRow key={session.sessionId} session={session} />
+                <ProjectSessionRow
+                  key={session.sessionId}
+                  active={isSessionActive(session)}
+                  isActive={() => isSessionActive(session)}
+                  session={session}
+                />
               ))}
             </SidebarMenu>
           </SidebarGroupContent>

--- a/apps/app/src/features/projects/session-actions-menu.tsx
+++ b/apps/app/src/features/projects/session-actions-menu.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useParams, useRouteContext } from "@tanstack/react-router";
+import { useNavigate, useRouteContext } from "@tanstack/react-router";
 import type { SessionSummary } from "@vibest/contract";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@vibest/ui/components/menu";
 import { SidebarMenuAction } from "@vibest/ui/components/sidebar";
@@ -10,12 +10,16 @@ import { toast } from "sonner";
 import { RenameSessionDialog } from "@/features/projects/rename-session-dialog";
 
 /** Session mutations live behind one actions-menu capability boundary. */
-export function SessionActionsMenu({ session }: { readonly session: SessionSummary }) {
+export function SessionActionsMenu({
+  isActive,
+  session,
+}: {
+  readonly isActive: () => boolean;
+  readonly session: SessionSummary;
+}) {
   const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  // strict: false — the menu also renders on routes without a sessionId.
-  const { sessionId: activeSessionId } = useParams({ strict: false });
   const [renaming, setRenaming] = useState(false);
   const title = session.title ?? "New chat";
 
@@ -39,7 +43,7 @@ export function SessionActionsMenu({ session }: { readonly session: SessionSumma
         queryClient.invalidateQueries({ queryKey: listKey(true) }),
       ]);
 
-      if (archived && activeSessionId === session.sessionId) {
+      if (archived && isActive()) {
         return Promise.all([
           refreshLists,
           navigate({ to: "/draft", search: { projectId: session.projectId } }),

--- a/apps/app/src/features/projects/use-project-sessions.test.ts
+++ b/apps/app/src/features/projects/use-project-sessions.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { SessionSummary } from "@vibest/contract";
+import type { SessionRef, SessionSummary } from "@vibest/contract";
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -20,15 +20,19 @@ vi.mock("@tanstack/react-router", () => ({
   }),
 }));
 
-import { selectProjectSession, useProjectSession } from "./use-project-sessions";
+import { selectProjectSessionTitle, useProjectSessionTitle } from "./use-project-sessions";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-const session = (sessionId: string, title: string, archived = false): SessionSummary => ({
+const session = (
+  sessionId: string,
+  title: string | undefined,
+  archived = false,
+): SessionSummary => ({
   projectId: "project-1",
   harnessAgentId: "pi",
   sessionId,
-  title,
+  ...(title === undefined ? {} : { title }),
   archived,
   createdAt: "2026-08-08T00:00:00.000Z",
   historyAvailable: true,
@@ -37,20 +41,32 @@ const session = (sessionId: string, title: string, archived = false): SessionSum
 let root: Root | undefined;
 let host: HTMLDivElement | undefined;
 
+const refFor = (sessionId: string, overrides: Partial<SessionRef> = {}): SessionRef => ({
+  projectId: "project-1",
+  harnessAgentId: "pi",
+  sessionId,
+  ...overrides,
+});
+
 function Probe({ sessionId }: { sessionId: string }) {
-  const selected = useProjectSession("project-1", sessionId);
-  return createElement("span", null, selected?.title ?? "missing");
+  const title = useProjectSessionTitle(refFor(sessionId));
+  return createElement("span", null, title ?? "missing");
 }
 
 const renderSession = async (
   sessionId: string,
   active: ReadonlyArray<SessionSummary>,
   archived: ReadonlyArray<SessionSummary> = [],
+  fetches: boolean[] = [],
+  waitForTitle = true,
 ): Promise<string> => {
   mocks.queryOptions.mockImplementation(
     ({ input }: { input: { projectId: string; archived: boolean } }) => ({
       queryKey: ["session.list", input],
-      queryFn: async () => (input.archived ? archived : active),
+      queryFn: async () => {
+        fetches.push(input.archived);
+        return input.archived ? archived : active;
+      },
     }),
   );
   if (!host) {
@@ -69,7 +85,11 @@ const renderSession = async (
     ),
   );
   await act(async () => {
-    await vi.waitFor(() => expect(host?.textContent).not.toBe("missing"));
+    await vi.waitFor(() =>
+      waitForTitle
+        ? expect(host?.textContent).not.toBe("missing")
+        : expect(fetches).toHaveLength(1),
+    );
   });
   return host.textContent ?? "";
 };
@@ -83,23 +103,47 @@ afterEach(() => {
   mocks.queryOptions.mockReset();
 });
 
-describe("selectProjectSession", () => {
+describe("selectProjectSessionTitle", () => {
   it("selects the title for the active session instead of reusing another session's header", () => {
     const sessions = [session("session-1", "First chat"), session("session-2", "Second chat")];
 
-    expect(selectProjectSession(sessions, "session-1")?.title).toBe("First chat");
-    expect(selectProjectSession(sessions, "session-2")?.title).toBe("Second chat");
+    expect(selectProjectSessionTitle(sessions, refFor("session-1"))).toBe("First chat");
+    expect(selectProjectSessionTitle(sessions, refFor("session-2"))).toBe("Second chat");
+    expect(
+      selectProjectSessionTitle(sessions, refFor("session-1", { projectId: "other-project" })),
+    ).toBeUndefined();
+    expect(
+      selectProjectSessionTitle([session("untitled", undefined)], refFor("untitled")),
+    ).toBeNull();
   });
 });
 
-describe("useProjectSession", () => {
-  it("reads an active session title from the project list", async () => {
+describe("useProjectSessionTitle", () => {
+  it("reads an active title without fetching the archived list", async () => {
+    const fetches: boolean[] = [];
     await expect(
-      renderSession("session-2", [
-        session("session-1", "First chat"),
-        session("session-2", "Second chat"),
-      ]),
+      renderSession(
+        "session-2",
+        [session("session-1", "First chat"), session("session-2", "Second chat")],
+        [],
+        fetches,
+      ),
     ).resolves.toBe("Second chat");
+    expect(fetches).toEqual([false]);
+  });
+
+  it("does not query archived sessions when the active session exists without a title", async () => {
+    const fetches: boolean[] = [];
+    await expect(
+      renderSession(
+        "untitled",
+        [session("untitled", undefined)],
+        [session("untitled", "stale archived title", true)],
+        fetches,
+        false,
+      ),
+    ).resolves.toBe("missing");
+    expect(fetches).toEqual([false]);
   });
 
   it("falls back to the archived list for a valid archived-session route", async () => {

--- a/apps/app/src/features/projects/use-project-sessions.test.ts
+++ b/apps/app/src/features/projects/use-project-sessions.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { SessionSummary } from "@vibest/contract";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  queryOptions: vi.fn<
+    (options: { input: { projectId: string; archived: boolean } }) => {
+      queryKey: ReadonlyArray<unknown>;
+      queryFn: () => Promise<ReadonlyArray<SessionSummary>>;
+    }
+  >(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouteContext: () => ({
+    orpcQueryUtils: { session: { list: { queryOptions: mocks.queryOptions } } },
+  }),
+}));
+
+import { selectProjectSession, useProjectSession } from "./use-project-sessions";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const session = (sessionId: string, title: string, archived = false): SessionSummary => ({
+  projectId: "project-1",
+  harnessAgentId: "pi",
+  sessionId,
+  title,
+  archived,
+  createdAt: "2026-08-08T00:00:00.000Z",
+  historyAvailable: true,
+});
+
+let root: Root | undefined;
+let host: HTMLDivElement | undefined;
+
+function Probe({ sessionId }: { sessionId: string }) {
+  const selected = useProjectSession("project-1", sessionId);
+  return createElement("span", null, selected?.title ?? "missing");
+}
+
+const renderSession = async (
+  sessionId: string,
+  active: ReadonlyArray<SessionSummary>,
+  archived: ReadonlyArray<SessionSummary> = [],
+): Promise<string> => {
+  mocks.queryOptions.mockImplementation(
+    ({ input }: { input: { projectId: string; archived: boolean } }) => ({
+      queryKey: ["session.list", input],
+      queryFn: async () => (input.archived ? archived : active),
+    }),
+  );
+  if (!host) {
+    host = document.createElement("div");
+    document.body.append(host);
+    root = createRoot(host);
+  }
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  act(() =>
+    root?.render(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(Probe, { sessionId }),
+      ),
+    ),
+  );
+  await act(async () => {
+    await vi.waitFor(() => expect(host?.textContent).not.toBe("missing"));
+  });
+  return host.textContent ?? "";
+};
+
+afterEach(() => {
+  const mounted = root;
+  act(() => mounted?.unmount());
+  host?.remove();
+  root = undefined;
+  host = undefined;
+  mocks.queryOptions.mockReset();
+});
+
+describe("selectProjectSession", () => {
+  it("selects the title for the active session instead of reusing another session's header", () => {
+    const sessions = [session("session-1", "First chat"), session("session-2", "Second chat")];
+
+    expect(selectProjectSession(sessions, "session-1")?.title).toBe("First chat");
+    expect(selectProjectSession(sessions, "session-2")?.title).toBe("Second chat");
+  });
+});
+
+describe("useProjectSession", () => {
+  it("reads an active session title from the project list", async () => {
+    await expect(
+      renderSession("session-2", [
+        session("session-1", "First chat"),
+        session("session-2", "Second chat"),
+      ]),
+    ).resolves.toBe("Second chat");
+  });
+
+  it("falls back to the archived list for a valid archived-session route", async () => {
+    await expect(
+      renderSession("session-3", [], [session("session-3", "Archived chat", true)]),
+    ).resolves.toBe("Archived chat");
+  });
+});

--- a/apps/app/src/features/projects/use-project-sessions.ts
+++ b/apps/app/src/features/projects/use-project-sessions.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
 import type { SessionSummary } from "@vibest/contract";
+import { useCallback } from "react";
 
 // Newest-first: a session is opened right after it is created. Module scope
 // keeps `select` referentially stable across renders.
@@ -27,4 +28,49 @@ export function useProjectSessions(
     staleTime: 30_000,
     select: selectNewestFirst,
   });
+}
+
+export const selectProjectSession = (
+  sessions: ReadonlyArray<SessionSummary>,
+  sessionId: string,
+): SessionSummary | undefined => sessions.find((session) => session.sessionId === sessionId);
+
+/**
+ * One session from a project's held lists.
+ *
+ * The selector closes over `sessionId`, so it stays memoised: title events can
+ * patch the shared list while this consumer re-renders only for its own row.
+ * The archived list stays cold unless the active list has loaded without the
+ * routed session; this preserves archived bookmarks without doubling the usual
+ * session-page request.
+ */
+export function useProjectSession(
+  projectId: string | undefined,
+  sessionId: string | undefined,
+): SessionSummary | undefined {
+  const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
+  const enabled = projectId !== undefined && sessionId !== undefined;
+  const select = useCallback(
+    (sessions: ReadonlyArray<SessionSummary>) =>
+      sessionId === undefined ? undefined : selectProjectSession(sessions, sessionId),
+    [sessionId],
+  );
+  const active = useQuery({
+    ...orpcQueryUtils.session.list.queryOptions({
+      input: { projectId: projectId ?? "", archived: false },
+    }),
+    enabled,
+    staleTime: 30_000,
+    select,
+  });
+  const archived = useQuery({
+    ...orpcQueryUtils.session.list.queryOptions({
+      input: { projectId: projectId ?? "", archived: true },
+    }),
+    enabled: enabled && active.isSuccess && active.data === undefined,
+    staleTime: 30_000,
+    select,
+  });
+
+  return active.data ?? archived.data;
 }

--- a/apps/app/src/features/projects/use-project-sessions.ts
+++ b/apps/app/src/features/projects/use-project-sessions.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
-import type { SessionSummary } from "@vibest/contract";
+import type { SessionRef, SessionSummary } from "@vibest/contract";
 import { useCallback } from "react";
+
+import { sameSessionRef } from "@/lib/session-ref";
 
 // Newest-first: a session is opened right after it is created. Module scope
 // keeps `select` referentially stable across renders.
@@ -30,30 +32,37 @@ export function useProjectSessions(
   });
 }
 
-export const selectProjectSession = (
+export const selectProjectSessionTitle = (
   sessions: ReadonlyArray<SessionSummary>,
-  sessionId: string,
-): SessionSummary | undefined => sessions.find((session) => session.sessionId === sessionId);
+  ref: SessionRef,
+): string | null | undefined => {
+  const session = sessions.find((candidate) => sameSessionRef(candidate, ref));
+  return session === undefined ? undefined : (session.title ?? null);
+};
 
 /**
- * One session from a project's held lists.
+ * One session title from a project's held lists.
  *
- * The selector closes over `sessionId`, so it stays memoised: title events can
- * patch the shared list while this consumer re-renders only for its own row.
+ * The selector closes over the primitive SessionRef fields, so it stays
+ * memoised: title events can patch the shared list while this consumer
+ * re-renders only for its own title.
  * The archived list stays cold unless the active list has loaded without the
  * routed session; this preserves archived bookmarks without doubling the usual
  * session-page request.
  */
-export function useProjectSession(
-  projectId: string | undefined,
-  sessionId: string | undefined,
-): SessionSummary | undefined {
+export function useProjectSessionTitle(ref: SessionRef | undefined): string | undefined {
   const { orpcQueryUtils } = useRouteContext({ from: "__root__" });
-  const enabled = projectId !== undefined && sessionId !== undefined;
+  const projectId = ref?.projectId;
+  const harnessAgentId = ref?.harnessAgentId;
+  const sessionId = ref?.sessionId;
+  const enabled =
+    projectId !== undefined && harnessAgentId !== undefined && sessionId !== undefined;
   const select = useCallback(
     (sessions: ReadonlyArray<SessionSummary>) =>
-      sessionId === undefined ? undefined : selectProjectSession(sessions, sessionId),
-    [sessionId],
+      projectId === undefined || harnessAgentId === undefined || sessionId === undefined
+        ? undefined
+        : selectProjectSessionTitle(sessions, { projectId, harnessAgentId, sessionId }),
+    [harnessAgentId, projectId, sessionId],
   );
   const active = useQuery({
     ...orpcQueryUtils.session.list.queryOptions({
@@ -72,5 +81,6 @@ export function useProjectSession(
     select,
   });
 
-  return active.data ?? archived.data;
+  if (active.data !== undefined) return active.data ?? undefined;
+  return archived.data ?? undefined;
 }

--- a/apps/app/src/lib/session-ref.test.ts
+++ b/apps/app/src/lib/session-ref.test.ts
@@ -1,0 +1,29 @@
+import type { SessionRef } from "@vibest/contract";
+import { describe, expect, it } from "vitest";
+
+import { sameSessionRef, sessionRefKey } from "./session-ref";
+
+const ref = (overrides: Partial<SessionRef> = {}): SessionRef => ({
+  projectId: "11111111-1111-4111-8111-111111111111",
+  harnessAgentId: "pi",
+  sessionId: "shared-session-id",
+  ...overrides,
+});
+
+describe("SessionRef identity", () => {
+  it("compares every field", () => {
+    expect(sameSessionRef(ref(), ref())).toBe(true);
+    expect(sameSessionRef(ref(), ref({ projectId: "22222222-2222-4222-8222-222222222222" }))).toBe(
+      false,
+    );
+    expect(sameSessionRef(ref(), ref({ harnessAgentId: "codex" }))).toBe(false);
+    expect(sameSessionRef(ref(), null)).toBe(false);
+  });
+
+  it("keys equal refs together and same-id refs from different projects apart", () => {
+    expect(sessionRefKey(ref())).toBe(sessionRefKey(ref()));
+    expect(sessionRefKey(ref())).not.toBe(
+      sessionRefKey(ref({ projectId: "22222222-2222-4222-8222-222222222222" })),
+    );
+  });
+});

--- a/apps/app/src/lib/session-ref.ts
+++ b/apps/app/src/lib/session-ref.ts
@@ -1,0 +1,13 @@
+import type { SessionRef } from "@vibest/contract";
+
+/** Stable client-side key for the complete session identity. */
+export const sessionRefKey = (ref: SessionRef): string =>
+  JSON.stringify([ref.projectId, ref.harnessAgentId, ref.sessionId]);
+
+/** Compare all identity fields; a bare sessionId is never sufficient. */
+export const sameSessionRef = (left: SessionRef, right: SessionRef | null | undefined): boolean =>
+  right !== null &&
+  right !== undefined &&
+  left.projectId === right.projectId &&
+  left.harnessAgentId === right.harnessAgentId &&
+  left.sessionId === right.sessionId;

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -100,14 +100,17 @@ function RootLayout() {
     >
       <ContentPanelProvider contentPanel={contentPanel} sessionRef={sessionRef}>
         <RegisterPanels definitions={STATIC_PANELS} />
-        <AppShell
-          sidebar={<AppSidebar isSessionActive={isSessionActive} onNewChat={handleNewChat} />}
-        >
-          <CardPanel
-            hasTrafficLights={os === "macos"}
-            heading={sessionRef === null ? "New chat" : (sessionTitle ?? "New chat")}
-            supportingText={project?.name}
-          />
+        <AppShell>
+          <AppShell.Sidebar>
+            <AppSidebar isSessionActive={isSessionActive} onNewChat={handleNewChat} />
+          </AppShell.Sidebar>
+          <AppShell.Main>
+            <CardPanel
+              hasTrafficLights={os === "macos"}
+              heading={sessionRef === null ? "New chat" : (sessionTitle ?? "New chat")}
+              supportingText={project?.name}
+            />
+          </AppShell.Main>
         </AppShell>
       </ContentPanelProvider>
     </SidebarProvider>

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -1,13 +1,20 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, useMatch, useNavigate } from "@tanstack/react-router";
+import type { SessionRef } from "@vibest/contract";
 import { SidebarProvider } from "@vibest/ui/components/sidebar";
+import { useCallback, useRef } from "react";
 
 import { AppShell } from "@/components/layout/app-shell";
+import { AppSidebar } from "@/components/layout/app-sidebar";
+import { CardPanel } from "@/components/layout/card-panel";
 import { ContentPanelProvider } from "@/components/layout/content-panel/react/provider";
 import { RegisterPanels } from "@/components/layout/content-panel/react/register";
 import { contentPanel, STATIC_PANELS } from "@/content-panel";
+import { useProjectSessionTitle } from "@/features/projects/use-project-sessions";
+import { useProject } from "@/features/projects/use-projects";
 import { useSessionListSync } from "@/features/projects/use-session-list-sync";
 import type { AppClients } from "@/lib/orpc";
+import { sameSessionRef } from "@/lib/session-ref";
 import { usePlatform } from "@/platform-context";
 
 export interface RouterAppContext {
@@ -40,20 +47,37 @@ function RootLayout() {
   const navigate = useNavigate();
   const { os } = usePlatform();
 
-  // The content panel is session-scoped, but it is bound here rather than in the
-  // session route: it is a card of the shell, peer to the chat's, and maximizing
-  // it has to be able to take the chat card's width.
+  // This is the shell's one route-identity seam: the content panel, active
+  // sidebar row, and card heading all derive from the same authoritative ref.
+  // The content panel is bound here rather than in the session route because it
+  // is a peer card whose maximized state controls the whole shell.
   //
   // A named match, not `useParams({ strict: false })`: this component *is* the
   // root route's, so the nearest match is always the root — which has no params
   // — and the session route's would never be seen. The match's loaderData is
   // also the ref the server confirmed, unlike the URL's search hints. Off a
   // session route it is null and every panel hook degrades to a no-op.
-  const sessionRef = useMatch({
-    from: "/session/$sessionId",
+  const sessionRef =
+    useMatch({
+      from: "/session/$sessionId",
+      shouldThrow: false,
+      select: (match) => match.loaderData ?? null,
+    }) ?? null;
+  const draftProjectId = useMatch({
+    from: "/draft",
     shouldThrow: false,
-    select: (match) => match.loaderData ?? null,
+    select: (match) => match.search.projectId ?? null,
   });
+  const project = useProject(sessionRef?.projectId ?? draftProjectId);
+  const sessionTitle = useProjectSessionTitle(sessionRef ?? undefined);
+  // Mutations can settle after navigation. This stable predicate reads the
+  // latest authoritative route ref instead of a render-time `active` boolean.
+  const currentSessionRef = useRef(sessionRef);
+  currentSessionRef.current = sessionRef;
+  const isSessionActive = useCallback(
+    (candidate: SessionRef) => sameSessionRef(candidate, currentSessionRef.current),
+    [],
+  );
   const handleNewChat = () => navigate({ to: "/draft" });
 
   return (
@@ -65,9 +89,17 @@ function RootLayout() {
       className="bg-sidebar h-svh overflow-hidden [-webkit-app-region:drag]"
       defaultOpen={readSidebarCookie()}
     >
-      <ContentPanelProvider contentPanel={contentPanel} sessionId={sessionRef?.sessionId ?? null}>
+      <ContentPanelProvider contentPanel={contentPanel} sessionRef={sessionRef}>
         <RegisterPanels definitions={STATIC_PANELS} />
-        <AppShell hasTrafficLights={os === "macos"} onNewChat={handleNewChat} />
+        <AppShell
+          sidebar={<AppSidebar isSessionActive={isSessionActive} onNewChat={handleNewChat} />}
+        >
+          <CardPanel
+            hasTrafficLights={os === "macos"}
+            heading={sessionRef === null ? "New chat" : (sessionTitle ?? "New chat")}
+            supportingText={project?.name}
+          />
+        </AppShell>
       </ContentPanelProvider>
     </SidebarProvider>
   );

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -6,8 +6,6 @@ import { AppShell } from "@/components/layout/app-shell";
 import { ContentPanelProvider } from "@/components/layout/content-panel/react/provider";
 import { RegisterPanels } from "@/components/layout/content-panel/react/register";
 import { contentPanel, STATIC_PANELS } from "@/content-panel";
-import { useProjectSession } from "@/features/projects/use-project-sessions";
-import { useProject } from "@/features/projects/use-projects";
 import { useSessionListSync } from "@/features/projects/use-session-list-sync";
 import type { AppClients } from "@/lib/orpc";
 import { usePlatform } from "@/platform-context";
@@ -56,14 +54,6 @@ function RootLayout() {
     shouldThrow: false,
     select: (match) => match.loaderData ?? null,
   });
-  const draftProjectId = useMatch({
-    from: "/draft",
-    shouldThrow: false,
-    select: (match) => match.search.projectId ?? null,
-  });
-  const project = useProject(sessionRef?.projectId ?? draftProjectId);
-  const session = useProjectSession(sessionRef?.projectId, sessionRef?.sessionId);
-
   const handleNewChat = () => navigate({ to: "/draft" });
 
   return (
@@ -77,12 +67,7 @@ function RootLayout() {
     >
       <ContentPanelProvider contentPanel={contentPanel} sessionId={sessionRef?.sessionId ?? null}>
         <RegisterPanels definitions={STATIC_PANELS} />
-        <AppShell
-          hasTrafficLights={os === "macos"}
-          onNewChat={handleNewChat}
-          projectName={project?.name}
-          title={sessionRef === null ? "New chat" : (session?.title ?? "New chat")}
-        />
+        <AppShell hasTrafficLights={os === "macos"} onNewChat={handleNewChat} />
       </ContentPanelProvider>
     </SidebarProvider>
   );

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -6,6 +6,8 @@ import { AppShell } from "@/components/layout/app-shell";
 import { ContentPanelProvider } from "@/components/layout/content-panel/react/provider";
 import { RegisterPanels } from "@/components/layout/content-panel/react/register";
 import { contentPanel, STATIC_PANELS } from "@/content-panel";
+import { useProjectSession } from "@/features/projects/use-project-sessions";
+import { useProject } from "@/features/projects/use-projects";
 import { useSessionListSync } from "@/features/projects/use-session-list-sync";
 import type { AppClients } from "@/lib/orpc";
 import { usePlatform } from "@/platform-context";
@@ -49,11 +51,18 @@ function RootLayout() {
   // — and the session route's would never be seen. The match's loaderData is
   // also the ref the server confirmed, unlike the URL's search hints. Off a
   // session route it is null and every panel hook degrades to a no-op.
-  const sessionId = useMatch({
+  const sessionRef = useMatch({
     from: "/session/$sessionId",
     shouldThrow: false,
-    select: (match) => match.loaderData?.sessionId ?? null,
+    select: (match) => match.loaderData ?? null,
   });
+  const draftProjectId = useMatch({
+    from: "/draft",
+    shouldThrow: false,
+    select: (match) => match.search.projectId ?? null,
+  });
+  const project = useProject(sessionRef?.projectId ?? draftProjectId);
+  const session = useProjectSession(sessionRef?.projectId, sessionRef?.sessionId);
 
   const handleNewChat = () => navigate({ to: "/draft" });
 
@@ -66,9 +75,14 @@ function RootLayout() {
       className="bg-sidebar h-svh overflow-hidden [-webkit-app-region:drag]"
       defaultOpen={readSidebarCookie()}
     >
-      <ContentPanelProvider contentPanel={contentPanel} sessionId={sessionId ?? null}>
+      <ContentPanelProvider contentPanel={contentPanel} sessionId={sessionRef?.sessionId ?? null}>
         <RegisterPanels definitions={STATIC_PANELS} />
-        <AppShell hasTrafficLights={os === "macos"} onNewChat={handleNewChat} />
+        <AppShell
+          hasTrafficLights={os === "macos"}
+          onNewChat={handleNewChat}
+          projectName={project?.name}
+          title={sessionRef === null ? "New chat" : (session?.title ?? "New chat")}
+        />
       </ContentPanelProvider>
     </SidebarProvider>
   );

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -9,7 +9,7 @@ import type { SessionRef } from "@vibest/contract";
 import { SidebarProvider } from "@vibest/ui/components/sidebar";
 import { useCallback } from "react";
 
-import { AppShell } from "@/components/layout/app-shell";
+import { AppShell, AppShellMain, AppShellSidebar } from "@/components/layout/app-shell";
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { CardPanel } from "@/components/layout/card-panel";
 import { ContentPanelProvider } from "@/components/layout/content-panel/react/provider";
@@ -101,16 +101,16 @@ function RootLayout() {
       <ContentPanelProvider contentPanel={contentPanel} sessionRef={sessionRef}>
         <RegisterPanels definitions={STATIC_PANELS} />
         <AppShell>
-          <AppShell.Sidebar>
+          <AppShellSidebar>
             <AppSidebar isSessionActive={isSessionActive} onNewChat={handleNewChat} />
-          </AppShell.Sidebar>
-          <AppShell.Main>
+          </AppShellSidebar>
+          <AppShellMain>
             <CardPanel
               hasTrafficLights={os === "macos"}
               heading={sessionRef === null ? "New chat" : (sessionTitle ?? "New chat")}
               supportingText={project?.name}
             />
-          </AppShell.Main>
+          </AppShellMain>
         </AppShell>
       </ContentPanelProvider>
     </SidebarProvider>

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -1,8 +1,13 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { createRootRouteWithContext, useMatch, useNavigate } from "@tanstack/react-router";
+import {
+  createRootRouteWithContext,
+  useMatch,
+  useNavigate,
+  useRouter,
+} from "@tanstack/react-router";
 import type { SessionRef } from "@vibest/contract";
 import { SidebarProvider } from "@vibest/ui/components/sidebar";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 
 import { AppShell } from "@/components/layout/app-shell";
 import { AppSidebar } from "@/components/layout/app-sidebar";
@@ -70,13 +75,17 @@ function RootLayout() {
   });
   const project = useProject(sessionRef?.projectId ?? draftProjectId);
   const sessionTitle = useProjectSessionTitle(sessionRef ?? undefined);
-  // Mutations can settle after navigation. This stable predicate reads the
-  // latest authoritative route ref instead of a render-time `active` boolean.
-  const currentSessionRef = useRef(sessionRef);
-  currentSessionRef.current = sessionRef;
+  // Mutations can settle after navigation. Read the router's current match at
+  // call time instead of capturing a render-time `active` boolean.
+  const router = useRouter();
   const isSessionActive = useCallback(
-    (candidate: SessionRef) => sameSessionRef(candidate, currentSessionRef.current),
-    [],
+    (candidate: SessionRef) => {
+      const current = router.state.matches.find(
+        (match) => match.routeId === "/session/$sessionId",
+      )?.loaderData;
+      return sameSessionRef(candidate, current);
+    },
+    [router],
   );
   const handleNewChat = () => navigate({ to: "/draft" });
 

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -18,7 +18,8 @@ export const HARNESS_AGENT_IDS: ReadonlyArray<HarnessAgentId> = HarnessAgentIdSc
 export const SessionRefSchema = Schema.Struct({
   projectId: Schema.String.check(Schema.isUUID()),
   harnessAgentId: HarnessAgentIdSchema,
-  // Server-generated, opaque to clients; unique within a project.
+  // Server-generated, opaque to clients, and globally unique for reverse lookup.
+  // Session operations still use the complete ref rather than this field alone.
   sessionId: Schema.NonEmptyString,
 });
 export type SessionRef = typeof SessionRefSchema.Type;


### PR DESCRIPTION
## Summary

Fix the static `New chat / Playground` header and make the shell's Project/Session dependencies explicit.

### Shell composition

- make `routes/__root.tsx` the shell's single authoritative route-identity seam
- make `AppShell` structural through context-driven `AppShellSidebar`/`AppShellMain` children
- keep `CardPanel` display-only with generic heading primitives
- derive the card heading, project label, sidebar selection, and content-panel binding from the same loader-confirmed `SessionRef`

### Session identity

- add canonical `sameSessionRef` and `sessionRefKey` helpers
- compare complete refs for sidebar active state and archive navigation
- key `ChatManager` instances by complete `SessionRef`
- bind ContentPanel persistence, tab caches, live instances, operations, and panel handles to complete refs
- document the globally unique server UUID invariant while retaining complete refs as the client operation/state identity

### ContentPanel persistence

- persist only the current composite-keyed panel state
- treat ContentPanel localStorage as disposable client state
- intentionally provide no application storage version or migration path; incompatible old state may be discarded

### Header query

- subscribe only to the selected session title rather than the whole `SessionSummary`
- keep archived-session lookup lazy
- distinguish an untitled active session from a missing active row

## Verification

- `pnpm check`
- `pnpm exec turbo run typecheck test --filter=@vibest/app --force` — 123 tests passed
- React Doctor 0.9.11 — 100/100, no issues
- browser-driven verification:
  - switching between sessions updates both the header and exactly one active sidebar row
  - ContentPanel binds to the active session
  - panel state does not leak to another session and restores when returning
- independent final architecture review: ready, no blocker/high/medium findings



