### PR TITLE
fix(app): simplify draft agent selector styling

### DIFF
--- a/apps/app/src/features/chat/components/harness-select.tsx
+++ b/apps/app/src/features/chat/components/harness-select.tsx
@@ -1,12 +1,12 @@
 import type { HarnessAgentId } from "@vibest/contract";
 import {
-  PromptInputButton,
   PromptInputModelSelect,
   PromptInputModelSelectContent,
   PromptInputModelSelectItem,
   PromptInputModelSelectTrigger,
   PromptInputModelSelectValue,
 } from "@vibest/ui/ai-elements/prompt-input";
+import { Button } from "@vibest/ui/components/button";
 import { ChevronDownIcon } from "lucide-react";
 
 import { useHarnessAgents } from "@/features/chat/harness/use-harness";
@@ -47,9 +47,9 @@ export function HarnessSelect({
           the field-style trigger chrome and its hard-coded up/down icon. */}
       <PromptInputModelSelectTrigger
         render={({ children: _children, className: _className, ...triggerProps }) => (
-          <PromptInputButton
+          <Button
             {...triggerProps}
-            className="text-foreground font-normal"
+            className="text-foreground gap-1.5 px-3 font-normal"
             size="default"
             variant="ghost"
           >
@@ -58,7 +58,7 @@ export function HarnessSelect({
               <span className="truncate">{selectedHarnessAgent?.name ?? value}</span>
             </PromptInputModelSelectValue>
             <ChevronDownIcon aria-hidden="true" className="size-4 shrink-0 opacity-70" />
-          </PromptInputButton>
+          </Button>
         )}
       />
       <PromptInputModelSelectContent>

--- a/apps/app/src/features/chat/components/harness-select.tsx
+++ b/apps/app/src/features/chat/components/harness-select.tsx
@@ -1,5 +1,6 @@
 import type { HarnessAgentId } from "@vibest/contract";
 import {
+  PromptInputButton,
   PromptInputModelSelect,
   PromptInputModelSelectContent,
   PromptInputModelSelectItem,
@@ -42,16 +43,24 @@ export function HarnessSelect({
         if (next) onChange(next as HarnessAgentId);
       }}
     >
-      <PromptInputModelSelectTrigger className="group hover:bg-accent data-pressed:bg-accent min-h-8 border-0 bg-transparent px-3 py-0 shadow-none not-data-disabled:not-focus-visible:not-aria-invalid:not-data-pressed:before:shadow-none dark:bg-transparent dark:not-data-disabled:not-focus-visible:not-aria-invalid:not-data-pressed:before:shadow-none [&>[data-slot=select-icon]]:hidden">
-        <PromptInputModelSelectValue className="flex min-w-0 items-center gap-2">
-          <HarnessIcon className="size-4 shrink-0" harnessAgentId={value} />
-          <span className="truncate">{selectedHarnessAgent?.name ?? value}</span>
-        </PromptInputModelSelectValue>
-        <ChevronDownIcon
-          aria-hidden="true"
-          className="size-4 shrink-0 opacity-70 transition-transform group-data-[popup-open]:rotate-180"
-        />
-      </PromptInputModelSelectTrigger>
+      {/* The render callback preserves Base UI's Select behavior while replacing
+          the field-style trigger chrome and its hard-coded up/down icon. */}
+      <PromptInputModelSelectTrigger
+        render={({ children: _children, className: _className, ...triggerProps }) => (
+          <PromptInputButton
+            {...triggerProps}
+            className="text-foreground font-normal"
+            size="default"
+            variant="ghost"
+          >
+            <PromptInputModelSelectValue className="flex min-w-0 items-center gap-2">
+              <HarnessIcon className="size-4 shrink-0" harnessAgentId={value} />
+              <span className="truncate">{selectedHarnessAgent?.name ?? value}</span>
+            </PromptInputModelSelectValue>
+            <ChevronDownIcon aria-hidden="true" className="size-4 shrink-0 opacity-70" />
+          </PromptInputButton>
+        )}
+      />
       <PromptInputModelSelectContent>
         {harnessAgents.map((harnessAgent) => (
           <PromptInputModelSelectItem

--- a/apps/app/src/features/chat/components/harness-select.tsx
+++ b/apps/app/src/features/chat/components/harness-select.tsx
@@ -6,6 +6,7 @@ import {
   PromptInputModelSelectTrigger,
   PromptInputModelSelectValue,
 } from "@vibest/ui/ai-elements/prompt-input";
+import { ChevronDownIcon } from "lucide-react";
 
 import { useHarnessAgents } from "@/features/chat/harness/use-harness";
 
@@ -41,11 +42,15 @@ export function HarnessSelect({
         if (next) onChange(next as HarnessAgentId);
       }}
     >
-      <PromptInputModelSelectTrigger className="min-h-8 py-0">
+      <PromptInputModelSelectTrigger className="group hover:bg-accent data-pressed:bg-accent min-h-8 border-0 bg-transparent px-3 py-0 shadow-none not-data-disabled:not-focus-visible:not-aria-invalid:not-data-pressed:before:shadow-none dark:bg-transparent dark:not-data-disabled:not-focus-visible:not-aria-invalid:not-data-pressed:before:shadow-none [&>[data-slot=select-icon]]:hidden">
         <PromptInputModelSelectValue className="flex min-w-0 items-center gap-2">
           <HarnessIcon className="size-4 shrink-0" harnessAgentId={value} />
           <span className="truncate">{selectedHarnessAgent?.name ?? value}</span>
         </PromptInputModelSelectValue>
+        <ChevronDownIcon
+          aria-hidden="true"
+          className="size-4 shrink-0 opacity-70 transition-transform group-data-[popup-open]:rotate-180"
+        />
       </PromptInputModelSelectTrigger>
       <PromptInputModelSelectContent>
         {harnessAgents.map((harnessAgent) => (


### PR DESCRIPTION
## Summary

- render the draft agent Select trigger through the shared ghost `Button`
- replace the field-style trigger chrome and hard-coded up/down indicator with a compact single chevron
- preserve Base UI Select behavior without changing shared Select components or hiding their icon with CSS

## Verification

- `pnpm exec oxlint --deny-warnings apps/app/src/features/chat/components/harness-select.tsx`
- `pnpm exec oxfmt --check apps/app/src/features/chat/components/harness-select.tsx`
- `pnpm turbo run typecheck --filter=@vibest/app`
- `pnpm turbo run build --filter=@vibest/app`
- visually verified the closed trigger and popup interaction in the browser