### PR TITLE
chore(deps): upgrade Effect family to 4.0.0-rc.109

### DIFF
--- a/.agents/rules/stack.md
+++ b/.agents/rules/stack.md
@@ -2,7 +2,7 @@
 
 These differ from what the library names suggest.
 
-- **Effect is 4.x beta, not v3.** `Schema` imports from `"effect"` (not
+- **Effect is 4.x RC, not v3.** `Schema` imports from `"effect"` (not
   `@effect/schema`); services are `Context.Service<Self, Shape>()("Tag")` with a
   hand-written `Layer`, not `Effect.Service`. Two experimental modules are in
   production use: `effect/unstable/cli` and `effect/unstable/process`.

--- a/.agents/rules/toolchain.md
+++ b/.agents/rules/toolchain.md
@@ -1,12 +1,14 @@
 # Toolchain constraints
 
 - **Dependencies:** `pnpm-workspace.yaml` has three catalogs (`catalog:`,
-  `catalog:orpc`, `catalog:tiptap`) plus `overrides` that pull _transitive_ deps
-  onto catalog versions — bumping a package's own `package.json` for `vite`,
-  `vitest`, `effect`, or `@effect/*` does nothing. Several pins are caret-free
-  because a caret breaks the runtime. The reasons are commented inline; read them
-  before changing versions. `packages/server` pins the Claude SDK as a literal
-  while `packages/vibest` uses `catalog:` — bump both together.
+  `catalog:orpc`, `catalog:tiptap`). Effect packages are exact-pinned together in
+  the main catalog and intentionally not overridden; keep the family aligned and
+  verify the lockfile resolves one Effect runtime. `overrides` pull transitive
+  Vite/Vitest dependencies onto catalog versions. Bumping a package's own
+  `package.json` for catalog dependencies does nothing. Several pins are
+  caret-free because a caret breaks the runtime. The reasons are commented
+  inline; read them before changing versions. `packages/server` pins the Claude
+  SDK as a literal while `packages/vibest` uses `catalog:` — bump both together.
 - **Lint:** `lint:check` runs `--deny-warnings`, so the whole `suspicious`
   category fails CI while only warning locally. oxfmt reorders imports.
 - **Commits rewrite files:** pre-commit runs lint-staged (`oxlint --fix` + `oxfmt`)

--- a/docs/2026-07-15-effect-native-harness-agent-runtime-design.md
+++ b/docs/2026-07-15-effect-native-harness-agent-runtime-design.md
@@ -940,7 +940,7 @@ type ResumeSessionError =
   SessionNotFound | SessionNotResumable | AgentUnavailable | ExecutableNotFound | AgentOpenError;
 ```
 
-Runtime 第一阶段使用 `Data.TaggedError`。需要跨 RPC 暴露的 error data 在 §11 Standard Schema spike 通过后使用当前 Effect v4 的 `Schema.TaggedErrorClass`，并通过 oRPC error map 显式映射。
+Runtime 第一阶段使用 `Data.TaggedError`。需要跨 RPC 暴露的 error data 在 §11 Standard Schema spike 通过后使用当前 Effect v4 的 `Schema.TaggedError`，并通过 oRPC error map 显式映射。
 
 禁止继续使用：
 

--- a/docs/2026-07-15-t3code-effect-agent-integration-research.md
+++ b/docs/2026-07-15-t3code-effect-agent-integration-research.md
@@ -79,7 +79,7 @@ Notable choices:
 - IDs and bounded numeric/domain values are branded or filtered schemas.
 - Runtime events optionally include provider references and a raw native payload for diagnostics.
 - RPC payload, success, error, and stream item schemas all come from Effect Schema.
-- Tagged errors in protocol packages use `Schema.TaggedErrorClass`.
+- Tagged errors in protocol packages use `Schema.TaggedError`.
 
 ### Relevance to Vibest
 

--- a/docs/plans/2026-07-15-effect-native-harness-agent-runtime-plan.md
+++ b/docs/plans/2026-07-15-effect-native-harness-agent-runtime-plan.md
@@ -231,7 +231,7 @@ schema["~standard"].jsonSchema.input;
   - `Deferred<A, E>`;
   - `SynchronizedRef`;
   - `Stream.fromQueue`, `Stream.fromAsyncIterable`, `Stream.toAsyncIterable`, `Stream.flatMap`, `Stream.filterMap`;
-  - `Schema.TaggedErrorClass`;
+  - `Schema.TaggedError`;
   - `effect/unstable/process/ChildProcess` and `ChildProcessSpawner`;
   - `@effect/platform-node/NodeServices`.
 - [ ] Spawn a fake JSONL child process through ChildProcessSpawner and verify scoped termination, stdio Streams/Sinks, exit status, and `forceKillAfter`.

--- a/packages/server/src/harness/claude-code/errors.ts
+++ b/packages/server/src/harness/claude-code/errors.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
 
-export class ClaudeSdkError extends Schema.TaggedErrorClass<ClaudeSdkError>()("ClaudeSdkError", {
+export class ClaudeSdkError extends Schema.TaggedError<ClaudeSdkError>()("ClaudeSdkError", {
   operation: Schema.String,
   cause: Schema.Defect(),
 }) {

--- a/packages/server/src/harness/errors.ts
+++ b/packages/server/src/harness/errors.ts
@@ -14,7 +14,7 @@ const causeSummary = (cause: unknown): string => {
   return String(cause);
 };
 
-export class HarnessAgentNotFound extends Schema.TaggedErrorClass<HarnessAgentNotFound>()(
+export class HarnessAgentNotFound extends Schema.TaggedError<HarnessAgentNotFound>()(
   "HarnessAgentNotFound",
   { harnessAgentId: HarnessAgentIdSchema },
 ) {
@@ -23,19 +23,16 @@ export class HarnessAgentNotFound extends Schema.TaggedErrorClass<HarnessAgentNo
   }
 }
 
-export class AgentUnavailable extends Schema.TaggedErrorClass<AgentUnavailable>()(
-  "AgentUnavailable",
-  {
-    harnessAgentId: HarnessAgentIdSchema,
-    reason: Schema.String,
-  },
-) {
+export class AgentUnavailable extends Schema.TaggedError<AgentUnavailable>()("AgentUnavailable", {
+  harnessAgentId: HarnessAgentIdSchema,
+  reason: Schema.String,
+}) {
   override get message() {
     return `Harness agent '${this.harnessAgentId}' is unavailable: ${this.reason}`;
   }
 }
 
-export class ExecutableNotFound extends Schema.TaggedErrorClass<ExecutableNotFound>()(
+export class ExecutableNotFound extends Schema.TaggedError<ExecutableNotFound>()(
   "ExecutableNotFound",
   {
     harnessAgentId: HarnessAgentIdSchema,
@@ -47,7 +44,7 @@ export class ExecutableNotFound extends Schema.TaggedErrorClass<ExecutableNotFou
   }
 }
 
-export class AgentOpenError extends Schema.TaggedErrorClass<AgentOpenError>()("AgentOpenError", {
+export class AgentOpenError extends Schema.TaggedError<AgentOpenError>()("AgentOpenError", {
   harnessAgentId: HarnessAgentIdSchema,
   cause: Schema.Defect(),
 }) {
@@ -62,7 +59,7 @@ export class AgentOpenError extends Schema.TaggedErrorClass<AgentOpenError>()("A
  * `SessionNotFound` — metadata missing from storage — and the two used to
  * share a tag, forcing structural sniffing at the RPC error mapping.
  */
-export class HarnessSessionNotFound extends Schema.TaggedErrorClass<HarnessSessionNotFound>()(
+export class HarnessSessionNotFound extends Schema.TaggedError<HarnessSessionNotFound>()(
   "HarnessSessionNotFound",
   {
     sessionId: Schema.String,
@@ -73,7 +70,7 @@ export class HarnessSessionNotFound extends Schema.TaggedErrorClass<HarnessSessi
   }
 }
 
-export class SessionNotResumable extends Schema.TaggedErrorClass<SessionNotResumable>()(
+export class SessionNotResumable extends Schema.TaggedError<SessionNotResumable>()(
   "SessionNotResumable",
   {
     sessionId: Schema.String,
@@ -87,7 +84,7 @@ export class SessionNotResumable extends Schema.TaggedErrorClass<SessionNotResum
   }
 }
 
-export class SessionClosed extends Schema.TaggedErrorClass<SessionClosed>()("SessionClosed", {
+export class SessionClosed extends Schema.TaggedError<SessionClosed>()("SessionClosed", {
   sessionId: Schema.String,
 }) {
   override get message() {
@@ -95,7 +92,7 @@ export class SessionClosed extends Schema.TaggedErrorClass<SessionClosed>()("Ses
   }
 }
 
-export class TurnAlreadyRunning extends Schema.TaggedErrorClass<TurnAlreadyRunning>()(
+export class TurnAlreadyRunning extends Schema.TaggedError<TurnAlreadyRunning>()(
   "TurnAlreadyRunning",
   {
     sessionId: Schema.String,
@@ -109,7 +106,7 @@ export class TurnAlreadyRunning extends Schema.TaggedErrorClass<TurnAlreadyRunni
   }
 }
 
-export class AgentRequestUnavailable extends Schema.TaggedErrorClass<AgentRequestUnavailable>()(
+export class AgentRequestUnavailable extends Schema.TaggedError<AgentRequestUnavailable>()(
   "AgentRequestUnavailable",
   {
     sessionId: Schema.String,
@@ -121,7 +118,7 @@ export class AgentRequestUnavailable extends Schema.TaggedErrorClass<AgentReques
   }
 }
 
-export class AgentOperationError extends Schema.TaggedErrorClass<AgentOperationError>()(
+export class AgentOperationError extends Schema.TaggedError<AgentOperationError>()(
   "AgentOperationError",
   {
     sessionId: Schema.String,
@@ -134,7 +131,7 @@ export class AgentOperationError extends Schema.TaggedErrorClass<AgentOperationE
   }
 }
 
-export class CodexTransportError extends Schema.TaggedErrorClass<CodexTransportError>()(
+export class CodexTransportError extends Schema.TaggedError<CodexTransportError>()(
   "CodexTransportError",
   {
     operation: Schema.String,
@@ -146,7 +143,7 @@ export class CodexTransportError extends Schema.TaggedErrorClass<CodexTransportE
   }
 }
 
-export class CodexRpcError extends Schema.TaggedErrorClass<CodexRpcError>()("CodexRpcError", {
+export class CodexRpcError extends Schema.TaggedError<CodexRpcError>()("CodexRpcError", {
   method: Schema.String,
   code: Schema.Number,
   errorMessage: Schema.String,
@@ -157,19 +154,16 @@ export class CodexRpcError extends Schema.TaggedErrorClass<CodexRpcError>()("Cod
   }
 }
 
-export class PiTransportError extends Schema.TaggedErrorClass<PiTransportError>()(
-  "PiTransportError",
-  {
-    operation: Schema.String,
-    cause: Schema.Defect(),
-  },
-) {
+export class PiTransportError extends Schema.TaggedError<PiTransportError>()("PiTransportError", {
+  operation: Schema.String,
+  cause: Schema.Defect(),
+}) {
   override get message() {
     return `Pi transport operation '${this.operation}' failed: ${causeSummary(this.cause)}`;
   }
 }
 
-export class PiRpcError extends Schema.TaggedErrorClass<PiRpcError>()("PiRpcError", {
+export class PiRpcError extends Schema.TaggedError<PiRpcError>()("PiRpcError", {
   command: Schema.String,
   errorMessage: Schema.String,
 }) {
@@ -178,7 +172,7 @@ export class PiRpcError extends Schema.TaggedErrorClass<PiRpcError>()("PiRpcErro
   }
 }
 
-export class AgentProcessExited extends Schema.TaggedErrorClass<AgentProcessExited>()(
+export class AgentProcessExited extends Schema.TaggedError<AgentProcessExited>()(
   "AgentProcessExited",
   {
     harnessAgentId: HarnessAgentIdSchema,
@@ -199,7 +193,7 @@ export class AgentProcessExited extends Schema.TaggedErrorClass<AgentProcessExit
   }
 }
 
-export class AgentProtocolError extends Schema.TaggedErrorClass<AgentProtocolError>()(
+export class AgentProtocolError extends Schema.TaggedError<AgentProtocolError>()(
   "AgentProtocolError",
   {
     harnessAgentId: HarnessAgentIdSchema,
@@ -216,7 +210,7 @@ export class AgentProtocolError extends Schema.TaggedErrorClass<AgentProtocolErr
 // this harness's declared subset — a client bug by definition (the subset is
 // closed and fully known to the client), so it maps to INVALID_ARGUMENT at the
 // RPC boundary rather than being silently ignored or half-applied.
-export class PermissionModeUnsupported extends Schema.TaggedErrorClass<PermissionModeUnsupported>()(
+export class PermissionModeUnsupported extends Schema.TaggedError<PermissionModeUnsupported>()(
   "PermissionModeUnsupported",
   {
     harnessAgentId: HarnessAgentIdSchema,
@@ -228,7 +222,7 @@ export class PermissionModeUnsupported extends Schema.TaggedErrorClass<Permissio
   }
 }
 
-export class CapabilityProbeFailed extends Schema.TaggedErrorClass<CapabilityProbeFailed>()(
+export class CapabilityProbeFailed extends Schema.TaggedError<CapabilityProbeFailed>()(
   "CapabilityProbeFailed",
   {
     harnessAgentId: HarnessAgentIdSchema,
@@ -240,7 +234,7 @@ export class CapabilityProbeFailed extends Schema.TaggedErrorClass<CapabilityPro
   }
 }
 
-export class CapabilityUnsupported extends Schema.TaggedErrorClass<CapabilityUnsupported>()(
+export class CapabilityUnsupported extends Schema.TaggedError<CapabilityUnsupported>()(
   "CapabilityUnsupported",
   {
     harnessAgentId: HarnessAgentIdSchema,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,12 @@ catalogs:
     '@anthropic-ai/claude-agent-sdk':
       specifier: 0.3.220
       version: 0.3.220
+    '@effect/platform-node':
+      specifier: 4.0.0-rc.109
+      version: 4.0.0-rc.109
+    '@effect/vitest':
+      specifier: 4.0.0-rc.109
+      version: 4.0.0-rc.109
     '@tailwindcss/vite':
       specifier: ^4.3.3
       version: 4.3.3
@@ -39,6 +45,9 @@ catalogs:
     clsx:
       specifier: ^2.1.1
       version: 2.1.1
+    effect:
+      specifier: 4.0.0-rc.109
+      version: 4.0.0-rc.109
     lucide-react:
       specifier: ^1.25.0
       version: 1.25.0
@@ -135,9 +144,6 @@ catalogs:
 overrides:
   vite: ^8.2.0
   vitest: 4.1.10
-  '@effect/platform-node': 4.0.0-beta.102
-  '@effect/vitest': 4.0.0-beta.102
-  effect: 4.0.0-beta.102
 
 patchedDependencies:
   react-scan@0.5.7: 3db48cf39ae98df6cc3c03ce20b2445004e89a6dd46e078b75ca8e795db568a9
@@ -322,8 +328,8 @@ importers:
   apps/desktop:
     dependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.11.1(supports-color@10.2.2))
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109(effect@4.0.0-rc.109)(redis@6.2.1(@opentelemetry/api@1.9.1))
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@41.10.2(supports-color@7.2.0))
@@ -335,7 +341,7 @@ importers:
         version: 2.0.0-beta.18(@opentelemetry/api@1.9.1)
       '@orpc/experimental-effect':
         specifier: catalog:orpc
-        version: 2.0.0-beta.18(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.102)
+        version: 2.0.0-beta.18(@opentelemetry/api@1.9.1)(effect@4.0.0-rc.109)
       '@orpc/server':
         specifier: catalog:orpc
         version: 2.0.0-beta.18(@opentelemetry/api@1.9.1)
@@ -346,15 +352,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       effect:
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109
       react-error-boundary:
         specifier: 'catalog:'
         version: 6.1.2(react@19.2.7)
     devDependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109(effect@4.0.0-rc.109)(vitest@4.1.10)
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
         version: 2.0.0(@types/node@24.13.3)
@@ -450,15 +456,15 @@ importers:
         specifier: 'catalog:'
         version: 7.0.31(zod@4.4.3)
       effect:
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109
       zod:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109(effect@4.0.0-rc.109)(vitest@4.1.10)
       '@vibest/typescript':
         specifier: workspace:*
         version: link:../../tools/typescript
@@ -472,15 +478,15 @@ importers:
   packages/effect-json-store:
     dependencies:
       effect:
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109
     devDependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.11.1(supports-color@10.2.2))
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109(effect@4.0.0-rc.109)(redis@6.2.1(@opentelemetry/api@1.9.1))
       '@effect/vitest':
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109(effect@4.0.0-rc.109)(vitest@4.1.10)
       '@vibest/typescript':
         specifier: workspace:*
         version: link:../../tools/typescript
@@ -494,11 +500,11 @@ importers:
         specifier: 0.80.7
         version: 0.80.7(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.21.1)(zod@4.4.3)
       '@effect/platform-node':
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.11.1(supports-color@10.2.2))
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109(effect@4.0.0-rc.109)(redis@6.2.1(@opentelemetry/api@1.9.0))
       '@orpc/experimental-effect':
         specifier: catalog:orpc
-        version: 2.0.0-beta.18(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.102)
+        version: 2.0.0-beta.18(@opentelemetry/api@1.9.0)(effect@4.0.0-rc.109)
       '@orpc/server':
         specifier: catalog:orpc
         version: 2.0.0-beta.18(@opentelemetry/api@1.9.0)
@@ -512,8 +518,8 @@ importers:
         specifier: 'catalog:'
         version: 7.0.31(zod@4.4.3)
       effect:
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109
       simple-git:
         specifier: 'catalog:'
         version: 3.36.0(supports-color@7.2.0)
@@ -528,8 +534,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109(effect@4.0.0-rc.109)(vitest@4.1.10)
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -631,8 +637,8 @@ importers:
         specifier: 'catalog:'
         version: 0.3.220(@anthropic-ai/sdk@0.111.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
       '@effect/platform-node':
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.11.1(supports-color@10.2.2))
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109(effect@4.0.0-rc.109)(redis@6.2.1(@opentelemetry/api@1.9.1))
       '@orpc/contract':
         specifier: catalog:orpc
         version: 2.0.0-beta.18(@opentelemetry/api@1.9.1)
@@ -643,8 +649,8 @@ importers:
         specifier: 'catalog:'
         version: 7.0.31(zod@4.4.3)
       effect:
-        specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102
+        specifier: 'catalog:'
+        version: 4.0.0-rc.109
       uuid:
         specifier: 'catalog:'
         version: 14.0.1
@@ -1137,23 +1143,23 @@ packages:
     resolution: {integrity: sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==}
     engines: {node: '>=22.19.0'}
 
-  '@effect/platform-node-shared@4.0.0-beta.102':
-    resolution: {integrity: sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ==}
+  '@effect/platform-node-shared@4.0.0-rc.109':
+    resolution: {integrity: sha512-jhZJnf81N7Z5+Z41Qr0cKT75WzGu6M1W05xrSdu/V8PK0kSFtU5hJMBxSGDWNlgWhBwK0WRZtnMHY8HLdONg1w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: 4.0.0-beta.102
+      effect: ^4.0.0-rc.109
 
-  '@effect/platform-node@4.0.0-beta.102':
-    resolution: {integrity: sha512-wYVAU9jAePT+gouMr/EVz1CaW6yDLjPAgXYeEFLz7wugT5iZhFRag6mqajV/wwN3bzWP2fzZHokLuPmqD/rqeA==}
+  '@effect/platform-node@4.0.0-rc.109':
+    resolution: {integrity: sha512-LE/GTh6MCZ0uzbEFH9WmxQkC9snjWuFyh8vW04AAgbKKxSHXsepHSK9RcE/2oYKr6RhrOTD0C2wC0i+J9qoe2g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: 4.0.0-beta.102
-      ioredis: ^5.7.0
+      effect: ^4.0.0-rc.109
+      redis: '>=5.0.0 <7.0.0'
 
-  '@effect/vitest@4.0.0-beta.102':
-    resolution: {integrity: sha512-4dipFAYG6imOzrY3zy3BgzCJkbb9xESyzUef0WSx8bsK0/SpITqbJpdwKeOyDWLZ+rimjua8IbTFMAde865pIQ==}
+  '@effect/vitest@4.0.0-rc.109':
+    resolution: {integrity: sha512-vu5ZkidJ/gM/+a0M07Jnq1PV4duFlYc+4Vj9TsJysK4Us7LL5bwV6uXiT7mi1/IM/3HgfAwc7Q9ROj8M65G4pA==}
     peerDependencies:
-      effect: 4.0.0-beta.102
+      effect: ^4.0.0-rc.109
       vitest: 4.1.10
 
   '@electron-internal/extract-zip@1.0.4':
@@ -1659,9 +1665,6 @@ packages:
   '@internationalized/number@3.6.6':
     resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
 
-  '@ioredis/commands@1.10.0':
-    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
-
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -1905,7 +1908,7 @@ packages:
   '@orpc/experimental-effect@2.0.0-beta.18':
     resolution: {integrity: sha512-Daf6Cg92cUoJj6vUNTCfbbg4PlYWuI+9TvyLZ96gnaT6OwPPz0tf+rT5NNlPxBdQHzikf7J+I8we49PY1s9ffw==}
     peerDependencies:
-      effect: 4.0.0-beta.102
+      effect: '>=4.0.0-beta.90'
 
   '@orpc/json-schema@2.0.0-beta.18':
     resolution: {integrity: sha512-o0FMq7PDZr4cdHonQOKiB9HxC188rkfOeRw2fk87RkCyd1onO7eFeT6ogpd5zCkV7qEQPtSGScHuC0m7UEtJcg==}
@@ -3089,6 +3092,42 @@ packages:
   '@react-grab/cli@0.1.50':
     resolution: {integrity: sha512-Px/Hwhhyk2PubCA4ZaRFsfvwxhbxXsetJyvqC6aFFi8WhJhA+oVC33aTzuAeWmM3fhb4/8ce8YsHXI1d6ChcKg==}
     hasBin: true
+
+  '@redis/bloom@6.2.1':
+    resolution: {integrity: sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/client@6.2.1':
+    resolution: {integrity: sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@6.2.1':
+    resolution: {integrity: sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/search@6.2.1':
+    resolution: {integrity: sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/time-series@6.2.1':
+    resolution: {integrity: sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
 
   '@rolldown/binding-android-arm64@1.2.0':
     resolution: {integrity: sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==}
@@ -5068,8 +5107,8 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cluster-key-slot@1.1.1:
-    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
   code-excerpt@4.0.0:
@@ -5405,10 +5444,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  denque@2.1.0:
-    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
-    engines: {node: '>=0.10'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -5498,8 +5533,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-beta.102:
-    resolution: {integrity: sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w==}
+  effect@4.0.0-rc.109:
+    resolution: {integrity: sha512-6ubcOCtfdbmFO5+vgcT2HsTw5s+n3aMUj4eAIbVpUxP7+VYCwXxxcBHgiWgizOrGO1eGmuOBFek3mM0dFcwaWA==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -5820,9 +5855,6 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  find-my-way-ts@0.1.6:
-    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -6139,10 +6171,6 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ini@7.0.0:
-    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
-    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
-
   ink-spinner@5.0.0:
     resolution: {integrity: sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==}
     engines: {node: '>=14.16'}
@@ -6172,10 +6200,6 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
-
-  ioredis@5.11.1:
-    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
-    engines: {node: '>=12.22.0'}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -6372,9 +6396,6 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-
-  kubernetes-types@1.30.0:
-    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
 
   launch-ide@1.4.8:
     resolution: {integrity: sha512-SeY4/242PZ6M2cUtZvwEatbmIAjSK2zBm5PFUHFgJsR+1Kw51SBcqUHYzd5yofVAiyt0L047Kya7DqxoP+0Ouw==}
@@ -6878,9 +6899,6 @@ packages:
 
   msgpackr@2.0.4:
     resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
-
-  multipasta@0.2.8:
-    resolution: {integrity: sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==}
 
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
@@ -7531,13 +7549,9 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
-  redis-errors@1.2.0:
-    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
-    engines: {node: '>=4'}
-
-  redis-parser@3.0.0:
-    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
-    engines: {node: '>=4'}
+  redis@6.2.1:
+    resolution: {integrity: sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==}
+    engines: {node: '>= 20.0.0'}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -7868,9 +7882,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  standard-as-callback@2.1.0:
-    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
-
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
@@ -8043,10 +8054,6 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-
-  toml@4.1.2:
-    resolution: {integrity: sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==}
-    engines: {node: '>=20'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -9477,29 +9484,40 @@ snapshots:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
 
-  '@effect/platform-node-shared@4.0.0-beta.102(effect@4.0.0-beta.102)':
+  '@effect/platform-node-shared@4.0.0-rc.109(effect@4.0.0-rc.109)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.102
+      effect: 4.0.0-rc.109
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.11.1(supports-color@10.2.2))':
+  '@effect/platform-node@4.0.0-rc.109(effect@4.0.0-rc.109)(redis@6.2.1(@opentelemetry/api@1.9.0))':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.102(effect@4.0.0-beta.102)
-      effect: 4.0.0-beta.102
-      ioredis: 5.11.1(supports-color@10.2.2)
+      '@effect/platform-node-shared': 4.0.0-rc.109(effect@4.0.0-rc.109)
+      effect: 4.0.0-rc.109
       mime: 4.1.0
+      redis: 6.2.1(@opentelemetry/api@1.9.0)
       undici: 8.7.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)':
+  '@effect/platform-node@4.0.0-rc.109(effect@4.0.0-rc.109)(redis@6.2.1(@opentelemetry/api@1.9.1))':
     dependencies:
-      effect: 4.0.0-beta.102
+      '@effect/platform-node-shared': 4.0.0-rc.109(effect@4.0.0-rc.109)
+      effect: 4.0.0-rc.109
+      mime: 4.1.0
+      redis: 6.2.1(@opentelemetry/api@1.9.1)
+      undici: 8.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/vitest@4.0.0-rc.109(effect@4.0.0-rc.109)(vitest@4.1.10)':
+    dependencies:
+      effect: 4.0.0-rc.109
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-preview@4.1.10)(jsdom@26.1.0(supports-color@10.2.2))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@electron-internal/extract-zip@1.0.4': {}
@@ -9903,8 +9921,6 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.18
 
-  '@ioredis/commands@1.10.0': {}
-
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -10181,24 +10197,24 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/experimental-effect@2.0.0-beta.18(@opentelemetry/api@1.9.0)(effect@4.0.0-beta.102)':
+  '@orpc/experimental-effect@2.0.0-beta.18(@opentelemetry/api@1.9.0)(effect@4.0.0-rc.109)':
     dependencies:
       '@orpc/contract': 2.0.0-beta.18(@opentelemetry/api@1.9.0)
       '@orpc/json-schema': 2.0.0-beta.18(@opentelemetry/api@1.9.0)
       '@orpc/server': 2.0.0-beta.18(@opentelemetry/api@1.9.0)
       '@orpc/shared': 2.0.0-beta.18(@opentelemetry/api@1.9.0)
-      effect: 4.0.0-beta.102
+      effect: 4.0.0-rc.109
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - crossws
 
-  '@orpc/experimental-effect@2.0.0-beta.18(@opentelemetry/api@1.9.1)(effect@4.0.0-beta.102)':
+  '@orpc/experimental-effect@2.0.0-beta.18(@opentelemetry/api@1.9.1)(effect@4.0.0-rc.109)':
     dependencies:
       '@orpc/contract': 2.0.0-beta.18(@opentelemetry/api@1.9.1)
       '@orpc/json-schema': 2.0.0-beta.18(@opentelemetry/api@1.9.1)
       '@orpc/server': 2.0.0-beta.18(@opentelemetry/api@1.9.1)
       '@orpc/shared': 2.0.0-beta.18(@opentelemetry/api@1.9.1)
-      effect: 4.0.0-beta.102
+      effect: 4.0.0-rc.109
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - crossws
@@ -10934,6 +10950,50 @@ snapshots:
       picocolors: 1.1.1
       prompts: 2.4.2
       tinyexec: 1.2.4
+
+  '@redis/bloom@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.0)
+
+  '@redis/bloom@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
+  '@redis/client@6.2.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@redis/client@6.2.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@redis/json@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.0)
+
+  '@redis/json@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
+  '@redis/search@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.0)
+
+  '@redis/search@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+
+  '@redis/time-series@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.0)
+
+  '@redis/time-series@6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
 
   '@rolldown/binding-android-arm64@1.2.0':
     optional: true
@@ -13098,7 +13158,7 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cluster-key-slot@1.1.1: {}
+  cluster-key-slot@1.1.2: {}
 
   code-excerpt@4.0.0:
     dependencies:
@@ -13458,8 +13518,6 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  denque@2.1.0: {}
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -13555,18 +13613,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-beta.102:
+  effect@4.0.0-rc.109:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0
-      find-my-way-ts: 0.1.6
-      ini: 7.0.0
-      kubernetes-types: 1.30.0
       msgpackr: 2.0.4
-      multipasta: 0.2.8
-      toml: 4.1.2
-      uuid: 14.0.1
-      yaml: 2.9.0
 
   ejs@3.1.10:
     dependencies:
@@ -13993,8 +14044,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way-ts@0.1.6: {}
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -14415,8 +14464,6 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@7.0.0: {}
-
   ink-spinner@5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5):
     dependencies:
       cli-spinners: 2.9.2
@@ -14462,18 +14509,6 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
-
-  ioredis@5.11.1(supports-color@10.2.2):
-    dependencies:
-      '@ioredis/commands': 1.10.0
-      cluster-key-slot: 1.1.1
-      debug: 4.4.3(supports-color@10.2.2)
-      denque: 2.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
 
   ip-address@10.2.0: {}
 
@@ -14646,8 +14681,6 @@ snapshots:
   khroma@2.1.0: {}
 
   kleur@3.0.3: {}
-
-  kubernetes-types@1.30.0: {}
 
   launch-ide@1.4.8:
     dependencies:
@@ -15338,8 +15371,6 @@ snapshots:
   msgpackr@2.0.4:
     optionalDependencies:
       msgpackr-extract: 3.0.4
-
-  multipasta@0.2.8: {}
 
   nanoid@3.3.16: {}
 
@@ -16290,11 +16321,27 @@ snapshots:
 
   readdirp@5.0.0: {}
 
-  redis-errors@1.2.0: {}
-
-  redis-parser@3.0.0:
+  redis@6.2.1(@opentelemetry/api@1.9.0):
     dependencies:
-      redis-errors: 1.2.0
+      '@redis/bloom': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.0))
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.0)
+      '@redis/json': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.0))
+      '@redis/search': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.0))
+      '@redis/time-series': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.0))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+
+  redis@6.2.1(@opentelemetry/api@1.9.1):
+    dependencies:
+      '@redis/bloom': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+      '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
+      '@redis/json': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 6.2.1(@redis/client@6.2.1(@opentelemetry/api@1.9.1))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   regex-recursion@6.0.2:
     dependencies:
@@ -16709,8 +16756,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  standard-as-callback@2.1.0: {}
-
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
@@ -16899,8 +16944,6 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
-
-  toml@4.1.2: {}
 
   totalist@3.0.1:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,8 @@ onlyBuiltDependencies:
   - "@swc/core"
 catalog:
   "@anthropic-ai/claude-agent-sdk": 0.3.220
-  "@effect/platform-node": 4.0.0-beta.102
-  "@effect/vitest": 4.0.0-beta.102
+  "@effect/platform-node": 4.0.0-rc.109
+  "@effect/vitest": 4.0.0-rc.109
   "@tailwindcss/vite": ^4.3.3
   "@tanstack/react-query": ^5.101.2
   "@tanstack/router-plugin": ^1.168.22
@@ -20,7 +20,7 @@ catalog:
   "@vitejs/plugin-react": ^6.0.3
   ai: ^7.0.31
   clsx: ^2.1.1
-  effect: 4.0.0-beta.102
+  effect: 4.0.0-rc.109
   lucide-react: ^1.25.0
   p-queue: ^9.3.1
   react: ^19.2.7
@@ -64,16 +64,10 @@ catalogs:
     "@tiptap/react": ^3.28.0
     "@tiptap/suggestion": ^3.28.0
 overrides:
-  # These overrides force TRANSITIVE deps onto the catalog version — the
-  # catalog alone only governs workspace package.json entries. Load-bearing:
-  # e.g. @effect/platform-node-shared@beta.98 peer-wants effect@^4.0.0-beta.98,
-  # which without the override would auto-install a second effect runtime;
-  # electron-vite/vite-plus would similarly resolve their own vite/vitest.
+  # electron-vite/vite-plus resolve their own Vite/Vitest versions unless the
+  # transitive graph is forced onto the workspace catalog versions.
   vite: "catalog:"
   vitest: "catalog:"
-  "@effect/platform-node": "catalog:"
-  "@effect/vitest": "catalog:"
-  effect: "catalog:"
 # pnpm 11 defaults minimumReleaseAge to 24h; disable it — the same-day
 # dependency bumps this repo does (e.g. claude-agent-sdk) would be blocked,
 # and its publish-time verification deadlocks pnpm 11.11.0 behind proxies.


### PR DESCRIPTION
## Summary

Grouped bump of the Effect runtime from `4.0.0-beta.102` to `4.0.0-rc.109`: `effect`, `@effect/platform-node`, and `@effect/vitest` move together in the catalog.

RC renamed `Schema.TaggedErrorClass` to `Schema.TaggedError`, so harness tagged errors (`packages/server/src/harness/errors.ts` and `claude-code/errors.ts`) and the design/plan notes follow that rename. The Effect family stays exact-pinned in the catalog; the `effect` / `@effect/*` catalog overrides are dropped because they are no longer needed to keep a single runtime. Vite/Vitest overrides stay.

`@orpc/experimental-effect@2.0.0-beta.18`'s effect peer still covers the new pin, so the oRPC family is unchanged.

## Verification

- `pnpm typecheck --force` — 10/10 tasks green against rc.109.
- `@vibest/contract`, `@vibest/effect-json-store`, and `@vibest/cli` tests passed.
- `@vibest/server` — 382 passed; two 5s timeouts (`rpc-session` create+stream, `pi/agent` create+stream) under the full parallel run. Both passed in isolation (`446ms` / `688ms`).