### PR TITLE
chore: upgrade pnpm to 12.0.0-rc.6

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -13,17 +13,17 @@ checksum = "sha256:8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac3
 url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz"
 
 [[tools.pnpm]]
-version = "11.15.1"
+version = "12.0.0-rc.6"
 backend = "aqua:pnpm/pnpm"
 
 [tools.pnpm."platforms.linux-x64"]
-checksum = "sha256:0c1373b6390f6b89ff8b896d3647c9826577ddc49173a2f732da69b36569f9e0"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.15.1/pnpm-linux-x64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/482780457"
+checksum = "sha256:91a587656717af75003896010fd1e9a78cd050b489028fcab541be59f9d0d06c"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896950"
 provenance = "github-attestations"
 
 [tools.pnpm."platforms.macos-arm64"]
-checksum = "sha256:4ff53ecc9de8df115d4efef60eab77f91be4f8237cdaca078351a22e707d1849"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.15.1/pnpm-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/482780456"
+checksum = "sha256:3d053af03a1f489863ee20b6a6b2149e19c313e2203e92731280ebcbd120d11a"
+url = "https://github.com/pnpm/pnpm/releases/download/v12.0.0-rc.6/pnpm-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/515896956"
 provenance = "github-attestations"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "24"
-pnpm = "11.15.1"
+pnpm = "12.0.0-rc.6"

--- a/package.json
+++ b/package.json
@@ -50,5 +50,5 @@
       "oxfmt --no-error-on-unmatched-pattern"
     ]
   },
-  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065"
+  "packageManager": "pnpm@12.0.0-rc.6+sha512.3927fce49c3054b7e5541dc720bce7b4ebab07f4562fa6ffce7b39720a25e6a767d76384984e2265c800799613f7f79c5c422e9f5cedc9b66cfffd08ca3c77a9"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0-rc.6
+        version: 12.0.0-rc.6
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.6':
+    resolution: {integrity: sha512-m57z/dG0gzeh4rCApyLaHbaLh+4SwOiIoEQAyYUvY/YVVThBY4PrgJIE/0jxfNe9WeJR2cGO6W0ehiQ9LZ4csg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.6':
+    resolution: {integrity: sha512-Kqojv9k2hrAoUKEa+U2J1nMcYGZnxBnZ90Al7RMavfcKIDE13GdnWMaeiNKFBWoyPdYgtR2qCtwyjAprWSUstg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.6':
+    resolution: {integrity: sha512-FGeJUQ9Pralhzibl1o5QZUPhPIIWbomoeJG5Gm2HFFNEkvDWm+MwRw5eRnPdb+zyGtrXfQAc7eZtMgLQh/tuVg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.6':
+    resolution: {integrity: sha512-/S+hdo/9b8jOa74bpF7p+rTKUlqvsSLGLaCtNAyH+PjEKmTsbOKDinTeFM4MJK+6qEipigmrnSYrt66AwuT+CA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.6':
+    resolution: {integrity: sha512-Sn88BvO6o1ChhP63qA/J96tWI+WBDtN57ZycUfl3ZV8n4ccmETYkWMRo4JaCexaMZI/b5U17neoBUo0MHZChHQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.6':
+    resolution: {integrity: sha512-gCeOwlSLqMo0J/X4pH9yDH0GpZ+FAxHuFHGdedN7YKhCKxacUt+b4m74xSaBgSK2r4eHYR9bGCsLqSQ9ZaERTQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.6':
+    resolution: {integrity: sha512-q7b2oxEcCBTBTh15qORCfCZfa3EHoNiIPdHJCS1Vs1tvv2qPys2AW9FpSwdPY6N9zb419CDQxb+Cwjfe2n/ZjQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.6':
+    resolution: {integrity: sha512-YBFLDcLgl60ssEeLJlBikCwK0LIjbmeVngA/0hu2MTvbbkV1GQcNlFKuVpG5OLW17PH5YGydIAbs0qEf0PQPiA==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0-rc.6:
+    resolution: {integrity: sha512-OSf85JwwVLflVB3HILzntOurB/RWL6b/zns5cgol5qdn12OEmE4iZcgAeZYT9/ecXEIun1ztybZs//0Iyjx3qQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.6':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.6':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.6':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.6':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.6':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.6':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.6':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.6':
+    optional: true
+
+  pnpm@12.0.0-rc.6:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.6
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.6
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.6
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.6
+      '@pnpm/exe.linux-x64': 12.0.0-rc.6
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.6
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.6
+      '@pnpm/exe.win32-x64': 12.0.0-rc.6
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,9 +90,8 @@ overrides:
   "@effect/platform-node-shared": "catalog:effect"
   "@effect/vitest": "catalog:effect"
   effect: "catalog:effect"
-# pnpm 11 defaults minimumReleaseAge to 24h; disable it — the same-day
-# dependency bumps this repo does (e.g. claude-agent-sdk) would be blocked,
-# and its publish-time verification deadlocks pnpm 11.11.0 behind proxies.
+# pnpm 11+ defaults minimumReleaseAge to 24h; disable it — the same-day
+# dependency bumps this repo does (e.g. claude-agent-sdk) would be blocked.
 minimumReleaseAge: 0
 allowBuilds:
   # Its postinstall only probes node-pty's spawn-helper and logs — it builds


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Upgrade the repo toolchain from pnpm 11.15.1 to the current pnpm 12 release candidate.

pnpm 12 is a Rust rewrite and is still an RC (`next-12` on npm). Commands, flags, settings, and lockfile version 9 stay the same; this pin is so CI and local installs use the native v12 CLI.

## Changes

- Pin `packageManager` to `pnpm@12.0.0-rc.6` with the npm tarball SHA-512
- Point `mise.toml` / `mise.lock` at the same version (linux-x64 and macos-arm64 GitHub assets)
- Record `packageManagerDependencies` in `pnpm-lock.yaml` (pnpm 12 writes this when the pin is v12+)
- Keep `minimumReleaseAge: 0` (still needed; v11+ defaults to 24h)

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm turbo run build test typecheck` (19/19 tasks)
- `pnpm run lint:check`
- `pnpm run format:check`
- CI pin check: `mise current pnpm`, `package.json#packageManager`, and `pnpm --version` all report `12.0.0-rc.6`

## New v12 features — what this repo can use

pnpm 12 is not meant to be a migration, but a few extras are actually relevant here. Most of them are either automatic, overlap something we already have (mise, changesets, turbo `clean`), or would fail CI today.

### Already in effect after this pin

- Native CLI: installs and lockfile verification are the Rust binary, not the TypeScript one.
- `packageManagerDependencies` in the lockfile, so the v12 pin is reproduced the same way catalog versions are.
- Canonical cycle-breaking on the *next* install that re-resolves (a catalog bump, not a frozen CI install). Frozen installs keep the current lockfile byte-for-byte.

### Worth using later — not in this PR

| Feature | Why it fits | Why not now |
| --- | --- | --- |
| `pnpm cache path` in CI | Docs’ intended use: cache the metadata dir so an unchanged lockfile skips supply-chain re-verification | Quality job is a persistent self-hosted runner; `~/.cache/pnpm` already lives outside the checkout that turbo cache has to restore |
| `pnpm peers check` as a gate | Reads peer issues from the lockfile; replacement for `--resolution-only` | Fails today: `vite-plus-core` wants typescript `^5 \|\| ^6` (we are on 7), `@pierre/theming` wants `@pierre/theme@^1`, `oxlint@1.77` wants `oxlint-tsgolint>=7` |
| `minimumReleaseAge` default + `minimumReleaseAgeExclude` for `@anthropic-ai/claude-agent-sdk` | Restore the 24h supply-chain gate for everything except same-day SDK bumps | Policy change; Effect/oRPC RCs and other same-day catalog moves would still need excludes |
| `pnpm outdated` (now includes GitHub Actions) | We pin Actions by SHA in `quality.yml` / `react-doctor.yml` | Maintenance command, not a repo setting |
| `pnpm pack-app` for `@vibest/cli` | Native SEA binary instead of `node dist/cli.mjs` | Needs a CJS entry and Node ≥ 25.5; CLI is ESM and `engines` is `>=24 <25` |
| `devEngines.runtime` / `pnpm runtime` | Project-aware `node` without mise | We just standardized on mise for Node 24; two managers would fight |

### Do not turn on

- **`catalogPrune`**: would drop `@effect/platform-node-shared` from the effect catalog. That entry exists only so the override can pin a transitive package.
- **`pnpm ci`**: runs `pnpm clean` first, and our root `clean` script is `turbo run clean && git clean …`, which overrides the built-in.
- **`injectWorkspacePackages` / `syncInjectedDepsAfterScripts`**: workspace deps are `workspace:*` links; desktop packaging already walks that tree via electron-builder.
- **`pnpm change` / `version` / `lane`**: built-in release intents; we already use Changesets.

https://pnpm.io/blog/whats-different-in-pnpm-12
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01091-15b5-7d1c-963b-c738610c19ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01091-15b5-7d1c-963b-c738610c19ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

