### PR TITLE
docs: add Cursor Cloud environment setup instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,36 @@ of `main`'s history, so deleting the local feature branch needs `git branch -D`
 - `.claude/skills/verify` — build, launch, and drive the app at runtime
 - `.claude/skills/react-doctor` — React health check; CI fails on error-level only
 - `todos/` — numbered security/perf remediation tickets
+
+## Cursor Cloud specific instructions
+
+Node 24 is required (`mise.toml`, and `@vibest/cli` `engines`). `mise` is not
+installed on the cloud VM; Node 24 comes from `nvm`, and `pnpm` from corepack.
+The base image also ships a Node 22 at `/exec-daemon/node` that shadows nvm's
+Node on `PATH` in **non-login** shells. Two consequences:
+
+- Login shells (a `bash -l`, and every tmux-backed terminal) already resolve
+  Node 24 + corepack `pnpm` — run dev servers, `pnpm test`, etc. from those.
+- In a bare non-login shell you may get Node 22 with no `pnpm`. Fix the shell
+  with `. "$NVM_DIR/nvm.sh" && nvm use 24 && corepack enable` (or just run a
+  login shell). The startup update script installs deps under Node 24, so
+  `node-pty`'s native build matches what login shells run — don't reinstall
+  under Node 22 or the runtime ABI won't match.
+
+Running the app is two processes (Vite on 4190 proxying `/api` + `/ws/rpc` to
+the server on 4180) — see `.claude/skills/verify/SKILL.md` for the exact
+recipe and gotchas. `pnpm dev` at the root runs both through turbo.
+
+Getting an actual agent reply needs a Claude Code credential and binary, neither
+of which the base VM has:
+
+- The `claude` binary is not on `PATH`. The server resolves it from the Agent
+  SDK's bundled platform package only via `moduleRequire`, which fails under
+  pnpm's layout — so export `VIBEST_CLAUDE_EXECUTABLE` to
+  `node_modules/.pnpm/@anthropic-ai+claude-agent-sdk-linux-x64@<ver>/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude`
+  for the server process, or Claude Code shows up unavailable in the composer.
+- Even when available, a prompt turn ends with `Not logged in · Please run
+/login` unless `ANTHROPIC_API_KEY` (or a `claude login`) is present. The
+  project-import → session-create → prompt-submit flow (user message renders,
+  URL moves to `/session/<uuid>`) works without it; only the model reply needs
+  the credential.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for `vibest` and records durable, non-obvious startup caveats for future agents. The only code change is a new `## Cursor Cloud specific instructions` section in `CLAUDE.md` (which `AGENTS.md` symlinks to). Dependency installation is handled by the startup update script, not this PR.

## Environment setup performed

- Installed **Node 24** (required by `mise.toml` / `@vibest/cli` engines) via `nvm`; the base VM's `/exec-daemon` Node 22 shadows it in non-login shells, so login/tmux shells are used for runtime.
- Enabled corepack → `pnpm@11.15.1`, then `pnpm install --frozen-lockfile` (builds native `node-pty` + rebuilds electron app-deps).

## Verification

| Task | Command | Result |
| --- | --- | --- |
| Build | `pnpm build` | 4/4 tasks pass |
| Lint + format + typecheck | `pnpm check` | 10/10 tasks pass |
| Tests | `pnpm test` | 391 passed, 2 skipped |
| Run | `pnpm dev` (server 4180 + Vite 4190) | `/api/health` → `ok` through the proxy |

## Hello-world (core flow)

Imported `/tmp/hello-vibest` as a project, opened the composer, typed a prompt, and sent it: a session was created, the user message rendered, and the URL moved to `/session/<uuid>`.

[Composer ready with imported project and Claude Code](https://cursor.com/agents/bc-2bc976f9-56db-44e2-81b7-9b311315e502/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvibest_composer_ready.webp)
<img alt="Session created: user message rendered, navigated to /session/<uuid>" src="/opt/cursor/artifacts/vibest_session_created.webp" />

The model reply itself requires a Claude Code credential (`ANTHROPIC_API_KEY` or `claude login`) which the VM does not have — the session page shows `Not logged in · Please run /login`. All other core machinery (RPC, session lifecycle, WS streaming, UI) works without it.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bc976f9-56db-44e2-81b7-9b311315e502?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bc976f9-56db-44e2-81b7-9b311315e502&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

