### PR TITLE
chore: enable Vite 8 bundledDev in app and desktop

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -25,6 +25,12 @@ const serverTarget = `http://127.0.0.1:${SERVER_PORT}`;
 const RUNNING_IN_AGENT = isRunningFromAgent({ experimentalProcessTree: true });
 
 export default defineConfig({
+  experimental: {
+    // Vite 8 bundled dev: Rolldown serves a bundle during `vite dev` instead
+    // of unbundled ESM. Still experimental — HMR acceptance is runtime-only,
+    // and third-party plugins may not work.
+    bundledDev: true,
+  },
   define: {
     "import.meta.env.VIBEST_RUN_IN_AGENT": JSON.stringify(RUNNING_IN_AGENT),
   },

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -26,9 +26,6 @@ const RUNNING_IN_AGENT = isRunningFromAgent({ experimentalProcessTree: true });
 
 export default defineConfig({
   experimental: {
-    // Vite 8 bundled dev: Rolldown serves a bundle during `vite dev` instead
-    // of unbundled ESM. Still experimental — HMR acceptance is runtime-only,
-    // and third-party plugins may not work.
     bundledDev: true,
   },
   define: {

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -80,6 +80,11 @@ export default defineConfig({
   },
   renderer: {
     root: url.fileURLToPath(new URL("./src/renderer/", import.meta.url)),
+    experimental: {
+      // Same opt-in as apps/app: Rolldown serves a bundle during `vite dev`.
+      // Renderer-only — main/preload are already bundled in both modes.
+      bundledDev: true,
+    },
     define: {
       "import.meta.env.VIBEST_RUN_IN_AGENT": JSON.stringify(RUNNING_IN_AGENT),
     },

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -81,8 +81,6 @@ export default defineConfig({
   renderer: {
     root: url.fileURLToPath(new URL("./src/renderer/", import.meta.url)),
     experimental: {
-      // Same opt-in as apps/app: Rolldown serves a bundle during `vite dev`.
-      // Renderer-only — main/preload are already bundled in both modes.
       bundledDev: true,
     },
     define: {


### PR DESCRIPTION
## Summary

- Turn on Vite 8's experimental bundled dev (`experimental.bundledDev`) for `@vibest/app` and the Electron renderer so `vite dev` serves a Rolldown bundle instead of unbundled ESM.
- Leave desktop `main` / `preload` alone: electron-vite already bundles those in both modes. Vitest and tsdown are not Vite serve and are unchanged.

This was previously called Full Bundle Mode. HMR acceptance is runtime-only, and third-party plugins may still misbehave.

## Test plan

- [x] `apps/app` `vite dev`: HTML loads `/bundledDevClient.mjs` + `/assets/index.js`; `/` redirects to `/draft`; composer input and an existing session route render.
- [x] Desktop renderer HTML (same markers + `/assets/index.js` 200). Full Electron window not launched in this change.
- [ ] Restart `apps/app` `pnpm dev` and confirm HMR still accepts an edit.
- [ ] Restart `apps/desktop` `pnpm dev` and confirm the renderer boots.